### PR TITLE
IPv6 CIDR blocks should return IPv6 addresses

### DIFF
--- a/cloudflare/data_source_ip_ranges.go
+++ b/cloudflare/data_source_ip_ranges.go
@@ -70,7 +70,7 @@ func dataSourceCloudflareIPRangesRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error setting ipv4 cidr blocks: %s", err)
 	}
 
-	if err := d.Set("ipv6_cidr_blocks", ipv4s); err != nil {
+	if err := d.Set("ipv6_cidr_blocks", ipv6s); err != nil {
 		return fmt.Errorf("Error setting ipv6 cidr blocks: %s", err)
 	}
 

--- a/website/docs/d/ip_ranges.html.md
+++ b/website/docs/d/ip_ranges.html.md
@@ -1,14 +1,14 @@
 ---
 layout: "cloudflare"
-page_title: "CloudFlare: cloudflare_ip_ranges"
+page_title: "Cloudflare: cloudflare_ip_ranges"
 sidebar_current: "docs-cloudflare-datasource-ip_ranges"
 description: |-
-  Get information on CloudFlare IP ranges.
+  Get information on Cloudflare IP ranges.
 ---
 
 # cloudflare_ip_ranges
 
-Use this data source to get the [IP ranges][1] of CloudFlare edge nodes.
+Use this data source to get the [IP ranges][1] of Cloudflare edge nodes.
 
 ## Example Usage
 


### PR DESCRIPTION
Currently returning IPv4 addresses.