### PR TITLE
[WIP] Api rate limiting

### DIFF
--- a/cloudflare/config.go
+++ b/cloudflare/config.go
@@ -8,13 +8,14 @@ import (
 )
 
 type Config struct {
-	Email string
-	Token string
+	Email   string
+	Token   string
+	Options []cloudflare.Option
 }
 
 // Client() returns a new client for accessing cloudflare.
 func (c *Config) Client() (*cloudflare.API, error) {
-	client, err := cloudflare.New(c.Token, c.Email)
+	client, err := cloudflare.New(c.Token, c.Email, c.Options...)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating new CloudFlare client: %s", err)
 	}

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -38,7 +38,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     3,
-				Description: "RPS limit to apply when making calls to the API",
+				Description: "Maximum number of retries to perform when an API request fails",
 			},
 
 			"min_backoff": &schema.Schema{
@@ -59,7 +59,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "RPS limit to apply when making calls to the API",
+				Description: "Whether to print logs from the API client (using the default log library logger)",
 			},
 		},
 

--- a/vendor/github.com/cloudflare/cloudflare-go/cloudflare.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/cloudflare.go
@@ -3,12 +3,18 @@ package cloudflare
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"log"
+	"math"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
 )
 
 const apiURL = "https://api.cloudflare.com/client/v4"
@@ -30,6 +36,9 @@ type API struct {
 	headers           http.Header
 	httpClient        *http.Client
 	authType          int
+	rateLimiter       *rate.Limiter
+	retryPolicy       RetryPolicy
+	logger            Logger
 }
 
 // New creates a new Cloudflare v4 API client.
@@ -38,12 +47,21 @@ func New(key, email string, opts ...Option) (*API, error) {
 		return nil, errors.New(errEmptyCredentials)
 	}
 
+	silentLogger := log.New(ioutil.Discard, "", log.LstdFlags)
+
 	api := &API{
-		APIKey:   key,
-		APIEmail: email,
-		BaseURL:  apiURL,
-		headers:  make(http.Header),
-		authType: AuthKeyEmail,
+		APIKey:      key,
+		APIEmail:    email,
+		BaseURL:     apiURL,
+		headers:     make(http.Header),
+		authType:    AuthKeyEmail,
+		rateLimiter: rate.NewLimiter(rate.Limit(4), 1), // 4rps equates to default api limit (1200 req/5 min)
+		retryPolicy: RetryPolicy{
+			MaxRetries:    3,
+			MinRetryDelay: time.Duration(1) * time.Second,
+			MaxRetryDelay: time.Duration(30) * time.Second,
+		},
+		logger: silentLogger,
 	}
 
 	err := api.parseOptions(opts...)
@@ -87,26 +105,73 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 
 func (api *API) makeRequestWithAuthType(method, uri string, params interface{}, authType int) ([]byte, error) {
 	// Replace nil with a JSON object if needed
-	var reqBody io.Reader
+	var jsonBody []byte
+	var err error
 	if params != nil {
-		json, err := json.Marshal(params)
+		jsonBody, err = json.Marshal(params)
 		if err != nil {
 			return nil, errors.Wrap(err, "error marshalling params to JSON")
 		}
-		reqBody = bytes.NewReader(json)
 	} else {
-		reqBody = nil
+		jsonBody = nil
 	}
 
-	resp, err := api.request(method, uri, reqBody, authType)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
+	var resp *http.Response
+	var respErr error
+	var reqBody io.Reader
+	var respBody []byte
+	for i := 0; i <= api.retryPolicy.MaxRetries; i++ {
+		if jsonBody != nil {
+			reqBody = bytes.NewReader(jsonBody)
+		}
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not read response body")
+		if i > 0 {
+			// expect the backoff introduced here on errored requests to dominate the effect of rate limiting
+			// dont need a random component here as the rate limiter should do something similar
+			// nb time duration could truncate an arbitrary float. Since our inputs are all ints, we should be ok
+			sleepDuration := time.Duration(math.Pow(2, float64(i-1)) * float64(api.retryPolicy.MinRetryDelay))
+
+			if sleepDuration > api.retryPolicy.MaxRetryDelay {
+				sleepDuration = api.retryPolicy.MaxRetryDelay
+			}
+			// useful to do some simple logging here, maybe introduce levels later
+			api.logger.Printf("Sleeping %s before retry attempt number %d for request %s %s", sleepDuration.String(), i, method, uri)
+			time.Sleep(sleepDuration)
+		}
+		api.rateLimiter.Wait(context.TODO())
+		if err != nil {
+			return nil, errors.Wrap(err, "Error caused by request rate limiting")
+		}
+		resp, respErr = api.request(method, uri, reqBody, authType)
+
+		// retry if the server is rate limiting us or if it failed
+		// assumes server operations are rolled back on failure
+		if respErr != nil || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			// if we got a valid http response, try to read body so we can reuse the connection
+			// see https://golang.org/pkg/net/http/#Client.Do
+			if respErr == nil {
+				respBody, err = ioutil.ReadAll(resp.Body)
+				resp.Body.Close()
+
+				respErr = errors.Wrap(err, "could not read response body")
+
+				api.logger.Printf("Request: %s %s got an error response %d: %s\n", method, uri, resp.StatusCode,
+					strings.Replace(strings.Replace(string(respBody), "\n", "", -1), "\t", "", -1))
+			} else {
+				api.logger.Printf("Error performing request: %s %s : %s \n", method, uri, respErr.Error())
+			}
+			continue
+		} else {
+			respBody, err = ioutil.ReadAll(resp.Body)
+			defer resp.Body.Close()
+			if err != nil {
+				return nil, errors.Wrap(err, "could not read response body")
+			}
+			break
+		}
+	}
+	if respErr != nil {
+		return nil, respErr
 	}
 
 	switch resp.StatusCode {
@@ -121,13 +186,13 @@ func (api *API) makeRequestWithAuthType(method, uri string, params interface{}, 
 		return nil, errors.Errorf("HTTP status %d: service failure", resp.StatusCode)
 	default:
 		var s string
-		if body != nil {
-			s = string(body)
+		if respBody != nil {
+			s = string(respBody)
 		}
 		return nil, errors.Errorf("HTTP status %d: content %q", resp.StatusCode, s)
 	}
 
-	return body, nil
+	return respBody, nil
 }
 
 // request makes a HTTP request to the given API endpoint, returning the raw
@@ -233,4 +298,18 @@ func (api *API) Raw(method, endpoint string, data interface{}) (json.RawMessage,
 type PaginationOptions struct {
 	Page    int `json:"page,omitempty"`
 	PerPage int `json:"per_page,omitempty"`
+}
+
+// RetryPolicy specifies number of retries and min/max retry delays
+// This config is used when the client exponentially backs off after errored requests
+type RetryPolicy struct {
+	MaxRetries    int
+	MinRetryDelay time.Duration
+	MaxRetryDelay time.Duration
+}
+
+// Logger defines the interface this library needs to use logging
+// This is a subset of the methods implemented in the log package
+type Logger interface {
+	Printf(format string, v ...interface{})
 }

--- a/vendor/github.com/cloudflare/cloudflare-go/options.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/options.go
@@ -1,6 +1,12 @@
 package cloudflare
 
-import "net/http"
+import (
+	"net/http"
+
+	"time"
+
+	"golang.org/x/time/rate"
+)
 
 // Option is a functional option for configuring the API client.
 type Option func(*API) error
@@ -27,6 +33,42 @@ func Headers(headers http.Header) Option {
 func UsingOrganization(orgID string) Option {
 	return func(api *API) error {
 		api.organizationID = orgID
+		return nil
+	}
+}
+
+// UsingRateLimit applies a non-default rate limit to client API requests
+// If not specified the default of 4rps will be applied
+func UsingRateLimit(rps float64) Option {
+	return func(api *API) error {
+		// because ratelimiter doesnt do any windowing
+		// setting burst makes it difficult to enforce a fixed rate
+		// so setting it equal to 1 this effectively disables bursting
+		// this doesn't check for sensible values, ultimately the api will enforce that the value is ok
+		api.rateLimiter = rate.NewLimiter(rate.Limit(rps), 1)
+		return nil
+	}
+}
+
+// UsingRetryPolicy applies a non-default number of retries and min/max retry delays
+// This will be used when the client exponentially backs off after errored requests
+func UsingRetryPolicy(maxRetries int, minRetryDelaySecs int, maxRetryDelaySecs int) Option {
+	// seconds is very granular for a minimum delay - but this is only in case of failure
+	return func(api *API) error {
+		api.retryPolicy = RetryPolicy{
+			MaxRetries:    maxRetries,
+			MinRetryDelay: time.Duration(minRetryDelaySecs) * time.Second,
+			MaxRetryDelay: time.Duration(maxRetryDelaySecs) * time.Second,
+		}
+		return nil
+	}
+}
+
+// UsingLogger can be set if you want to get log output from this API instance
+// By default no log output is emitted
+func UsingLogger(logger Logger) Option {
+	return func(api *API) error {
+		api.logger = logger
 		return nil
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,3 +37,9 @@ The following arguments are supported:
   specified with the `CLOUDFLARE_EMAIL` shell environment variable.
 * `token` - (Required) The Cloudflare API token. This can also be specified
   with the `CLOUDFLARE_TOKEN` shell environment variable.
+* `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4.
+* `retries` - (Optional) Maximum number of retries to perform when an API request fails. Default: 3.
+* `min_backoff` - (Optional) Minimum backoff period in seconds after failed API calls. Default: 1.
+* `max_backoff` - (Optional) Maximum backoff period in seconds after failed API calls Default: 30.
+* `api_client_logging` - (Optional) Whether to print logs from the API client (using the default log library logger). Default: false.
+


### PR DESCRIPTION
This introduces options to the provider to allow for rate limiting, backoff and logging. Options are just passed through to the API client. 

This can't be merged until the upstream change https://github.com/cloudflare/cloudflare-go/pull/163 gets included. In the meantime, the updated code is added manually, but it should be replaced by a proper vendored version of the API client