### PR TITLE
Load balancer + load balancer pool resources

### DIFF
--- a/cloudflare/import_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/import_cloudflare_load_balancer_pool_test.go
@@ -1,0 +1,37 @@
+package cloudflare
+
+import (
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccCloudFlareLoadBalancerPool_Import(t *testing.T) {
+	t.Parallel()
+	var loadBalancerPool cloudflare.LoadBalancerPool
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer_pool." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+				),
+			},
+		},
+	})
+}

--- a/cloudflare/import_cloudflare_load_balancer_test.go
+++ b/cloudflare/import_cloudflare_load_balancer_test.go
@@ -1,0 +1,41 @@
+package cloudflare
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccCloudFlareLoadBalancer_Import(t *testing.T) {
+	t.Parallel()
+	var loadBalancer cloudflare.LoadBalancer
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+				),
+			},
+		},
+	})
+}

--- a/cloudflare/import_cloudflare_load_balancer_test.go
+++ b/cloudflare/import_cloudflare_load_balancer_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 
+	"fmt"
+
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -28,9 +30,10 @@ func TestAccCloudFlareLoadBalancer_Import(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", zone),
+				ImportState:         true,
+				ImportStateVerify:   true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
 					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -29,7 +29,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"cloudflare_record": resourceCloudFlareRecord(),
+			"cloudflare_record":        resourceCloudFlareRecord(),
+			"cloudflare_load_balancer": resourceCloudFlareLoadBalancer(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -29,8 +29,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"cloudflare_record":        resourceCloudFlareRecord(),
-			"cloudflare_load_balancer": resourceCloudFlareLoadBalancer(),
+			"cloudflare_record":             resourceCloudFlareRecord(),
+			"cloudflare_load_balancer":      resourceCloudFlareLoadBalancer(),
+			"cloudflare_load_balancer_pool": resourceCloudFlareLoadBalancerPool(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -1,0 +1,361 @@
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"time"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudFlareLoadBalancer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudFlareLoadBalancerCreate,
+		Read:   resourceCloudFlareLoadBalancerRead,
+		Update: resourceCloudFlareLoadBalancerUpdate,
+		Delete: resourceCloudFlareLoadBalancerDelete,
+		Exists: resourceCloudFlareLoadBalancerExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudFlareLoadBalancerImport,
+		},
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"load_balancer_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": { // "dns_name" ??
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false, // allow reusing same load balancer for different dns names
+				// todo: validate dns name
+			},
+
+			"fallback_pool_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+			},
+
+			"default_pool_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(1, 32),
+				},
+			},
+
+			"proxied": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+
+			"ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				// TODO is this computed / does it have a default?
+			},
+
+			// see https://github.com/hashicorp/terraform/issues/6215
+			// nb enterprise only
+			"pop_pools": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"pop": {
+							Type:     schema.TypeString,
+							Required: true,
+							// let the api handle validating pops
+						},
+
+						"pool_ids": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(1, 32),
+							},
+						},
+					},
+				},
+				Set: HashByMapKey("pop"),
+			},
+
+			"region_pools": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:     schema.TypeString,
+							Required: true,
+							// let the api handle validating regions
+						},
+
+						"pool_ids": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(1, 32),
+							},
+						},
+					},
+				},
+				Set: HashByMapKey("region"),
+			},
+
+			"created_on": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"modified_on": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCloudFlareLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	newLoadBalancer := cloudflare.LoadBalancer{
+		Name:         d.Get("name").(string),
+		FallbackPool: d.Get("fallback_pool_id").(string),
+		DefaultPools: expandInterfaceToStringList(d.Get("default_pool_ids")),
+		Proxied:      d.Get("proxied").(bool),
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		newLoadBalancer.Description = description.(string)
+	}
+
+	// TODO in default case, this is sending ttl=0, is this ok??
+	if ttl, ok := d.GetOk("ttl"); ok {
+		newLoadBalancer.TTL = ttl.(int)
+	}
+
+	if regionPools, ok := d.GetOk("region_pools"); ok {
+		newLoadBalancer.RegionPools = expandGeoPools(regionPools, "region")
+	}
+
+	if popPools, ok := d.GetOk("pop_pools"); ok {
+		newLoadBalancer.PopPools = expandGeoPools(popPools, "pop")
+	}
+
+	zoneName := d.Get("zone").(string)
+	zoneId, err := client.ZoneIDByName(zoneName)
+	if err != nil {
+		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
+	}
+
+	log.Printf("[INFO] Creating CloudFlare Load Balancer from struct: %+v", newLoadBalancer)
+
+	r, err := client.CreateLoadBalancer(zoneId, newLoadBalancer)
+	if err != nil {
+		return errors.Wrap(err, "error creating load balancer for zone")
+	}
+
+	if r.ID == "" {
+		return fmt.Errorf("cailed to find id in Create response; resource was empty")
+	}
+
+	// terraform id is *not* the same as the resource id, is is the combination with the zoneId
+	// this makes it easier to import and also matches the keys needed for cloudflare-go operations
+	d.SetId(zoneName + "_" + r.ID)
+	d.Set("load_balancer_id", r.ID)
+
+	log.Printf("[INFO] CloudFlare Load Balancer ID: %s", d.Id())
+
+	return resourceCloudFlareLoadBalancerRead(d, meta)
+}
+
+func resourceCloudFlareLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error {
+	// since api only supports replace, update looks a lot like create...
+	client := meta.(*cloudflare.API)
+
+	newLoadBalancer := cloudflare.LoadBalancer{
+		Name:         d.Get("name").(string),
+		FallbackPool: d.Get("fallback_pool_id").(string),
+		DefaultPools: expandInterfaceToStringList(d.Get("default_pool_ids")),
+		Proxied:      d.Get("proxied").(bool),
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		newLoadBalancer.Description = description.(string)
+	}
+
+	if ttl, ok := d.GetOk("ttl"); ok {
+		newLoadBalancer.TTL = ttl.(int)
+	}
+
+	if regionPools, ok := d.GetOk("region_pools"); ok {
+		newLoadBalancer.RegionPools = expandGeoPools(regionPools, "region")
+	}
+
+	if popPools, ok := d.GetOk("pop_pools"); ok {
+		newLoadBalancer.PopPools = expandGeoPools(popPools, "pop")
+	}
+
+	zoneName := d.Get("zone").(string)
+	zoneId, err := client.ZoneIDByName(zoneName)
+	if err != nil {
+		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
+	}
+
+	log.Printf("[INFO] Creating CloudFlare Load Balancer from struct: %+v", newLoadBalancer)
+
+	_, err = client.ModifyLoadBalancer(zoneId, newLoadBalancer)
+	if err != nil {
+		return errors.Wrap(err, "error creating load balancer for zone")
+	}
+
+	return resourceCloudFlareLoadBalancerRead(d, meta)
+}
+
+func expandGeoPools(pool interface{}, geoType string) map[string][]string {
+	cfg := pool.(*schema.Set).List()
+	expanded := make(map[string][]string)
+	for _, v := range cfg {
+		locationConfig := v.(map[string]interface{})
+		// assume for now that lists are of type interface{} by default
+		expanded[locationConfig[geoType].(string)] = expandInterfaceToStringList(locationConfig["pool_ids"])
+	}
+	return expanded
+}
+
+func resourceCloudFlareLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneId := d.Get("zone_id").(string)
+	loadBalancerId := d.Get("load_balancer_id").(string)
+
+	loadBalancer, err := client.LoadBalancerDetails(zoneId, loadBalancerId)
+	if err != nil {
+		return errors.Wrap(err,
+			fmt.Sprintf("Error reading load balancer resource from API for resource %s in zone %s", zoneId, loadBalancerId))
+	}
+	log.Printf("[INFO] Read CloudFlare Load Balancer from API as struct: %+v", loadBalancer)
+
+	// api generally tries to populate everything, so just assume all data is present
+	// start by setting required values
+	d.Set("name", loadBalancer.Name)
+	d.Set("fallback_pool_id", loadBalancer.FallbackPool)
+	d.Set("default_pool_ids", loadBalancer.DefaultPools) // ok to pass []string to []interface{}
+
+	d.Set("proxied", loadBalancer.Proxied)
+	d.Set("description", loadBalancer.Description)
+	d.Set("ttl", loadBalancer.TTL) // ok to pass []string to []interface{}
+
+	d.Set("pop_pools", flattenGeoPools(loadBalancer.PopPools, "pop"))
+	d.Set("region_pools", flattenGeoPools(loadBalancer.RegionPools, "region"))
+
+	d.Set("created_on", loadBalancer.CreatedOn.Format(time.RFC3339Nano))
+	d.Set("modified_on", loadBalancer.ModifiedOn.Format(time.RFC3339Nano))
+
+	return nil
+}
+
+func flattenGeoPools(pools map[string][]string, geoType string) *schema.Set {
+	flattened := make([]interface{}, 0)
+	for k, v := range pools {
+		geoConf := map[string]interface{}{
+			geoType:    k,
+			"pool_ids": flattenStringList(v),
+		}
+		flattened = append(flattened, geoConf)
+		// assume for now that lists are of type interface{} by default
+	}
+	return schema.NewSet(HashByMapKey(geoType), flattened)
+}
+
+func resourceCloudFlareLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneId := d.Get("zone_id").(string)
+	loadBalancerId := d.Get("load_balancer_id").(string)
+
+	log.Printf("[INFO] Deleting CloudFlare Load Balancer: %s in zone: %s", loadBalancerId, zoneId)
+
+	err := client.DeleteLoadBalancer(zoneId, loadBalancerId)
+	if err != nil {
+		return fmt.Errorf("error deleting CloudFlare Load Balancer: %s", err)
+	}
+
+	return nil
+}
+
+func resourceCloudFlareLoadBalancerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*cloudflare.API)
+	zoneId := d.Get("zone_id").(string)
+	loadBalancerId := d.Get("load_balancer_id").(string)
+
+	_, err := client.LoadBalancerDetails(zoneId, loadBalancerId)
+	if err != nil {
+		log.Printf("[INFO] Error found when checking if  load balancer exists: %s", err.Error())
+		if strings.Contains(err.Error(), "HTTP status 404") {
+			log.Printf("[INFO] Found status 404 looking for resource %s in zone %s", loadBalancerId, zoneId)
+			return false, nil
+		} else {
+			return false, errors.Wrap(err,
+				fmt.Sprintf("Error reading load balancer resource from API for resource %s in zone %s", loadBalancerId, zoneId))
+		}
+	}
+
+	return true, nil
+}
+
+func resourceCloudFlareLoadBalancerImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*cloudflare.API)
+
+	// split the id so we can lookup
+	idAttr := strings.SplitN(d.Id(), "_", 2)
+	var zoneName string
+	var loadBalancerId string
+	if len(idAttr) == 2 {
+		zoneName = idAttr[0]
+		loadBalancerId = idAttr[1]
+		d.Set("zone", zoneName)
+		d.Set("load_balancer_id", loadBalancerId)
+	} else {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneName_loadBalancerId\"", d.Id())
+	}
+	zoneId, err := client.ZoneIDByName(zoneName)
+	d.Set("zone_id", zoneId)
+	if err != nil {
+		return nil, fmt.Errorf("error finding zoneName %q: %s", zoneName, err)
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+func HashByMapKey(key string) func(v interface{}) int {
+	return func(v interface{}) int {
+		m := v.(map[string]interface{})
+		return schema.HashString(m[key])
+	}
+}

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -261,14 +261,23 @@ func resourceCloudFlareLoadBalancerRead(d *schema.ResourceData, meta interface{}
 
 	d.Set("name", loadBalancer.Name)
 	d.Set("fallback_pool_id", loadBalancer.FallbackPool)
-	d.Set("default_pool_ids", loadBalancer.DefaultPools)
 	d.Set("proxied", loadBalancer.Proxied)
 	d.Set("description", loadBalancer.Description)
 	d.Set("ttl", loadBalancer.TTL)
-	d.Set("pop_pools", flattenGeoPools(loadBalancer.PopPools, "pop"))
-	d.Set("region_pools", flattenGeoPools(loadBalancer.RegionPools, "region"))
 	d.Set("created_on", loadBalancer.CreatedOn.Format(time.RFC3339Nano))
 	d.Set("modified_on", loadBalancer.ModifiedOn.Format(time.RFC3339Nano))
+
+	if err := d.Set("default_pool_ids", loadBalancer.DefaultPools); err != nil {
+		log.Printf("[WARN] Error setting default_pool_ids on load balancer %q: %s", d.Id(), err)
+	}
+
+	if err := d.Set("pop_pools", flattenGeoPools(loadBalancer.PopPools, "pop")); err != nil {
+		log.Printf("[WARN] Error setting pop_pools on load balancer %q: %s", d.Id(), err)
+	}
+
+	if err := d.Set("region_pools", flattenGeoPools(loadBalancer.RegionPools, "region")); err != nil {
+		log.Printf("[WARN] Error setting region_pools on load balancer %q: %s", d.Id(), err)
+	}
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -138,12 +138,12 @@ func resourceCloudFlareLoadBalancer() *schema.Resource {
 			},
 
 			"created_on": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 
 			"modified_on": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},

--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -194,15 +194,21 @@ func resourceCloudFlareLoadBalancerPoolRead(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Read CloudFlare Load Balancer Pool from API as struct: %+v", loadBalancerPool)
 
 	d.Set("name", loadBalancerPool.Name)
-	d.Set("origins", flattenLoadBalancerOrigins(loadBalancerPool.Origins))
 	d.Set("enabled", loadBalancerPool.Enabled)
 	d.Set("minimum_origins", loadBalancerPool.MinimumOrigins)
-	d.Set("check_regions", schema.NewSet(schema.HashString, flattenStringList(loadBalancerPool.CheckRegions)))
 	d.Set("description", loadBalancerPool.Description)
 	d.Set("monitor", loadBalancerPool.Monitor)
 	d.Set("notification_email", loadBalancerPool.NotificationEmail)
 	d.Set("created_on", loadBalancerPool.CreatedOn.Format(time.RFC3339Nano))
 	d.Set("modified_on", loadBalancerPool.ModifiedOn.Format(time.RFC3339Nano))
+
+	if err := d.Set("origins", flattenLoadBalancerOrigins(loadBalancerPool.Origins)); err != nil {
+		log.Printf("[WARN] Error setting origins on load balancer pool %q: %s", d.Id(), err)
+	}
+
+	if err := d.Set("check_regions", schema.NewSet(schema.HashString, flattenStringList(loadBalancerPool.CheckRegions))); err != nil {
+		log.Printf("[WARN] Error setting check_regions on load balancer pool %q: %s", d.Id(), err)
+	}
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -1,0 +1,273 @@
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"time"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudFlareLoadBalancerPool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudFlareLoadBalancerPoolCreate,
+		Read:   resourceCloudFlareLoadBalancerPoolRead,
+		Update: resourceCloudFlareLoadBalancerPoolUpdate,
+		Delete: resourceCloudFlareLoadBalancerPoolDelete,
+		Exists: resourceCloudFlareLoadBalancerPoolExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// TODO check that order of origins is not significant
+			"origins": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"address": {
+							Type:     schema.TypeString,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								// TODO: validate IP address
+							},
+						},
+
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+					},
+				},
+				Set: HashByMapKey("address"),
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"minimum_origins": { // TODO not currently used as not in the API client
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
+
+			"check_regions": { //TODO: set??
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true, // TODO this is messy for people on a restricted plan
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+
+			"monitor": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 32),
+			},
+
+			"notification_email": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"created_on": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"modified_on": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCloudFlareLoadBalancerPoolCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	loadBalancerPool := cloudflare.LoadBalancerPool{
+		Name:         d.Get("name").(string),
+		Origins:      expandLoadBalancerOrigins(d.Get("origins").(*schema.Set)),
+		Enabled:      d.Get("enabled").(bool),
+		CheckRegions: expandInterfaceToStringList(d.Get("check_regions")),
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		loadBalancerPool.Description = description.(string)
+	}
+
+	if monitor, ok := d.GetOk("monitor"); ok {
+		loadBalancerPool.Monitor = monitor.(string)
+	}
+
+	if notificationEmail, ok := d.GetOk("notification_email"); ok {
+		loadBalancerPool.NotificationEmail = notificationEmail.(string)
+	}
+
+	log.Printf("[INFO] Creating CloudFlare Load Balancer Pool from struct: %+v", loadBalancerPool)
+
+	r, err := client.CreateLoadBalancerPool(loadBalancerPool)
+	if err != nil {
+		return errors.Wrap(err, "error creating load balancer pool")
+	}
+
+	if r.ID == "" {
+		return fmt.Errorf("cailed to find id in create response; resource was empty")
+	}
+
+	d.SetId(r.ID)
+
+	log.Printf("[INFO] New CloudFlare Load Balancer Pool created with  ID: %s", d.Id())
+
+	return resourceCloudFlareLoadBalancerPoolRead(d, meta)
+}
+
+func expandLoadBalancerOrigins(originSet *schema.Set) (origins []cloudflare.LoadBalancerOrigin) {
+	for _, iface := range originSet.List() {
+		o := iface.(map[string]interface{})
+		origin := cloudflare.LoadBalancerOrigin{
+			Name:    o["name"].(string),
+			Address: o["address"].(string),
+			Enabled: o["enabled"].(bool),
+		}
+		origins = append(origins, origin)
+	}
+	return
+}
+
+func resourceCloudFlareLoadBalancerPoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	// since api only supports replace, update looks a lot like create...
+	client := meta.(*cloudflare.API)
+
+	loadBalancerPool := cloudflare.LoadBalancerPool{
+		Name:         d.Get("name").(string),
+		Origins:      expandLoadBalancerOrigins(d.Get("origins").(*schema.Set)),
+		Enabled:      d.Get("enabled").(bool),
+		CheckRegions: expandInterfaceToStringList(d.Get("check_regions")),
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		loadBalancerPool.Description = description.(string)
+	}
+
+	if monitor, ok := d.GetOk("monitor"); ok {
+		loadBalancerPool.Monitor = monitor.(string)
+	}
+
+	if notificationEmail, ok := d.GetOk("notification_email"); ok {
+		loadBalancerPool.NotificationEmail = notificationEmail.(string)
+	}
+
+	log.Printf("[INFO] Replacing CloudFlare Load Balancer Pool from struct: %+v", loadBalancerPool)
+
+	_, err := client.ModifyLoadBalancerPool(loadBalancerPool)
+	if err != nil {
+		return errors.Wrap(err, "error updating load balancer pool")
+	}
+
+	return resourceCloudFlareLoadBalancerPoolRead(d, meta)
+}
+
+func resourceCloudFlareLoadBalancerPoolRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	loadBalancerPool, err := client.LoadBalancerPoolDetails(d.Id())
+	if err != nil {
+		return errors.Wrap(err,
+			fmt.Sprintf("Error reading load balancer resource from API for resource %s ", d.Id()))
+	}
+	log.Printf("[INFO] Read CloudFlare Load Balancer Pool from API as struct: %+v", loadBalancerPool)
+
+	// api generally tries to populate everything, so just assume all data is present
+	// start by setting required values
+	d.Set("name", loadBalancerPool.Name)
+	d.Set("origins", flattenLoadBalancerOrigins(loadBalancerPool.Origins))
+	d.Set("enabled", loadBalancerPool.Enabled)
+
+	//d.Set("minimum_origins", loadBalancerPool.MinimumOrigins)
+	d.Set("check_regions", flattenStringList(loadBalancerPool.CheckRegions))
+
+	// ok to set empty optional/ noncomputed values?
+	d.Set("description", loadBalancerPool.Description)
+	d.Set("monitor", loadBalancerPool.Monitor)
+	d.Set("notification_email", loadBalancerPool.NotificationEmail)
+
+	d.Set("created_on", loadBalancerPool.CreatedOn.Format(time.RFC3339Nano))
+	d.Set("modified_on", loadBalancerPool.ModifiedOn.Format(time.RFC3339Nano))
+
+	return nil
+}
+
+func flattenLoadBalancerOrigins(origins []cloudflare.LoadBalancerOrigin) *schema.Set {
+	flattened := make([]interface{}, 0)
+	for _, o := range origins {
+		cfg := map[string]interface{}{
+			"name":    o.Name,
+			"address": o.Address,
+			"enabled": o.Enabled,
+		}
+		flattened = append(flattened, cfg)
+	}
+	return schema.NewSet(HashByMapKey("address"), flattened)
+}
+
+func resourceCloudFlareLoadBalancerPoolDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	log.Printf("[INFO] Deleting CloudFlare Load Balancer Pool: %s ", d.Id())
+
+	err := client.DeleteLoadBalancerPool(d.Id())
+	if err != nil {
+		return errors.Wrap(err, "error deleting CloudFlare Load Balancer Pool")
+	}
+
+	return nil
+}
+
+func resourceCloudFlareLoadBalancerPoolExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*cloudflare.API)
+
+	_, err := client.LoadBalancerPoolDetails(d.Id())
+	if err != nil {
+		log.Printf("[INFO] Error found when checking if load balancer pool exists: %s", err.Error())
+		if strings.Contains(err.Error(), "HTTP status 404") {
+			log.Printf("[INFO] Found status 404 looking for resource %s", d.Id())
+			return false, nil
+		} else {
+			return false, errors.Wrap(err,
+				fmt.Sprintf("Error reading load balancer resource from API for resource %s", d.Id()))
+		}
+	}
+
+	return true, nil
+}

--- a/cloudflare/resource_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool_test.go
@@ -1,0 +1,264 @@
+package cloudflare
+
+import (
+	"fmt"
+	"testing"
+
+	"time"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudFlareLoadBalancerPool_Basic(t *testing.T) {
+	// multiple instances of this config would conflict but we only use it once
+	t.Parallel()
+	testStartTime := time.Now().UTC()
+	var loadBalancerPool cloudflare.LoadBalancerPool
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer_pool." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					// dont check that specified values are set, this will be evident by lack of plan diff
+					// some values will get empty values
+					resource.TestCheckResourceAttr(name, "check_regions.#", "0"),
+					// also expect api to generate some values
+					testAccCheckCloudFlareLoadBalancerPoolDates(name, &loadBalancerPool, testStartTime),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFlareLoadBalancerPool_FullySpecified(t *testing.T) {
+	t.Parallel()
+	var loadBalancerPool cloudflare.LoadBalancerPool
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer_pool." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerPoolConfigFullySpecified(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					// checking our overrides of default values worked
+					resource.TestCheckResourceAttr(name, "enabled", "false"),
+					resource.TestCheckResourceAttr(name, "description", "tfacc-fully-specified"),
+				),
+			},
+		},
+	})
+}
+
+/**
+Any change to a load balancer pool results in a new resource
+Although the API client contains a modify method, this always results in 405 status
+*/
+func TestAccCloudFlareLoadBalancerPool_ForceNew(t *testing.T) {
+	t.Parallel()
+	var loadBalancerPool cloudflare.LoadBalancerPool
+	var initialId string
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer_pool." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+				),
+			},
+			{
+				PreConfig: func() {
+					initialId = loadBalancerPool.ID
+				},
+				Config: testAccCheckCloudFlareLoadBalancerPoolConfigFullySpecified(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					func(state *terraform.State) error {
+						if initialId == loadBalancerPool.ID {
+							return fmt.Errorf("id should be different after recreation, but is unchanged ",
+								initialId, loadBalancerPool.ID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFlareLoadBalancerPool_CreateAfterManualDestroy(t *testing.T) {
+	t.Parallel()
+	var loadBalancerPool cloudflare.LoadBalancerPool
+	var initialId string
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer_pool." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccManuallyDeleteLoadBalancerPool(name, &loadBalancerPool, &initialId),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					func(state *terraform.State) error {
+						if initialId == loadBalancerPool.ID {
+							return fmt.Errorf("load balancer pool id is unchanged even after we thought we deleted it ( %s )",
+								loadBalancerPool.ID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudFlareLoadBalancerPoolDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_load_balancer_pool" {
+			continue
+		}
+
+		_, err := client.LoadBalancerPoolDetails(rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Load balancer pool still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudFlareLoadBalancerPoolExists(n string, loadBalancerPool *cloudflare.LoadBalancerPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Load Balancer ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+		foundLoadBalancerPool, err := client.LoadBalancerPoolDetails(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		// TODO : probably this should never happen??
+		if foundLoadBalancerPool.ID != rs.Primary.ID {
+			return fmt.Errorf("Load balancer not found")
+		}
+
+		*loadBalancerPool = foundLoadBalancerPool
+
+		return nil
+	}
+}
+
+func testAccCheckCloudFlareLoadBalancerPoolDates(n string, loadBalancerPool *cloudflare.LoadBalancerPool, testStartTime time.Time) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, _ := s.RootModule().Resources[n]
+
+		for timeStampAttr, serverVal := range map[string]time.Time{"created_on": *loadBalancerPool.CreatedOn, "modified_on": *loadBalancerPool.ModifiedOn} {
+			timeStamp, err := time.Parse(time.RFC3339Nano, rs.Primary.Attributes[timeStampAttr])
+			if err != nil {
+				return err
+			}
+
+			if timeStamp != serverVal {
+				return fmt.Errorf("state value of %s: %s is different than server created value: %s",
+					timeStampAttr, rs.Primary.Attributes[timeStampAttr], serverVal.Format(time.RFC3339Nano))
+			}
+
+			// check retrieved values are reasonable
+			// note this could fail if local time is out of sync with server time
+			if timeStamp.Before(testStartTime) {
+				return fmt.Errorf("State value of %s: %s should be greater than test start time: %s",
+					timeStampAttr, timeStamp.Format(time.RFC3339Nano), testStartTime.Format(time.RFC3339Nano))
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccManuallyDeleteLoadBalancerPool(name string, loadBalancerPool *cloudflare.LoadBalancerPool, initialId *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*cloudflare.API)
+		*initialId = loadBalancerPool.ID
+		err := client.DeleteLoadBalancerPool(loadBalancerPool.ID)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+// using IPs from 192.0.2.0/24 as per RFC5737
+func testAccCheckCloudFlareLoadBalancerPoolConfigBasic(id string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_load_balancer_pool" "%[1]s" {
+  name = "my-tf-pool-basic-%[1]s"
+  origins {
+    name = "example-1"
+    address = "192.0.2.1"
+    enabled = false
+  }
+}`, id)
+}
+
+func testAccCheckCloudFlareLoadBalancerPoolConfigFullySpecified(id string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_load_balancer_pool" "%[1]s" {
+  name = "my-tf-pool-basic-%[1]s"
+  origins {
+    name = "example-1"
+    address = "192.0.2.1"
+    enabled = false
+  }
+  origins {
+    name = "example-2"
+    address = "192.0.2.2"
+  }
+  description = "tfacc-fully-specified"
+  enabled = false
+  // minimum_origins = 2 TODO: need to upgrade client api
+  // monitor = abcd TODO: monitor resource
+  notification_email = "someone@example.com"
+}`, id)
+	// TODO add fields to config
+}

--- a/cloudflare/resource_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool_test.go
@@ -58,6 +58,8 @@ func TestAccCloudFlareLoadBalancerPool_FullySpecified(t *testing.T) {
 					// checking our overrides of default values worked
 					resource.TestCheckResourceAttr(name, "enabled", "false"),
 					resource.TestCheckResourceAttr(name, "description", "tfacc-fully-specified"),
+					resource.TestCheckResourceAttr(name, "check_regions.#", "1"),
+					resource.TestCheckResourceAttr(name, "minimum_origins", "2"),
 				),
 			},
 		},
@@ -95,8 +97,8 @@ func TestAccCloudFlareLoadBalancerPool_ForceNew(t *testing.T) {
 					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
 					func(state *terraform.State) error {
 						if initialId == loadBalancerPool.ID {
-							return fmt.Errorf("id should be different after recreation, but is unchanged ",
-								initialId, loadBalancerPool.ID)
+							return fmt.Errorf("id should be different after recreation, but is unchanged: %s ",
+								loadBalancerPool.ID)
 						}
 						return nil
 					},
@@ -177,11 +179,6 @@ func testAccCheckCloudFlareLoadBalancerPoolExists(n string, loadBalancerPool *cl
 			return err
 		}
 
-		// TODO : probably this should never happen??
-		if foundLoadBalancerPool.ID != rs.Primary.ID {
-			return fmt.Errorf("Load balancer not found")
-		}
-
 		*loadBalancerPool = foundLoadBalancerPool
 
 		return nil
@@ -254,11 +251,12 @@ resource "cloudflare_load_balancer_pool" "%[1]s" {
     name = "example-2"
     address = "192.0.2.2"
   }
+  check_regions = ["WEU"]
   description = "tfacc-fully-specified"
   enabled = false
-  // minimum_origins = 2 TODO: need to upgrade client api
+  minimum_origins = 2
   // monitor = abcd TODO: monitor resource
   notification_email = "someone@example.com"
 }`, id)
-	// TODO add fields to config
+	// TODO add field to config after creating monitor resource
 }

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -1,0 +1,317 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"time"
+
+	"os"
+
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudFlareLoadBalancer_Basic(t *testing.T) {
+	// multiple instances of this config would conflict but we only use it once
+	t.Parallel()
+	testStartTime := time.Now().UTC()
+	var loadBalancer cloudflare.LoadBalancer
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					// dont check that specified values are set, this will be evident by lack of plan diff
+					// some values will get empty values
+					resource.TestCheckResourceAttr(name, "pop_pools.#", "0"),
+					resource.TestCheckResourceAttr(name, "region_pools.#", "0"),
+					// also expect api to generate some values
+					testAccCheckCloudFlareLoadBalancerDates(name, &loadBalancer, testStartTime),
+					resource.TestCheckResourceAttr(name, "proxied", "false"), // default value
+					resource.TestCheckResourceAttr(name, "ttl", "30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFlareLoadBalancer_GeoBalanced(t *testing.T) {
+	t.Parallel()
+	var loadBalancer cloudflare.LoadBalancer
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerConfigGeoBalanced(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					// checking our overrides of default values worked
+					resource.TestCheckResourceAttr(name, "description", "tf-acctest load balancer using geo-balancing"),
+					resource.TestCheckResourceAttr(name, "proxied", "true"),
+					resource.TestCheckResourceAttr(name, "ttl", "0"),
+					resource.TestCheckResourceAttr(name, "pop_pools.#", "1"),
+					resource.TestCheckResourceAttr(name, "region_pools.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+/**
+Any change to a load balancer  results in a new resource
+Although the API client contains a modify method, this always results in 405 status
+*/
+func TestAccCloudFlareLoadBalancer_Update(t *testing.T) {
+	t.Parallel()
+	var loadBalancer cloudflare.LoadBalancer
+	var initialId string
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+				),
+			},
+			{
+				PreConfig: func() {
+					initialId = loadBalancer.ID
+				},
+				Config: testAccCheckCloudFlareLoadBalancerConfigGeoBalanced(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					func(state *terraform.State) error {
+						if initialId != loadBalancer.ID {
+							// want in place update
+							return fmt.Errorf("load balancer id is different after second config applied ( %s -> %s )",
+								initialId, loadBalancer.ID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFlareLoadBalancer_CreateAfterManualDestroy(t *testing.T) {
+	t.Parallel()
+	var loadBalancer cloudflare.LoadBalancer
+	var initialId string
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_load_balancer." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccManuallyDeleteLoadBalancer(name, &loadBalancer, &initialId),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					func(state *terraform.State) error {
+						if initialId == loadBalancer.ID {
+							return fmt.Errorf("load balancer id is unchanged even after we thought we deleted it ( %s )",
+								loadBalancer.ID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudFlareLoadBalancerDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_load_balancer" {
+			continue
+		}
+
+		_, err := client.LoadBalancerDetails(rs.Primary.Attributes["zone_id"], rs.Primary.Attributes["load_balancer_id"])
+		if err == nil {
+			return fmt.Errorf("load balancer still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudFlareLoadBalancerExists(n string, loadBalancer *cloudflare.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Load Balancer ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+		foundLoadBalancer, err := client.LoadBalancerDetails(rs.Primary.Attributes["zone_id"], rs.Primary.Attributes["load_balancer_id"])
+		if err != nil {
+			return err
+		}
+
+		*loadBalancer = foundLoadBalancer
+
+		return nil
+	}
+}
+
+func testAccCheckCloudFlareLoadBalancerIDIsValid(n, expectedZone string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		idAttr := strings.SplitN(rs.Primary.ID, "_", 2)
+
+		if len(idAttr) == 2 {
+			if expectedZone != idAttr[0] {
+				return fmt.Errorf("zone in id: %s doesn't match the expected: %s", idAttr[0], expectedZone)
+			}
+			// resource id is 33 char string
+			if len(idAttr[1]) != 32 {
+				return fmt.Errorf("rate limit id value in id: %s is the wrong length for an id", idAttr[1])
+			}
+		} else {
+			return fmt.Errorf("invalid id (\"%s\"), should be in format \"zoneName_loadBalancerId\"", rs.Primary.ID)
+		}
+
+		// check attributes relating to id components should always be set in state
+		if rs.Primary.Attributes["zone"] != idAttr[0] {
+			return fmt.Errorf("zone in id: %s doesn't match the zone attribute in state: %s", idAttr[0], rs.Primary.Attributes["zone"])
+		}
+
+		if rs.Primary.Attributes["load_balancer_id"] != idAttr[1] {
+			return fmt.Errorf("load balancer id in resource id: %s doesn't match the load_balancer_id attribute in state: %s", idAttr[0], rs.Primary.Attributes["load_balancer_id"])
+		}
+		if zoneId, ok := rs.Primary.Attributes["zone_id"]; !ok || len(zoneId) < 1 {
+			return errors.New("zone_id is unset, should always be set with id")
+		}
+		return nil
+	}
+}
+
+func testAccCheckCloudFlareLoadBalancerDates(n string, loadBalancer *cloudflare.LoadBalancer, testStartTime time.Time) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, _ := s.RootModule().Resources[n]
+
+		for timeStampAttr, serverVal := range map[string]time.Time{"created_on": *loadBalancer.CreatedOn, "modified_on": *loadBalancer.ModifiedOn} {
+			timeStamp, err := time.Parse(time.RFC3339Nano, rs.Primary.Attributes[timeStampAttr])
+			if err != nil {
+				return err
+			}
+
+			if timeStamp != serverVal {
+				return fmt.Errorf("state value of %s: %s is different than server created value: %s",
+					timeStampAttr, rs.Primary.Attributes[timeStampAttr], serverVal.Format(time.RFC3339Nano))
+			}
+
+			// check retrieved values are reasonable
+			// note this could fail if local time is out of sync with server time
+			if timeStamp.Before(testStartTime) {
+				return fmt.Errorf("State value of %s: %s should be greater than test start time: %s",
+					timeStampAttr, timeStamp.Format(time.RFC3339Nano), testStartTime.Format(time.RFC3339Nano))
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccManuallyDeleteLoadBalancer(name string, loadBalancer *cloudflare.LoadBalancer, initialId *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[name]
+		client := testAccProvider.Meta().(*cloudflare.API)
+		*initialId = loadBalancer.ID
+		err := client.DeleteLoadBalancer(rs.Primary.Attributes["zone_id"], rs.Primary.Attributes["load_balancer_id"])
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckCloudFlareLoadBalancerConfigBasic(zone, id string) string {
+	return testAccCheckCloudFlareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
+resource "cloudflare_load_balancer" "%[2]s" {
+  zone = "%[1]s"
+  name = "tf-testacc-lb-%[2]s"
+  fallback_pool_id = "${cloudflare_load_balancer_pool.%[2]s.id}"
+  default_pool_ids = ["${cloudflare_load_balancer_pool.%[2]s.id}"]
+}`, zone, id)
+}
+
+func testAccCheckCloudFlareLoadBalancerConfigGeoBalanced(zone, id string) string {
+	return testAccCheckCloudFlareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
+resource "cloudflare_load_balancer" "%[2]s" {
+  zone = "%[1]s"
+  name = "tf-testacc-lb-%[2]s"
+  fallback_pool_id = "${cloudflare_load_balancer_pool.%[2]s.id}"
+  default_pool_ids = ["${cloudflare_load_balancer_pool.%[2]s.id}"]
+  description = "tf-acctest load balancer using geo-balancing"
+  proxied = true // can't set ttl with proxied
+  pop_pools {
+    pop = "LAX"
+    pool_ids = ["${cloudflare_load_balancer_pool.%[2]s.id}"]
+  }
+  region_pools {
+    region = "WNAM"
+    pool_ids = ["${cloudflare_load_balancer_pool.%[2]s.id}"]
+  }
+}`, zone, id)
+	// TODO add fields to config
+}

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -313,5 +313,4 @@ resource "cloudflare_load_balancer" "%[2]s" {
     pool_ids = ["${cloudflare_load_balancer_pool.%[2]s.id}"]
   }
 }`, zone, id)
-	// TODO add fields to config
 }

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -1,0 +1,18 @@
+package cloudflare
+
+func expandInterfaceToStringList(list interface{}) []string {
+	ifaceList := list.([]interface{})
+	vs := make([]string, 0, len(ifaceList))
+	for _, v := range ifaceList {
+		vs = append(vs, v.(string))
+	}
+	return vs
+}
+
+func flattenStringList(list []string) []interface{} {
+	vs := make([]interface{}, 0, len(list))
+	for _, v := range list {
+		vs = append(vs, v)
+	}
+	return vs
+}

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -1,5 +1,7 @@
 package cloudflare
 
+import "github.com/hashicorp/terraform/helper/schema"
+
 func expandInterfaceToStringList(list interface{}) []string {
 	ifaceList := list.([]interface{})
 	vs := make([]string, 0, len(ifaceList))
@@ -15,4 +17,11 @@ func flattenStringList(list []string) []interface{} {
 		vs = append(vs, v)
 	}
 	return vs
+}
+
+func HashByMapKey(key string) func(v interface{}) int {
+	return func(v interface{}) int {
+		m := v.(map[string]interface{})
+		return schema.HashString(m[key])
+	}
 }

--- a/cloudflare/validators.go
+++ b/cloudflare/validators.go
@@ -79,3 +79,11 @@ func validateRecordName(t string, value string) error {
 
 	return nil
 }
+
+func validateStringIP(v interface{}, k string) (warnings []string, errors []error) {
+	ip := net.ParseIP(v.(string))
+	if ip == nil {
+		errors = append(errors, fmt.Errorf("%q is not a valid IP: %q", k, v.(string)))
+	}
+	return
+}

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -22,6 +22,12 @@
         <li<%= sidebar_current("docs-cloudflare-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-cloudflare-resource-load-balancer") %>>
+              <a href="/docs/providers/cloudflare/r/load_balancer.html">cloudflare_load_balancer</a>
+            </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-load-balancer-pool") %>>
+              <a href="/docs/providers/cloudflare/r/load_balancer_pool.html">cloudflare_load_balancer_pool</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-record") %>>
               <a href="/docs/providers/cloudflare/r/record.html">cloudflare_record</a>
             </li>

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_load_balancer"
+sidebar_current: "docs-cloudflare-resource-load-balancer"
+description: |-
+  Provides a Cloudflare Load Balancer resource.
+---
+
+# cloudflare_load_balancer
+
+Provides a Cloudflare Load Balancer resource. This sits in front of a number of defined pools of origins and provides various options for geographically-aware load balancing.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_load_balancer_pool" "foo" {
+  name = "example-lb-pool"
+  origins {
+    name = "example-1"
+    address = "192.0.2.1"
+    enabled = false
+  }
+}
+
+# Define a load balancer which always points to the pool we defined
+# In normal usage, would have different pools set for different pops/regions
+# And some failover defined within that
+resource "cloudflare_load_balancer" "bar" {
+  zone = "example.com"
+  name = "example-load-balancer"
+  fallback_pool_id = "${cloudflare_load_balancer_pool.foo.id}"
+  default_pool_ids = ["${cloudflare_load_balancer_pool.foo.id}"]
+  description = "example load balancer using geo-balancing"
+  proxied = true
+  pop_pools {
+    pop = "LAX"
+    pool_ids = ["${cloudflare_load_balancer_pool.foo.id}"]
+  }
+  region_pools {
+    region = "WNAM"
+    pool_ids = ["${cloudflare_load_balancer_pool.foo.id}"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone` - (Required) The zone to add the load balancer to.
+* `name` - (Required) The DNS name to associate with the load balancer.
+* `fallback_pool_id` - (Required) The pool ID to use when all other pools are detected as unhealthy.
+* `default_pool_ids` - (Required) A list of pool IDs ordered by their failover priority. Used whenever region/pop pools are not defined.
+* `description` - (Optional) Free text description.
+* `ttl` - (Optional) Time to live (TTL) of this load balancer's DNS `name`. Conflicts with `proxied` - this cannot be set for proxied load balancers. Default is `30`.
+* `proxied` - (Optional) Whether the hostname gets Cloudflare's origin protection. Defaults to `false`.
+* `region_pools` - (Optional) A set containing mappings of region/country codes to a list of pool IDs (ordered by their failover priority) for the given region. Fields documented below.
+* `pop_pools` - (Optional) A set containing mappings of Cloudflare Point-of-Presence identifiers to a list of pool IDs (ordered by their failover priority) for the PoP (datacenter). This feature is only available to enterprise customers. Fields documented below.
+
+**region_pools** requires the following:
+
+* `region` - (Required) A region code which must be in the list defined [here](https://support.cloudflare.com/hc/en-us/articles/115000540888-Load-Balancing-Geographic-Regions).
+* `pool_ids` - (Required) A list of pool IDs in failover priority to use in the given region.
+
+**pop_pools** requires the following:
+
+* `pop` - (Required) A 3-letter code for the PoP. Allowed values can be found in the list of datacenters on the [status page](https://www.cloudflarestatus.com/).
+* `pool_ids` - (Required) A list of pool IDs in failover priority to use for traffic reaching the given PoP.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Combination of the zone name and load balancer ID, e.g. `example.com_12345678910`.
+* `load_balancer_id` - Unique identifier in the API for the load balancer.
+* `zone_id` - ID associated with the specified `zone`.
+* `created_on` - The RFC3339 timestamp of when the load balancer was created.
+* `modified_on` - The RFC3339 timestamp of when the load balancer was last modified.

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -71,8 +71,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - Combination of the zone name and load balancer ID, e.g. `example.com_12345678910`.
-* `load_balancer_id` - Unique identifier in the API for the load balancer.
+* `id` - Unique identifier in the API for the load balancer.
 * `zone_id` - ID associated with the specified `zone`.
 * `created_on` - The RFC3339 timestamp of when the load balancer was created.
 * `modified_on` - The RFC3339 timestamp of when the load balancer was last modified.

--- a/website/docs/r/load_balancer_pool.html.markdown
+++ b/website/docs/r/load_balancer_pool.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_load_balancer_pool"
+sidebar_current: "docs-cloudflare-resource-load-balancer-pool"
+description: |-
+  Provides a Cloudflare Load Balancer Pool resource.
+---
+
+# cloudflare_load_balancer_pool
+
+Provides a Cloudflare Load Balancer pool resource. This provides a pool of origins that can be used by a Cloudflare Load Balancer.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_load_balancer_pool" "foo" {
+  name = "example-pool"
+  origins {
+    name = "example-1"
+    address = "192.0.2.1"
+    enabled = false
+  }
+  origins {
+    name = "example-2"
+    address = "192.0.2.2"
+  }
+  description = "example load balancer pool"
+  enabled = false
+  minimum_origins = 1
+  notification_email = "someone@example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A short name (tag) for the pool. Only alphanumeric characters, hyphens and underscores are allowed.
+* `origins` - (Required) The list of origins within this pool. Traffic directed at this pool is balanced across all currently healthy origins, provided the pool itself is healthy. Fields documented below
+* `check_regions` - (Optional) A list of regions from which to run health checks. Empty means every Cloudflare datacenter (the default).
+* `description` - (Optional) Free text description.
+* `enabled` - (Optional) Whether to enable (the default) this pool. Disabled pools will not receive traffic and are excluded from health checks. Disabling a pool will cause any load balancers using it to failover to the next pool (if any).
+* `minimum_origins` - (Optional) The minimum number of origins that must be healthy for this pool to serve traffic. If the number of healthy origins falls below this number, the pool will be marked unhealthy and we wil failover to the next available pool. Default: 1.
+* `monitor` - (Optional) The ID of the Monitor to use for health checking origins within this pool.
+* `notification_email` - (Optional) The email address to send health status notifications to. This can be an individual mailbox or a mailing list.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - ID for this load balancer pool.
+* `created_on` - The RFC3339 timestamp of when the load balancer was created.
+* `modified_on` - The RFC3339 timestamp of when the load balancer was last modified.


### PR DESCRIPTION
These load balancers do geographically aware load-balancing based on defined pools.

As such, I realized that load balancer pools are necessary as a prereq to doing load balancers so I have both in this PR. Can split this up if it proves too difficult to digest

Note - there are also associated 'monitors' for load balancing pools, I intend to add that as a separate resource in a subsequent PR. Then it would be useful to have it in at least one of the load balancer pool tests.

Also worth noting that the load balancer uses the same kind of compound id as rate_limit