### PR TITLE
Add link to geographic regions, detail on address field. 

### DIFF
--- a/website/docs/r/load_balancer_pool.html.markdown
+++ b/website/docs/r/load_balancer_pool.html.markdown
@@ -36,12 +36,12 @@ resource "cloudflare_load_balancer_pool" "foo" {
 
 The following arguments are supported:
 
-* `name` - (Required) A short name (tag) for the pool. Only alphanumeric characters, hyphens and underscores are allowed.
-* `origins` - (Required) The list of origins within this pool. Traffic directed at this pool is balanced across all currently healthy origins, provided the pool itself is healthy. Fields documented below
-* `check_regions` - (Optional) A list of regions from which to run health checks. Empty means every Cloudflare datacenter (the default).
+* `name` - (Required) A short name (tag) for the pool. Only alphanumeric characters, hyphens, and underscores are allowed.
+* `origins` - (Required) The list of origins within this pool. Traffic directed at this pool is balanced across all currently healthy origins, provided the pool itself is healthy. The name and enabled fields follow the same conventions as they do for the pool itself (defined in this section), and address can be either an IPv4 or IPv6 address.
+* `check_regions` - (Optional) A list of regions (specified by region code) from which to run health checks. Empty means every Cloudflare data center (the default), but requires an Enterprise plan. Region codes can be found [here](https://support.cloudflare.com/hc/en-us/articles/115000540888-Load-Balancing-Geographic-Regions).
 * `description` - (Optional) Free text description.
 * `enabled` - (Optional) Whether to enable (the default) this pool. Disabled pools will not receive traffic and are excluded from health checks. Disabling a pool will cause any load balancers using it to failover to the next pool (if any).
-* `minimum_origins` - (Optional) The minimum number of origins that must be healthy for this pool to serve traffic. If the number of healthy origins falls below this number, the pool will be marked unhealthy and we wil failover to the next available pool. Default: 1.
+* `minimum_origins` - (Optional) The minimum number of origins that must be healthy for this pool to serve traffic. If the number of healthy origins falls below this number, the pool will be marked unhealthy and we will failover to the next available pool. Default: 1.
 * `monitor` - (Optional) The ID of the Monitor to use for health checking origins within this pool.
 * `notification_email` - (Optional) The email address to send health status notifications to. This can be an individual mailbox or a mailing list.
 


### PR DESCRIPTION
The load balancing documentation indicates that omitting check regions is optional, but this is true only for Enterprise accounts. Make this clear.

The origin definition doesn't include detail on the address field, so this is added.

Fixed a couple typos.