### PR TITLE
Add support for `min_tls_version`

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -381,6 +381,13 @@ var resourceCloudFlareZoneSettingsSchema = map[string]*schema.Schema{
 		Computed:     true,
 	},
 
+	"min_tls_version": {
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice([]string{"1.0", "1.1", "1.2", "1.3"}, false),
+		Optional:     true,
+		Computed:     true,
+	},
+
 	"tls_1_2_only": {
 		Type:         schema.TypeString,
 		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -87,6 +87,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `ssl`. Allowed values: "off", "flexible", "full", "strict".
 * `pseudo_ipv4`. Allowed values: "off", "add_header", "overwrite_header".
 * `cname_flattening`.
+* `min_tls_version`. Allowed values: "1.0", "1.1", "1.2", "1.3"
 
 ### Integer Values
 


### PR DESCRIPTION
Updates the crypto settings to accept `min_tls_version` and it's
associated values.

See https://api.cloudflare.com/#zone-settings-get-minimum-tls-version-setting