### PR TITLE
Page rule additions v2

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -199,6 +199,12 @@ func resourceCloudFlarePageRule() *schema.Resource {
 							Optional: true,
 						},
 
+						"disable_railgun": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							Optional: true,
+						},
+
 						"disable_security": {
 							Type:     schema.TypeBool,
 							Default:  false,
@@ -502,7 +508,7 @@ var pageRuleAPIOnOffFields = []string{
 	"sort_query_string_for_cache",
 	"true_client_ip_header",
 }
-var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_security"}
+var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_railgun", "disable_security"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}
 var pageRuleAPIStringFields = []string{"cache_level", "rocket_loader", "security_level", "ssl"}
 

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -91,6 +91,12 @@ func resourceCloudFlarePageRule() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 						},
 
+						"mirage": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+						},
+
 						"polish": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -485,6 +491,7 @@ var pageRuleAPIOnOffFields = []string{
 	"explicit_cache_control",
 	"host_header_override",
 	"ip_geolocation",
+	"mirage",
 	"opportunistic_encryption",
 	"origin_error_page_pass_thru",
 	"polish",

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -510,7 +510,7 @@ var pageRuleAPIOnOffFields = []string{
 }
 var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_railgun", "disable_security"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}
-var pageRuleAPIStringFields = []string{"cache_level", "rocket_loader", "security_level", "ssl"}
+var pageRuleAPIStringFields = []string{"cache_key", "cache_level", "rocket_loader", "security_level", "ssl"}
 
 func transformFromCloudFlarePageRuleAction(pageRuleAction *cloudflare.PageRuleAction) (key string, value interface{}, err error) {
 	key = pageRuleAction.ID

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -261,7 +261,7 @@ func resourceCloudFlarePageRule() *schema.Resource {
 						"security_level": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"essentially_off", "low", "medium", "high", "under_attack"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"off", "essentially_off", "low", "medium", "high", "under_attack"}, false),
 						},
 
 						"ssl": {

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -57,7 +57,7 @@ Action blocks support the following:
 * `cache_level` - (Optional) Whether to set the cache level to `"byypass"`, `"basic"`, `"simplified"`, `"aggressive"`, or `"cache_everything"`.
 * `forwarding_url` - (Optional) The URL to forward to, and with what status. See below.
 * `rocket_loader` - (Optional) Whether to set the rocket loader to `"off"`, `"manual"`, or `"automatic"`.
-* `security_level` - (Optional) Whether to set the security level to `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
+* `security_level` - (Optional) Whether to set the security level to `"off"`, `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
 * `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, or `"strict"`.
 
 Forwarding URL actions support the following:

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -43,6 +43,7 @@ Action blocks support the following:
 * `browser_check` - (Optional) Whether this action is `"on"` or `"off"`.
 * `email_obfuscation` - (Optional) Whether this action is `"on"` or `"off"`.
 * `ip_geolocation` - (Optional) Whether this action is `"on"` or `"off"`.
+* `mirage` - (Optional) Whether this action is `"on"` or `"off"`.
 * `opportunistic_encryption` - (Optional) Whether this action is `"on"` or `"off"`.
 * `server_side_exclude` - (Optional) Whether this action is `"on"` or `"off"`.
 * `smart_errors` - (Optional) Whether this action is `"on"` or `"off"`.

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -50,6 +50,7 @@ Action blocks support the following:
 * `always_use_https` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `disable_apps` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `disable_performance` - (Optional) Boolean of whether this action is enabled. Default: false.
+* `disable_railgun` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `disable_security` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `browser_cache_ttl` - (Optional) The Time To Live for the browser cache.
 * `edge_cache_ttl` - (Optional) The Time To Live for the edge cache.


### PR DESCRIPTION
This is take 2 of https://github.com/terraform-providers/terraform-provider-cloudflare/pull/68; that PR was in turn based off https://github.com/terraform-providers/terraform-provider-cloudflare/pull/61 and contained too many changes (some of which have since been merged).

It adds the following:
- `mirage` action
- `disable_railgun` action
- `off` value for `security_level` action
- `cache_key` string field

Note: I haven't written any tests because the existing test suite doesn't test each action and value. Happy to add tests that exercise the new functionality if you'd prefer.

Thanks for your consideration!
Ross