### PR TITLE
docs: add previously undocumented zone_id attribute

### DIFF
--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -47,3 +47,4 @@ The following attributes are exported:
 * `priority` - The priority of the record
 * `hostname` - The FQDN of the record
 * `proxied` - (Optional) Whether the record gets Cloudflare's origin protection.
+* `zone_id` - (Computed) the zone id of the record


### PR DESCRIPTION
this PR adds a previously undocumented, computed property to the documentation.