### PR TITLE
Change status value from paused to disabled

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -283,7 +283,7 @@ func resourceCloudFlarePageRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Default:      "active",
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"active", "paused"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"active", "disabled"}, false),
 			},
 		},
 	}

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `target` - (Required) The URL pattern to target with the page rule.
 * `actions` - (Required) The actions taken by the page rule, options given below.
 * `priority` - (Optional) The priority of the page rule among others for this target.
-* `status` - (Optional) Whether the page rule is active or paused.
+* `status` - (Optional) Whether the page rule is active or disabled.
 
 Action blocks support the following:
 
@@ -74,4 +74,4 @@ The following attributes are exported:
 * `target` - The URL pattern targeted by the page rule.
 * `actions` - The actions applied by the page rule.
 * `priority` - The priority of the page rule.
-* `status` - Whether the page rule is active or paused.
+* `status` - Whether the page rule is active or disabled.


### PR DESCRIPTION
The API supports `active` and `disabled`, not `paused`.

Change code and docs to support `disabled` instead.

Fixes https://github.com/terraform-providers/terraform-provider-cloudflare/issues/60.
Supersedes part of https://github.com/terraform-providers/terraform-provider-cloudflare/pull/61.