### PR TITLE
forwarding_urls in page rules are lists

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -422,7 +422,7 @@ func transformFromCloudFlarePageRuleAction(pageRuleAction *cloudflare.PageRuleAc
 		break
 
 	case pageRuleAction.ID == "forwarding_url":
-		value = pageRuleAction.Value.(map[string]interface{})
+		value = []interface{}{pageRuleAction.Value.(map[string]interface{})}
 		break
 
 	default:


### PR DESCRIPTION
Currently when importing a page rule with a forwarding_url, the following error is given.

        2018-07-03T14:43:23.366-0700 [DEBUG] plugin.terraform-provider-cloudflare_v1.0.0_x4: 2018/07/03 14:43:23 [WARN] Error setting actions in page rule "XXXXXXXXXXXXXX": actions.0.forwarding_url: '': source data must be an array or slice, got map

This fixes that. forwarding_url is defined as a list and there needs to be set to a list.