### PR TITLE
Allow zero for `browser_cache_ttl` values

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -101,10 +101,13 @@ var resourceCloudFlareZoneSettingsSchema = map[string]*schema.Schema{
 		Type:     schema.TypeInt,
 		Optional: true,
 		Computed: true,
-		ValidateFunc: validateIntInSlice([]int{30, 60, 300, 1200, 1800, 3600, 7200, 10800, 14400, 18000, 28800,
+		ValidateFunc: validateIntInSlice([]int{0, 30, 60, 300, 1200, 1800, 3600, 7200, 10800, 14400, 18000, 28800,
 			43200, 57600, 72000, 86400, 172800, 259200, 345600, 432000, 691200, 1382400, 2073600, 2678400, 5356800,
 			16070400, 31536000}),
-		// minimum TTL available depends on the plan level of the zone. (Enterprise = 30, Business = 1800, Pro = 1800, Free = 1800)
+		// minimum TTL available depends on the plan level of the zone.
+		// - Respect existing headers = 0
+		// - Enterprise = 30
+		// - Business, Pro, Free = 1800
 	},
 
 	"browser_check": {

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -8,11 +8,12 @@ import (
 
 	"time"
 
+	"reflect"
+
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/pkg/errors"
-	"reflect"
 )
 
 func resourceCloudFlareZoneSettingsOverride() *schema.Resource {


### PR DESCRIPTION
Updates the validation for `browser_cache_ttl` to accept zero as a value
since it informs the configuration to respect the existing origin cache
control directives.

Fixes #69