### PR TITLE
Add Load balancer monitor resource 

### DIFF
--- a/cloudflare/import_cloudflare_load_balancer_monitor_test.go
+++ b/cloudflare/import_cloudflare_load_balancer_monitor_test.go
@@ -1,0 +1,27 @@
+package cloudflare
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccCloudFlareLoadBalancerMonitor_Import(t *testing.T) {
+	t.Parallel()
+	name := "cloudflare_load_balancer_monitor.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -29,7 +29,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"cloudflare_record": resourceCloudFlareRecord(),
+			"cloudflare_record":                resourceCloudFlareRecord(),
+			"cloudflare_load_balancer_monitor": resourceCloudFlareLoadBalancerMonitor(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -1,0 +1,258 @@
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"time"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudFlareLoadBalancerMonitor() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudFlareLoadBalancerPoolMonitorCreate,
+		Read:   resourceCloudFlareLoadBalancerPoolMonitorRead,
+		Update: resourceCloudFlareLoadBalancerPoolMonitorUpdate,
+		Delete: resourceCloudFlareLoadBalancerPoolMonitorDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"expected_body": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"expected_codes": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"method": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "GET",
+			},
+
+			"timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      5,
+				ValidateFunc: validation.IntBetween(1, 10),
+			},
+
+			"path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "/",
+			},
+
+			"interval": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  60,
+			},
+			// interval has to be larger than (retries+1) * probe_timeout:
+
+			"retries": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				ValidateFunc: validation.IntBetween(1, 5),
+			},
+
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "http",
+				ValidateFunc: validation.StringInSlice([]string{"http", "https"}, false),
+			},
+
+			"header": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"header": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"values": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+				Set: HashByMapKey("header"),
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"created_on": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"modified_on": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCloudFlareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	loadBalancerMonitor := cloudflare.LoadBalancerMonitor{
+		ExpectedBody:  d.Get("expected_body").(string),
+		ExpectedCodes: d.Get("expected_codes").(string),
+		Method:        d.Get("method").(string),
+		Timeout:       d.Get("timeout").(int),
+		Type:          d.Get("type").(string),
+		Path:          d.Get("path").(string),
+		Interval:      d.Get("interval").(int),
+		Retries:       d.Get("retries").(int),
+	}
+
+	if header, ok := d.GetOk("header"); ok {
+		loadBalancerMonitor.Header = expandLoadBalancerMonitorHeader(header)
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		loadBalancerMonitor.Description = description.(string)
+	}
+
+	log.Printf("[DEBUG] Creating CloudFlare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
+
+	r, err := client.CreateLoadBalancerMonitor(loadBalancerMonitor)
+	if err != nil {
+		return errors.Wrap(err, "error creating load balancer monitor")
+	}
+
+	if r.ID == "" {
+		return fmt.Errorf("cailed to find id in create response; resource was empty")
+	}
+
+	d.SetId(r.ID)
+
+	log.Printf("[INFO] New CloudFlare Load Balancer Monitor created with  ID: %s", d.Id())
+
+	return resourceCloudFlareLoadBalancerPoolMonitorRead(d, meta)
+}
+
+func resourceCloudFlareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	loadBalancerMonitor := cloudflare.LoadBalancerMonitor{
+		ID:            d.Id(),
+		ExpectedBody:  d.Get("expected_body").(string),
+		ExpectedCodes: d.Get("expected_codes").(string),
+		Method:        d.Get("method").(string),
+		Timeout:       d.Get("timeout").(int),
+		Type:          d.Get("type").(string),
+		Path:          d.Get("path").(string),
+		Interval:      d.Get("interval").(int),
+		Retries:       d.Get("retries").(int),
+	}
+
+	if header, ok := d.GetOk("header"); ok {
+		loadBalancerMonitor.Header = expandLoadBalancerMonitorHeader(header)
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		loadBalancerMonitor.Description = description.(string)
+	}
+
+	log.Printf("[DEBUG] Update CloudFlare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
+
+	_, err := client.ModifyLoadBalancerMonitor(loadBalancerMonitor)
+	if err != nil {
+		return errors.Wrap(err, "error modifying load balancer monitor")
+	}
+
+	log.Printf("[INFO] CloudFlare Load Balancer Monitor %q was modified", d.Id())
+
+	return resourceCloudFlareLoadBalancerPoolMonitorRead(d, meta)
+}
+
+func expandLoadBalancerMonitorHeader(cfgSet interface{}) map[string][]string {
+	header := make(map[string][]string)
+	cfgList := cfgSet.(*schema.Set).List()
+	for _, item := range cfgList {
+		cfg := item.(map[string]interface{})
+		header[cfg["header"].(string)] = expandInterfaceToStringList(cfg["values"].(*schema.Set).List())
+	}
+	return header
+}
+
+func resourceCloudFlareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	loadBalancerMonitor, err := client.LoadBalancerMonitorDetails(d.Id())
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP status 404") {
+			log.Printf("[INFO] Load balancer monitor %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		} else {
+			return errors.Wrap(err,
+				fmt.Sprintf("Error reading load balancer monitor from API for resource %s ", d.Id()))
+		}
+	}
+	log.Printf("[DEBUG] Read CloudFlare Load Balancer Monitor from API as struct: %+v", loadBalancerMonitor)
+
+	d.Set("expected_body", loadBalancerMonitor.ExpectedBody)
+	d.Set("expected_codes", loadBalancerMonitor.ExpectedCodes)
+	d.Set("method", loadBalancerMonitor.Method)
+	d.Set("timeout", loadBalancerMonitor.Timeout)
+	d.Set("path", loadBalancerMonitor.Path)
+	d.Set("interval", loadBalancerMonitor.Interval)
+	d.Set("retries", loadBalancerMonitor.Retries)
+	d.Set("header", flattenLoadBalancerMonitorHeader(loadBalancerMonitor.Header))
+	d.Set("type", loadBalancerMonitor.Type)
+	d.Set("description", loadBalancerMonitor.Description)
+	d.Set("created_on", loadBalancerMonitor.CreatedOn.Format(time.RFC3339Nano))
+	d.Set("modified_on", loadBalancerMonitor.ModifiedOn.Format(time.RFC3339Nano))
+
+	return nil
+}
+
+func flattenLoadBalancerMonitorHeader(header map[string][]string) *schema.Set {
+	flattened := make([]interface{}, 0)
+	for k, v := range header {
+		cfg := map[string]interface{}{
+			"header": k,
+			"values": schema.NewSet(schema.HashString, flattenStringList(v)),
+		}
+		flattened = append(flattened, cfg)
+	}
+	return schema.NewSet(HashByMapKey("header"), flattened)
+}
+
+func resourceCloudFlareLoadBalancerPoolMonitorDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	log.Printf("[INFO] Deleting CloudFlare Load Balancer Monitor: %s ", d.Id())
+
+	err := client.DeleteLoadBalancerMonitor(d.Id())
+	if err != nil {
+		return errors.Wrap(err, "error deleting cloudflare load balancer monitor")
+	}
+
+	return nil
+}

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -223,11 +223,14 @@ func resourceCloudFlareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta 
 	d.Set("path", loadBalancerMonitor.Path)
 	d.Set("interval", loadBalancerMonitor.Interval)
 	d.Set("retries", loadBalancerMonitor.Retries)
-	d.Set("header", flattenLoadBalancerMonitorHeader(loadBalancerMonitor.Header))
 	d.Set("type", loadBalancerMonitor.Type)
 	d.Set("description", loadBalancerMonitor.Description)
 	d.Set("created_on", loadBalancerMonitor.CreatedOn.Format(time.RFC3339Nano))
 	d.Set("modified_on", loadBalancerMonitor.ModifiedOn.Format(time.RFC3339Nano))
+
+	if err := d.Set("header", flattenLoadBalancerMonitorHeader(loadBalancerMonitor.Header)); err != nil {
+		log.Printf("[WARN] Error setting header for load balancer monitor %q: %s", d.Id(), err)
+	}
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -254,7 +254,12 @@ func resourceCloudFlareLoadBalancerPoolMonitorDelete(d *schema.ResourceData, met
 
 	err := client.DeleteLoadBalancerMonitor(d.Id())
 	if err != nil {
-		return errors.Wrap(err, "error deleting cloudflare load balancer monitor")
+		if strings.Contains(err.Error(), "HTTP status 404") {
+			log.Printf("[INFO] Load balancer monitor %s no longer exists", d.Id())
+			return nil
+		} else {
+			return errors.Wrap(err, "error deleting cloudflare load balancer monitor")
+		}
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
@@ -1,0 +1,245 @@
+package cloudflare
+
+import (
+	"fmt"
+	"testing"
+
+	"time"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudFlareLoadBalancerMonitor_Basic(t *testing.T) {
+	// multiple instances of this config would conflict but we only use it once
+	t.Parallel()
+	testStartTime := time.Now().UTC()
+	var loadBalancerMonitor cloudflare.LoadBalancerMonitor
+	name := "cloudflare_load_balancer_monitor.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					// dont check that specified values are set, this will be evident by lack of plan diff
+					// some values will get empty values
+					resource.TestCheckResourceAttr(name, "description", ""),
+					resource.TestCheckResourceAttr(name, "header.#", "0"),
+					// also expect api to generate some values
+					testAccCheckCloudFlareLoadBalancerMonitorDates(name, &loadBalancerMonitor, testStartTime),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFlareLoadBalancerMonitor_FullySpecified(t *testing.T) {
+	t.Parallel()
+	var loadBalancerMonitor cloudflare.LoadBalancerMonitor
+	name := "cloudflare_load_balancer_monitor.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigFullySpecified(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					// checking our overrides of default values worked
+					resource.TestCheckResourceAttr(name, "path", "/custom"),
+					resource.TestCheckResourceAttr(name, "header.#", "1"),
+					resource.TestCheckResourceAttr(name, "retries", "5"),
+					resource.TestCheckResourceAttr(name, "expected_codes", "5xx"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFlareLoadBalancerMonitor_Update(t *testing.T) {
+	t.Parallel()
+	var loadBalancerMonitor cloudflare.LoadBalancerMonitor
+	var initialId string
+	name := "cloudflare_load_balancer_monitor.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+				),
+			},
+			{
+				PreConfig: func() {
+					initialId = loadBalancerMonitor.ID
+				},
+				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigFullySpecified(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					func(state *terraform.State) error {
+						if initialId != loadBalancerMonitor.ID {
+							return fmt.Errorf("wanted update but monitor got recreated (id changed %q -> %q)",
+								initialId, loadBalancerMonitor.ID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFlareLoadBalancerMonitor_CreateAfterManualDestroy(t *testing.T) {
+	t.Parallel()
+	var loadBalancerMonitor cloudflare.LoadBalancerMonitor
+	var initialId string
+	name := "cloudflare_load_balancer_monitor.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFlareLoadBalancerMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					testAccManuallyDeleteLoadBalancerMonitor(name, &loadBalancerMonitor, &initialId),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					func(state *terraform.State) error {
+						if initialId == loadBalancerMonitor.ID {
+							return fmt.Errorf("load balancer monitor id is unchanged even after we thought we deleted it ( %s )",
+								loadBalancerMonitor.ID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudFlareLoadBalancerMonitorDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_load_balancer_monitor" {
+			continue
+		}
+
+		_, err := client.LoadBalancerMonitorDetails(rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Load balancer monitor still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudFlareLoadBalancerMonitorExists(n string, load *cloudflare.LoadBalancerMonitor) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Load Balancer Monitor ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+		foundLoadBalancerMonitor, err := client.LoadBalancerMonitorDetails(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*load = foundLoadBalancerMonitor
+
+		return nil
+	}
+}
+
+func testAccCheckCloudFlareLoadBalancerMonitorDates(n string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, testStartTime time.Time) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, _ := s.RootModule().Resources[n]
+
+		for timeStampAttr, serverVal := range map[string]time.Time{"created_on": *loadBalancerMonitor.CreatedOn, "modified_on": *loadBalancerMonitor.ModifiedOn} {
+			timeStamp, err := time.Parse(time.RFC3339Nano, rs.Primary.Attributes[timeStampAttr])
+			if err != nil {
+				return err
+			}
+
+			if timeStamp != serverVal {
+				return fmt.Errorf("state value of %s: %s is different than server created value: %s",
+					timeStampAttr, rs.Primary.Attributes[timeStampAttr], serverVal.Format(time.RFC3339Nano))
+			}
+
+			// check retrieved values are reasonable
+			// note this could fail if local time is out of sync with server time
+			if timeStamp.Before(testStartTime) {
+				return fmt.Errorf("State value of %s: %s should be greater than test start time: %s",
+					timeStampAttr, timeStamp.Format(time.RFC3339Nano), testStartTime.Format(time.RFC3339Nano))
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccManuallyDeleteLoadBalancerMonitor(name string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, initialId *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*cloudflare.API)
+		*initialId = loadBalancerMonitor.ID
+		err := client.DeleteLoadBalancerMonitor(loadBalancerMonitor.ID)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckCloudFlareLoadBalancerMonitorConfigBasic() string {
+	return `
+resource "cloudflare_load_balancer_monitor" "test" {
+  expected_body = "alive"
+  expected_codes = "2xx"
+
+}`
+}
+
+func testAccCheckCloudFlareLoadBalancerMonitorConfigFullySpecified() string {
+	return `
+resource "cloudflare_load_balancer_monitor" "test" {
+  expected_body = "dead" 
+  expected_codes = "5xx" 
+  method = "HEAD"
+  timeout = 9
+  path = "/custom"
+  interval = 55
+  retries = 5
+  description = "this is a very weird load balancer"
+  header {
+    header = "Host"
+    values = ["example.com"]
+  }
+}`
+}

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -1,0 +1,27 @@
+package cloudflare
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func expandInterfaceToStringList(list interface{}) []string {
+	ifaceList := list.([]interface{})
+	vs := make([]string, 0, len(ifaceList))
+	for _, v := range ifaceList {
+		vs = append(vs, v.(string))
+	}
+	return vs
+}
+
+func flattenStringList(list []string) []interface{} {
+	vs := make([]interface{}, 0, len(list))
+	for _, v := range list {
+		vs = append(vs, v)
+	}
+	return vs
+}
+
+func HashByMapKey(key string) func(v interface{}) int {
+	return func(v interface{}) int {
+		m := v.(map[string]interface{})
+		return schema.HashString(m[key])
+	}
+}

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -25,6 +25,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-record") %>>
               <a href="/docs/providers/cloudflare/r/record.html">cloudflare_record</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-load-balancer-monitor") %>>
+              <a href="/docs/providers/cloudflare/r/load_balancer_monitor.html">cloudflare_load_balancer_monitor</a>
+            </li>
           </ul>
         </li>
       </ul>

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_load_balancer_monitor"
+sidebar_current: "docs-cloudflare-resource-load-balancer-monitor"
+description: |-
+  Provides a Cloudflare Load Balancer Monitor resource.
+---
+
+# cloudflare_load_balancer_monitor
+
+If you're using Cloudflare's Load Balancing to load-balance across multiple origin servers or data centers, you configure one of these Monitors to actively check the availability of those servers over HTTP(S).
+
+## Example Usage
+
+```hcl
+resource "cloudflare_load_balancer_monitor" "test" {
+  expected_body = "alive"
+  expected_codes = "2xx"
+  method = "GET"
+  timeout = 7
+  path = "/health"
+  interval = 55
+  retries = 5
+  description = "example load balancer"
+  header {
+    header = "Host"
+    values = ["example.com"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `expected_body` - (Required) A case-insensitive sub-string to look for in the response body. If this string is not found, the origin will be marked as unhealthy.
+* `expected_codes` - (Required) The expected HTTP response code or code range of the health check. Eg `2xx`
+* `method` - (Optional) The HTTP method to use for the health check. Default: "GET".
+* `timeout` - (Optional) The timeout (in seconds) before marking the health check as failed. Default: 5.
+* `path` - (Optional) The endpoint path to health check against. Default: "/".
+* `interval` - (Optional) The interval between each health check. Shorter intervals may improve failover time, but will increase load on the origins as we check from multiple locations. Default: 60.
+* `retries` - (Optional) The number of retries to attempt in case of a timeout before marking the origin as unhealthy. Retries are attempted immediately. Default: 2.
+* `header` - (Optional) The HTTP request headers to send in the health check. It is recommended you set a Host header by default. The User-Agent header cannot be overridden. Fields documented below.
+* `type` - (Optional) The protocol to use for the healthcheck. Currently supported protocols are 'HTTP' and 'HTTPS'. Default: "http".
+* `description` - (Optional) Free text description.
+
+**header** requires the following:
+
+* `header` - (Required) The header name.
+* `values` - (Required) A list of string values for the header.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Load balancer monitor ID.
+* `created_on` - The RFC3339 timestamp of when the load balancer monitor was created.
+* `modified_on` - The RFC3339 timestamp of when the load balancer monitor was last modified.


### PR DESCRIPTION
A simple, fairly standard-looking resource which enables load balancers created via the load balancer resource to work correctly. Relates to and follows the same patterns used in #31 , maybe helpful to consider them together