### PR TITLE
Fixed "Example Usage" problem in "page_rule.html.markdown"

### DIFF
--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -15,7 +15,7 @@ Provides a Cloudflare page rule resource.
 ```hcl
 # Add a page rule to the domain
 resource "cloudflare_page_rule" "foobar" {
-  domain = "${var.cloudflare_domain}"
+  zone = "${var.cloudflare_domain}"
   target = "sub.${self.domain}/page"
   priority = 1
 


### PR DESCRIPTION
Fixed an issue where "zone" was incorrectly entered as "domain" in the content of "Example Usage".