### PR TITLE
Update cloudflare-go library to latest upstream version

### DIFF
--- a/vendor/github.com/cloudflare/cloudflare-go/README.md
+++ b/vendor/github.com/cloudflare/cloudflare-go/README.md
@@ -25,22 +25,22 @@ this project.
 
 The current feature list includes:
 
-* [x] DNS Records
-* [x] Zones
-* [x] Web Application Firewall (WAF)
+* [x] Cache purging
 * [x] Cloudflare IPs
+* [x] Custom hostnames
+* [x] DNS Records
+* [x] Firewall (partial)
+* [ ] [Keyless SSL](https://blog.cloudflare.com/keyless-ssl-the-nitty-gritty-technical-details/)
+* [x] [Load Balancing](https://blog.cloudflare.com/introducing-load-balancing-intelligent-failover-with-cloudflare/)
+* [ ] Organization Administration
+* [x] [Origin CA](https://blog.cloudflare.com/universal-ssl-encryption-all-the-way-to-the-origin-for-free/)
+* [x] [Railgun](https://www.cloudflare.com/railgun/) administration
+* [x] Rate Limiting
 * [x] User Administration (partial)
 * [x] Virtual DNS Management
-* [x] Custom hostnames
+* [x] Web Application Firewall (WAF)
 * [x] Zone Lockdown and User-Agent Block rules
-* [x] Cache purging
-* [ ] Organization Administration
-* [x] [Railgun](https://www.cloudflare.com/railgun/) administration
-* [ ] [Keyless SSL](https://blog.cloudflare.com/keyless-ssl-the-nitty-gritty-technical-details/)
-* [x] [Origin CA](https://blog.cloudflare.com/universal-ssl-encryption-all-the-way-to-the-origin-for-free/)
-* [x] [Load Balancing](https://blog.cloudflare.com/introducing-load-balancing-intelligent-failover-with-cloudflare/)
-* [x] Firewall (partial)
-* [x] Rate Limiting
+* [x] Zones
 
 Pull Requests are welcome, but please open an issue (or comment in an existing
 issue) to discuss any non-trivial changes before submitting code.

--- a/vendor/github.com/cloudflare/cloudflare-go/cloudflare.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/cloudflare.go
@@ -236,7 +236,7 @@ func (api *API) request(method, uri string, reqBody io.Reader, authType int) (*h
 // parameter because it is not consistent across APIs.
 func (api *API) userBaseURL(accountBase string) string {
 	if api.organizationID != "" {
-		return "/organizations/" + api.organizationID
+		return "/accounts/" + api.organizationID
 	}
 	return accountBase
 }

--- a/vendor/github.com/cloudflare/cloudflare-go/custom_hostname.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/custom_hostname.go
@@ -28,7 +28,7 @@ type CustomHostname struct {
 	CustomMetadata CustomMetadata    `json:"custom_metadata,omitempty"`
 }
 
-// CustomHostNameResponse represents a response from the Custom Hostnames endpoints.
+// CustomHostnameResponse represents a response from the Custom Hostnames endpoints.
 type CustomHostnameResponse struct {
 	Result CustomHostname `json:"result"`
 	Response
@@ -41,14 +41,16 @@ type CustomHostnameListResponse struct {
 	ResultInfo `json:"result_info"`
 }
 
-// Modify SSL configuration for the given custom hostname in the given zone.
+// UpdateCustomHostnameSSL modifies SSL configuration for the given custom
+// hostname in the given zone.
 //
 // API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-update-custom-hostname-configuration
 func (api *API) UpdateCustomHostnameSSL(zoneID string, customHostnameID string, ssl CustomHostnameSSL) (CustomHostname, error) {
 	return CustomHostname{}, errors.New("Not implemented")
 }
 
-// Delete a custom hostname (and any issued SSL certificates)
+// DeleteCustomHostname deletes a custom hostname (and any issued SSL
+// certificates).
 //
 // API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-delete-a-custom-hostname-and-any-issued-ssl-certificates-
 func (api *API) DeleteCustomHostname(zoneID string, customHostnameID string) error {

--- a/vendor/github.com/cloudflare/cloudflare-go/firewall.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/firewall.go
@@ -125,7 +125,7 @@ func (api *API) DeleteZoneAccessRule(zoneID, accessRuleID string) (*AccessRuleRe
 //
 // API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-list-access-rules
 func (api *API) ListOrganizationAccessRules(organizationID string, accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
-	return api.listAccessRules("/organizations/"+organizationID, accessRule, page)
+	return api.listAccessRules("/accounts/"+organizationID, accessRule, page)
 }
 
 // CreateOrganizationAccessRule creates a firewall access rule for the given
@@ -133,7 +133,7 @@ func (api *API) ListOrganizationAccessRules(organizationID string, accessRule Ac
 //
 // API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-create-access-rule
 func (api *API) CreateOrganizationAccessRule(organizationID string, accessRule AccessRule) (*AccessRuleResponse, error) {
-	return api.createAccessRule("/organizations/"+organizationID, accessRule)
+	return api.createAccessRule("/accounts/"+organizationID, accessRule)
 }
 
 // UpdateOrganizationAccessRule updates a single access rule for the given
@@ -141,7 +141,7 @@ func (api *API) CreateOrganizationAccessRule(organizationID string, accessRule A
 //
 // API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-update-access-rule
 func (api *API) UpdateOrganizationAccessRule(organizationID, accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
-	return api.updateAccessRule("/organizations/"+organizationID, accessRuleID, accessRule)
+	return api.updateAccessRule("/accounts/"+organizationID, accessRuleID, accessRule)
 }
 
 // DeleteOrganizationAccessRule deletes a single access rule for the given
@@ -149,7 +149,7 @@ func (api *API) UpdateOrganizationAccessRule(organizationID, accessRuleID string
 //
 // API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-delete-access-rule
 func (api *API) DeleteOrganizationAccessRule(organizationID, accessRuleID string) (*AccessRuleResponse, error) {
-	return api.deleteAccessRule("/organizations/"+organizationID, accessRuleID)
+	return api.deleteAccessRule("/accounts/"+organizationID, accessRuleID)
 }
 
 func (api *API) listAccessRules(prefix string, accessRule AccessRule, page int) (*AccessRuleListResponse, error) {

--- a/vendor/github.com/cloudflare/cloudflare-go/load_balancing.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/load_balancing.go
@@ -25,10 +25,12 @@ type LoadBalancerPool struct {
 	CheckRegions []string `json:"check_regions"`
 }
 
+// LoadBalancerOrigin represents a Load Balancer origin's properties.
 type LoadBalancerOrigin struct {
-	Name    string `json:"name"`
-	Address string `json:"address"`
-	Enabled bool   `json:"enabled"`
+	Name    string  `json:"name"`
+	Address string  `json:"address"`
+	Enabled bool    `json:"enabled"`
+	Weight  float64 `json:"weight"`
 }
 
 // LoadBalancerMonitor represents a load balancer monitor's properties.
@@ -61,6 +63,7 @@ type LoadBalancer struct {
 	RegionPools  map[string][]string `json:"region_pools"`
 	PopPools     map[string][]string `json:"pop_pools"`
 	Proxied      bool                `json:"proxied"`
+	Persistence  string              `json:"session_affinity,omitempty"`
 }
 
 // loadBalancerPoolResponse represents the response from the load balancer pool endpoints.

--- a/vendor/github.com/cloudflare/cloudflare-go/options.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/options.go
@@ -28,8 +28,8 @@ func Headers(headers http.Header) Option {
 	}
 }
 
-// Organization allows you to apply account-level changes (Load Balancing, Railguns)
-// to an organization instead.
+// UsingOrganization allows you to apply account-level changes (Load Balancing,
+// Railguns) to an organization instead.
 func UsingOrganization(orgID string) Option {
 	return func(api *API) error {
 		api.organizationID = orgID

--- a/vendor/github.com/cloudflare/cloudflare-go/organizations.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/organizations.go
@@ -139,7 +139,8 @@ type organizationInvitesResponse struct {
 	ResultInfo `json:"result_info"`
 }
 
-// OrganizationMembers returns list of invites for specified organization of the logged-in user.
+// OrganizationInvites returns list of invites for specified organization of
+// the logged-in user.
 //
 // API reference: https://api.cloudflare.com/#organization-invites
 func (api *API) OrganizationInvites(organizationID string) ([]OrganizationInvite, ResultInfo, error) {

--- a/vendor/github.com/cloudflare/cloudflare-go/zone.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/zone.go
@@ -132,7 +132,8 @@ type ZoneSSLSetting struct {
 	CertificateStatus string `json:"certificate_status"`
 }
 
-// ZoneSettingResponse represents the response from the Zone SSL Setting endpoint.
+// ZoneSSLSettingResponse represents the response from the Zone SSL Setting
+// endpoint.
 type ZoneSSLSettingResponse struct {
 	Response
 	Result ZoneSSLSetting `json:"result"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -227,10 +227,10 @@
 			"revisionTime": "2017-07-27T06:48:18Z"
 		},
 		{
-			"checksumSHA1": "mDCKeVKLfjNsKNhPhBnxDPGPeVE=",
+			"checksumSHA1": "+bWvugaO1atwUqXsfeHAZBKrWhI=",
 			"path": "github.com/cloudflare/cloudflare-go",
-			"revision": "e1f3c4226ea9280f7177f0bf4a8bb2f750466b12",
-			"revisionTime": "2018-03-28T15:27:59Z"
+			"revision": "a2bb67156ba6cf0c380761ce404875c9e265b9a7",
+			"revisionTime": "2018-06-27T14:11:45Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",


### PR DESCRIPTION
Update upstream `cloudflare-go` with changes related to account API endpoints.
See: cloudflare/cloudflare-go#197

Fixes #74.