### PR TITLE
bypass_cache_on_cookie is not limited to on/off

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -64,7 +64,6 @@ func resourceCloudFlarePageRule() *schema.Resource {
 						"bypass_cache_on_cookie": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 						},
 
 						"cache_by_device_type": {
@@ -493,7 +492,6 @@ var pageRuleAPIOnOffFields = []string{
 	"always_online",
 	"automatic_https_rewrites",
 	"browser_check",
-	"bypass_cache_on_cookie",
 	"cache_by_device_type",
 	"cache_deception_armor",
 	"cache_on_cookie",
@@ -521,6 +519,7 @@ var pageRuleAPIStringFields = []string{
 	"resolve_override",
 	"security_level",
 	"ssl",
+	"bypass_cache_on_cookie",
 }
 
 func transformFromCloudFlarePageRuleAction(pageRuleAction *cloudflare.PageRuleAction) (key string, value interface{}, err error) {

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -62,8 +62,8 @@ func resourceCloudFlarePageRule() *schema.Resource {
 						},
 
 						"bypass_cache_on_cookie": {
-							Type:         schema.TypeString,
-							Optional:     true,
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						"cache_by_device_type": {


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-cloudflare/commit/1d787b2c49f8b7c1e5910f09450a41a10c77b2b8#diff-f1bba0bb24bfe33e56d7c9f834a25c82R64

Added `bypass_cache_on_cookie` in the above commit but that field is not limited to on/off values. It should be a freeform string. Can't find CF API documentation on this field but in the UI it is a text field and no on/off toggle.