### PR TITLE
Add missing waf action

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -163,6 +163,12 @@ func resourceCloudFlarePageRule() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 						},
+
+						"waf": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+						},
 						// end on/off fields
 
 						// unitary fields
@@ -503,6 +509,7 @@ var pageRuleAPIOnOffFields = []string{
 	"server_side_exclude",
 	"sort_query_string_for_cache",
 	"true_client_ip_header",
+	"waf",
 }
 var pageRuleAPINilFields = []string{"always_use_https", "disable_apps", "disable_performance", "disable_railgun", "disable_security"}
 var pageRuleAPIFloatFields = []string{"browser_cache_ttl", "edge_cache_ttl"}

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -61,6 +61,7 @@ Action blocks support the following:
 * `rocket_loader` - (Optional) Whether to set the rocket loader to `"off"`, `"manual"`, or `"automatic"`.
 * `security_level` - (Optional) Whether to set the security level to `"off"`, `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
 * `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, or `"strict"`.
+* `waf` - (Optional) Whether this action is `"on"` or `"off"`.
 
 Forwarding URL actions support the following:
 


### PR DESCRIPTION
`waf` is an OnOff value.

Also added to the docs.

This PR, along with https://github.com/terraform-providers/terraform-provider-cloudflare/pull/76 and https://github.com/terraform-providers/terraform-provider-cloudflare/pull/83, together supersede everything that's in https://github.com/terraform-providers/terraform-provider-cloudflare/pull/61.