### PR TITLE
Fix incorrect code example

### DIFF
--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -15,7 +15,7 @@ Provides a Cloudflare page rule resource.
 ```hcl
 # Add a page rule to the domain
 resource "cloudflare_page_rule" "foobar" {
-  domain = "${var.cloudflare_domain}"
+  zone = "${var.cloudflare_domain}"
   target = "sub.${self.domain}/page"
   priority = 1
 


### PR DESCRIPTION
As mentioned in the argument reference below the code example (and as I experienced when using it), `domain` should be `zone`.