### PR TITLE
Add data source for IP ranges

### DIFF
--- a/cloudflare/data_source_ip_ranges.go
+++ b/cloudflare/data_source_ip_ranges.go
@@ -1,0 +1,52 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	cf "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceCloudflareIPRanges() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudflareIPRangesRead,
+
+		Schema: map[string]*schema.Schema{
+			"cidr_blocks_v4": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cidr_blocks_v6": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceCloudflareIPRangesRead(d *schema.ResourceData, meta interface{}) error {
+	ips, err := cf.IPs()
+	if err != nil {
+		return err
+	}
+
+	serialized, err := json.Marshal(ips)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(hashcode.String(string(serialized))))
+
+	sort.Strings(ips.IPv4CIDRs)
+	d.Set("cidr_blocks_v4", ips.IPv4CIDRs)
+
+	sort.Strings(ips.IPv6CIDRs)
+	d.Set("cidr_blocks_v6", ips.IPv6CIDRs)
+
+	return nil
+}

--- a/cloudflare/data_source_ip_ranges_test.go
+++ b/cloudflare/data_source_ip_ranges_test.go
@@ -1,0 +1,101 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudflareIPRanges(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCloudflareIPRangesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudflareIPRanges("data.cloudflare_ip_ranges.testing"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareIPRanges(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		var (
+			cidrBlockSizeV4 int
+			cidrBlockSizeV6 int
+			err             error
+		)
+
+		// v4
+		if cidrBlockSizeV4, err = strconv.Atoi(a["cidr_blocks_v4.#"]); err != nil {
+			return err
+		}
+
+		if cidrBlockSizeV4 < 10 {
+			return fmt.Errorf("cidr_blocks_v4 seem suspiciously low: %d", cidrBlockSizeV4)
+		}
+
+		var cidrBlocksV4 sort.StringSlice = make([]string, cidrBlockSizeV4)
+
+		for i := range make([]string, cidrBlockSizeV4) {
+
+			block := a[fmt.Sprintf("cidr_blocks_v4.%d", i)]
+
+			if _, _, err := net.ParseCIDR(block); err != nil {
+				return fmt.Errorf("malformed CIDR block %s: %s", block, err)
+			}
+
+			cidrBlocksV4[i] = block
+
+		}
+
+		if !sort.IsSorted(cidrBlocksV4) {
+			return fmt.Errorf("unexpected order of cidr_blocks: %s", cidrBlocksV4)
+		}
+
+		// v6
+		if cidrBlockSizeV6, err = strconv.Atoi(a["cidr_blocks_v6.#"]); err != nil {
+			return err
+		}
+
+		if cidrBlockSizeV6 < 5 {
+			return fmt.Errorf("cidr_blocks_v6 seem suspiciously low: %d", cidrBlockSizeV6)
+		}
+
+		var cidrBlocksV6 sort.StringSlice = make([]string, cidrBlockSizeV6)
+
+		for i := range make([]string, cidrBlockSizeV6) {
+
+			block := a[fmt.Sprintf("cidr_blocks_v6.%d", i)]
+
+			if _, _, err := net.ParseCIDR(block); err != nil {
+				return fmt.Errorf("malformed CIDR block %s: %s", block, err)
+			}
+
+			cidrBlocksV6[i] = block
+
+		}
+
+		if !sort.IsSorted(cidrBlocksV6) {
+			return fmt.Errorf("unexpected order of cidr_blocks: %s", cidrBlocksV6)
+		}
+
+		return nil
+	}
+}
+
+const testAccCloudflareIPRangesConfig = `
+data "cloudflare_ip_ranges" "testing" {}
+`

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -24,6 +24,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"cloudflare_ip_ranges": dataSourceCloudflareIPRanges(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudflare_record": resourceCloudFlareRecord(),
 		},


### PR DESCRIPTION
Regarding Issue #6, I'm contributing to `data.cloudflare_ip_ranges` resource to get v4 and v6 CIDR blocks of Cloudflare IPs.  

Example output:
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

v4_ranges = [
    103.21.244.0/22,
    103.22.200.0/22,
    103.31.4.0/22,
    104.16.0.0/12,
    108.162.192.0/18,
    131.0.72.0/22,
    141.101.64.0/18,
    162.158.0.0/15,
    172.64.0.0/13,
    173.245.48.0/20,
    188.114.96.0/20,
    190.93.240.0/20,
    197.234.240.0/22,
    198.41.128.0/17
]
v6_ranges = [
    2400:cb00::/32,
    2405:8100::/32,
    2405:b500::/32,
    2606:4700::/32,
    2803:f800::/32,
    2a06:98c0::/29,
    2c0f:f248::/32
]
```