### PR TITLE
Fix resolve override and host header override

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -85,12 +85,6 @@ func resourceCloudFlarePageRule() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 						},
 
-						"host_header_override": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
-						},
-
 						"mirage": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -116,12 +110,6 @@ func resourceCloudFlarePageRule() *schema.Resource {
 						},
 
 						"sort_query_string_for_cache": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
-						},
-
-						"resolve_override": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
@@ -249,6 +237,16 @@ func resourceCloudFlarePageRule() *schema.Resource {
 									},
 								},
 							},
+						},
+
+						"host_header_override": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"resolve_override": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						// may not be used with disable_performance
@@ -495,13 +493,11 @@ var pageRuleAPIOnOffFields = []string{
 	"cache_on_cookie",
 	"email_obfuscation",
 	"explicit_cache_control",
-	"host_header_override",
 	"ip_geolocation",
 	"mirage",
 	"opportunistic_encryption",
 	"origin_error_page_pass_thru",
 	"polish",
-	"resolve_override",
 	"respect_strong_etag",
 	"response_buffering",
 	"server_side_exclude",
@@ -510,7 +506,14 @@ var pageRuleAPIOnOffFields = []string{
 }
 var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_railgun", "disable_security"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}
-var pageRuleAPIStringFields = []string{"cache_key", "cache_level", "rocket_loader", "security_level", "ssl"}
+var pageRuleAPIStringFields = []string{
+	"cache_key",
+	"cache_level",
+	"host_header_override",
+	"rocket_loader",
+	"resolve_override",
+	"security_level",
+	"ssl"}
 
 func transformFromCloudFlarePageRuleAction(pageRuleAction *cloudflare.PageRuleAction) (key string, value interface{}, err error) {
 	key = pageRuleAction.ID

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -513,7 +513,8 @@ var pageRuleAPIStringFields = []string{
 	"rocket_loader",
 	"resolve_override",
 	"security_level",
-	"ssl"}
+	"ssl",
+}
 
 func transformFromCloudFlarePageRuleAction(pageRuleAction *cloudflare.PageRuleAction) (key string, value interface{}, err error) {
 	key = pageRuleAction.ID

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -56,6 +56,8 @@ Action blocks support the following:
 * `edge_cache_ttl` - (Optional) The Time To Live for the edge cache.
 * `cache_level` - (Optional) Whether to set the cache level to `"byypass"`, `"basic"`, `"simplified"`, `"aggressive"`, or `"cache_everything"`.
 * `forwarding_url` - (Optional) The URL to forward to, and with what status. See below.
+* `host_header_override` - (Optional) Value of the Host header to send.
+* `resolve_override` - (Optional) Overridden origin server name.
 * `rocket_loader` - (Optional) Whether to set the rocket loader to `"off"`, `"manual"`, or `"automatic"`.
 * `security_level` - (Optional) Whether to set the security level to `"off"`, `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
 * `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, or `"strict"`.


### PR DESCRIPTION
`host_header_override` and `resolve_override` should both take a plain
text string value, but they're currently treated as OnOff fields.

This PR moves them both to plain string fields with no validation
(there's no suitable validation function for a plain text string).

It also adds them to the docs.

This fixes https://github.com/terraform-providers/terraform-provider-cloudflare/issues/82.