### PR TITLE
Validate TXT records

### DIFF
--- a/cloudflare/validators.go
+++ b/cloudflare/validators.go
@@ -63,6 +63,14 @@ func validateRecordName(t string, value string) error {
 		if addr == nil || !strings.Contains(value, ":") {
 			return fmt.Errorf("AAAA record must be a valid IPv6 address, got: %q", value)
 		}
+	case "TXT":
+		// Must be printable ASCII
+		for i := 0; i < len(value); i++ {
+			char := value[i]
+			if (char < 0x20) || (0x7F < char) {
+				return fmt.Errorf("TXT record must contain printable ASCII, found: %q", char)
+			}
+		}
 	}
 
 	return nil

--- a/cloudflare/validators_test.go
+++ b/cloudflare/validators_test.go
@@ -43,6 +43,7 @@ func TestValidateRecordName(t *testing.T) {
 	validNames := map[string]string{
 		"A":    "192.168.0.1",
 		"AAAA": "2001:0db8:0000:0042:0000:8a2e:0370:7334",
+		"TXT":  " ",
 	}
 
 	for k, v := range validNames {
@@ -54,6 +55,7 @@ func TestValidateRecordName(t *testing.T) {
 	invalidNames := map[string]string{
 		"A":    "terraform.io",
 		"AAAA": "192.168.0.1",
+		"TXT":  "\n",
 	}
 	for k, v := range invalidNames {
 		if err := validateRecordName(k, v); err == nil {


### PR DESCRIPTION
This PR contains an implementation of validation for TXT records, which must consist only of printable ASCII characters.

Resolves #9.