### PR TITLE
Page rule additions

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -92,6 +92,12 @@ func resourceCloudFlarePageRule() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 						},
 
+						"origin_error_page_pass_thru": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+						},
+
 						"server_side_exclude": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -99,6 +105,12 @@ func resourceCloudFlarePageRule() *schema.Resource {
 						},
 
 						"sort_query_string_for_cache": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+						},
+
+						"true_client_ip_header": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
@@ -432,7 +444,7 @@ func resourceCloudFlarePageRuleDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "explicit_cache_control", "ip_geolocation", "opportunistic_encryption", "server_side_exclude", "sort_query_string_for_cache", "smart_errors", "waf"}
+var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "explicit_cache_control", "ip_geolocation", "opportunistic_encryption", "origin_error_page_pass_thru", "server_side_exclude", "sort_query_string_for_cache", "smart_errors", "true_client_ip_header", "waf"}
 var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_security"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}
 var pageRuleAPIStringFields = []string{"bypass_cache_on_cookie", "cache_level", "host_header_override", "resolve_override", "rocket_loader", "security_level", "ssl", "cache_key"}

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -73,6 +73,12 @@ func resourceCloudFlarePageRule() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 						},
 
+						"explicit_cache_control": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+						},
+
 						"ip_geolocation": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -419,7 +425,7 @@ func resourceCloudFlarePageRuleDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "ip_geolocation", "opportunistic_encryption", "server_side_exclude", "smart_errors", "waf"}
+var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "explicit_cache_control", "ip_geolocation", "opportunistic_encryption", "server_side_exclude", "smart_errors", "waf"}
 var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_security"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}
 var pageRuleAPIStringFields = []string{"bypass_cache_on_cookie", "cache_level", "host_header_override", "resolve_override", "rocket_loader", "security_level", "ssl"}

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -85,6 +85,12 @@ func resourceCloudFlarePageRule() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 						},
 
+						"mirage": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+						},
+
 						// may get api errors trying to set this
 						"opportunistic_encryption": {
 							Type:         schema.TypeString,
@@ -146,6 +152,12 @@ func resourceCloudFlarePageRule() *schema.Resource {
 						},
 
 						"disable_security": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							Optional: true,
+						},
+
+						"disable_railgun": {
 							Type:     schema.TypeBool,
 							Default:  false,
 							Optional: true,
@@ -444,8 +456,8 @@ func resourceCloudFlarePageRuleDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "explicit_cache_control", "ip_geolocation", "opportunistic_encryption", "origin_error_page_pass_thru", "server_side_exclude", "sort_query_string_for_cache", "smart_errors", "true_client_ip_header", "waf"}
-var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_security"}
+var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "explicit_cache_control", "ip_geolocation", "mirage", "opportunistic_encryption", "origin_error_page_pass_thru", "server_side_exclude", "sort_query_string_for_cache", "smart_errors", "true_client_ip_header", "waf"}
+var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_security", "disable_railgun"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}
 var pageRuleAPIStringFields = []string{"bypass_cache_on_cookie", "cache_level", "host_header_override", "resolve_override", "rocket_loader", "security_level", "ssl", "cache_key"}
 

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -97,6 +97,13 @@ func resourceCloudFlarePageRule() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 						},
+
+						"sort_query_string_for_cache": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+						},
+
 						"waf": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -425,7 +432,7 @@ func resourceCloudFlarePageRuleDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "explicit_cache_control", "ip_geolocation", "opportunistic_encryption", "server_side_exclude", "smart_errors", "waf"}
+var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "explicit_cache_control", "ip_geolocation", "opportunistic_encryption", "server_side_exclude", "sort_query_string_for_cache", "smart_errors", "waf"}
 var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_security"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}
 var pageRuleAPIStringFields = []string{"bypass_cache_on_cookie", "cache_level", "host_header_override", "resolve_override", "rocket_loader", "security_level", "ssl", "cache_key"}

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -201,7 +201,7 @@ func resourceCloudFlarePageRule() *schema.Resource {
 						"security_level": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"essentially_off", "low", "medium", "high", "under_attack"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"off", "essentially_off", "low", "medium", "high", "under_attack"}, false),
 						},
 
 						"ssl": {

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -428,7 +428,7 @@ func resourceCloudFlarePageRuleDelete(d *schema.ResourceData, meta interface{}) 
 var pageRuleAPIOnOffFields = []string{"always_online", "automatic_https_rewrites", "browser_check", "email_obfuscation", "explicit_cache_control", "ip_geolocation", "opportunistic_encryption", "server_side_exclude", "smart_errors", "waf"}
 var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_security"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}
-var pageRuleAPIStringFields = []string{"bypass_cache_on_cookie", "cache_level", "host_header_override", "resolve_override", "rocket_loader", "security_level", "ssl"}
+var pageRuleAPIStringFields = []string{"bypass_cache_on_cookie", "cache_level", "host_header_override", "resolve_override", "rocket_loader", "security_level", "ssl", "cache_key"}
 
 func transformFromCloudFlarePageRuleAction(pageRuleAction *cloudflare.PageRuleAction) (key string, value interface{}, err error) {
 	key = pageRuleAction.ID

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -57,11 +57,13 @@ Action blocks support the following:
 * `cache_level` - (Optional) Whether to set the cache level to `"byypass"`, `"basic"`, `"simplified"`, `"aggressive"`, or `"cache_everything"`.
 * `forwarding_url` - (Optional) The URL to forward to, and with what status. See below.
 * `host_header_override` - (Optional) The Host Header to override on the origin servers.
+* `origin_error_page_pass_thru` - (Optional) Whether this action is `"on"` or `"off"`.
 * `resolve_override` - (Optional) Override the origin server with this host.
 * `rocket_loader` - (Optional) Whether to set the rocket loader to `"off"`, `"manual"`, or `"automatic"`.
 * `security_level` - (Optional) Whether to set the security level to `"off"`, `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
 * `sort_query_string_for_cache` - (Optional) Whether this action is `"on"` or `"off"`.
 * `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, or `"strict"`.
+* `true_client_ip_header` - (Optional) Whether this action is `"on"` or `"off"`.
 * `waf` - (Optional) Whether this action is `"on"` or `"off"`.
 
 Forwarding URL actions support the following:

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -50,6 +50,7 @@ Action blocks support the following:
 * `always_use_https` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `disable_apps` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `disable_performance` - (Optional) Boolean of whether this action is enabled. Default: false.
+* `disable_railgun` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `disable_security` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `browser_cache_ttl` - (Optional) The Time To Live for the browser cache.
 * `bypass_cache_on_cookie` - (Optional) Disable the cache on cookie regex match.
@@ -57,6 +58,7 @@ Action blocks support the following:
 * `cache_level` - (Optional) Whether to set the cache level to `"byypass"`, `"basic"`, `"simplified"`, `"aggressive"`, or `"cache_everything"`.
 * `forwarding_url` - (Optional) The URL to forward to, and with what status. See below.
 * `host_header_override` - (Optional) The Host Header to override on the origin servers.
+* `mirage` - (Optional) Whether this action is `"on"` or `"off"`.
 * `origin_error_page_pass_thru` - (Optional) Whether this action is `"on"` or `"off"`.
 * `resolve_override` - (Optional) Override the origin server with this host.
 * `rocket_loader` - (Optional) Whether to set the rocket loader to `"off"`, `"manual"`, or `"automatic"`.

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -60,6 +60,7 @@ Action blocks support the following:
 * `resolve_override` - (Optional) Override the origin server with this host.
 * `rocket_loader` - (Optional) Whether to set the rocket loader to `"off"`, `"manual"`, or `"automatic"`.
 * `security_level` - (Optional) Whether to set the security level to `"off"`, `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
+* `sort_query_string_for_cache` - (Optional) Whether this action is `"on"` or `"off"`.
 * `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, or `"strict"`.
 * `waf` - (Optional) Whether this action is `"on"` or `"off"`.
 

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -42,6 +42,7 @@ Action blocks support the following:
 * `automatic_https_rewrites` - (Optional) Whether this action is `"on"` or `"off"`.
 * `browser_check` - (Optional) Whether this action is `"on"` or `"off"`.
 * `email_obfuscation` - (Optional) Whether this action is `"on"` or `"off"`.
+* `explicit_cache_control` - (Optional) Whether this action is `"on"` or `"off"`.
 * `ip_geolocation` - (Optional) Whether this action is `"on"` or `"off"`.
 * `opportunistic_encryption` - (Optional) Whether this action is `"on"` or `"off"`.
 * `server_side_exclude` - (Optional) Whether this action is `"on"` or `"off"`.

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -59,7 +59,7 @@ Action blocks support the following:
 * `host_header_override` - (Optional) The Host Header to override on the origin servers.
 * `resolve_override` - (Optional) Override the origin server with this host.
 * `rocket_loader` - (Optional) Whether to set the rocket loader to `"off"`, `"manual"`, or `"automatic"`.
-* `security_level` - (Optional) Whether to set the security level to `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
+* `security_level` - (Optional) Whether to set the security level to `"off"`, `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
 * `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, or `"strict"`.
 * `waf` - (Optional) Whether this action is `"on"` or `"off"`.
 


### PR DESCRIPTION
This PR adds a new page rule action and adds a new value to an existing action.

It is based on unmerged upstream PR terraform-providers#61, so currently includes the changes from that PR as well.

- Adds action `explicit_cache_control action`
- Adds missing `off` value to `security_level` action

I've been using this code for the past couple of days and it's working as expected -- I can successfully enable the `explicit_cache_control` action and set `security_level` to `off` via Terraform, and see the results reflected in the Page Rules UI.

Note: I haven't written any tests because the existing test suite doesn't test each action and value. Happy to add tests that exercise the new functionality if you'd prefer.

Thanks for your consideration!
Ross