### PR TITLE
Update ip_ranges example

### DIFF
--- a/website/docs/d/ip_ranges.html.md
+++ b/website/docs/d/ip_ranges.html.md
@@ -16,13 +16,14 @@ Use this data source to get the [IP ranges][1] of Cloudflare edge nodes.
 data "cloudflare_ip_ranges" "cloudflare" {}
 
 resource "google_compute_firewall" "allow_cloudflare_ingress" {
-  name    = "from_cloudflare"
+  name    = "from-cloudflare"
   network = "default"
 
-  ingress {
-    ports         = "443"
-    protocol      = "tcp"
-    source_ranges = ["${data.cloudflare_ip_ranges.cloudflare.cidr_blocks}"]
+  source_ranges = ["${data.cloudflare_ip_ranges.cloudflare.ipv4_cidr_blocks}"]
+  
+  allow {
+    ports    = "443"
+    protocol = "tcp"
   }
 }
 ```


### PR DESCRIPTION
Google Compute Firewall currently supports only IPV4 addresses, and using current example produces an error:

* google_compute_firewall.allow_cloudflare_ingress: Error creating firewall: googleapi: Error 400: Invalid value for field 'resource.sourceRanges[0]': '2405:b500::/32'. Must be a valid IPV4 CIDR address range.

So, moving from cidr_blocks to ipv4_cidr_blocks. Also, updating google_compute_firewall syntax to the actual one.