### PR TITLE
Update usages of CloudFlare to Cloudflare

### DIFF
--- a/cloudflare/config.go
+++ b/cloudflare/config.go
@@ -17,8 +17,8 @@ type Config struct {
 func (c *Config) Client() (*cloudflare.API, error) {
 	client, err := cloudflare.New(c.Token, c.Email, c.Options...)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating new CloudFlare client: %s", err)
+		return nil, fmt.Errorf("Error creating new Cloudflare client: %s", err)
 	}
-	log.Printf("[INFO] CloudFlare Client configured for user: %s", c.Email)
+	log.Printf("[INFO] Cloudflare Client configured for user: %s", c.Email)
 	return client, nil
 }

--- a/cloudflare/import_cloudflare_load_balancer_monitor_test.go
+++ b/cloudflare/import_cloudflare_load_balancer_monitor_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccCloudFlareLoadBalancerMonitor_Import(t *testing.T) {
+func TestAccCloudflareLoadBalancerMonitor_Import(t *testing.T) {
 	t.Parallel()
 	name := "cloudflare_load_balancer_monitor.test"
 
@@ -15,7 +15,7 @@ func TestAccCloudFlareLoadBalancerMonitor_Import(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Config: testAccCheckCloudflareLoadBalancerMonitorConfigBasic(),
 			},
 			{
 				ResourceName:      name,

--- a/cloudflare/import_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/import_cloudflare_load_balancer_pool_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccCloudFlareLoadBalancerPool_Import(t *testing.T) {
+func TestAccCloudflareLoadBalancerPool_Import(t *testing.T) {
 	t.Parallel()
 	var loadBalancerPool cloudflare.LoadBalancerPool
 	rnd := acctest.RandString(10)
@@ -19,9 +19,9 @@ func TestAccCloudFlareLoadBalancerPool_Import(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
 				),
 			},
 			{
@@ -29,7 +29,7 @@ func TestAccCloudFlareLoadBalancerPool_Import(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
 				),
 			},
 		},

--- a/cloudflare/import_cloudflare_load_balancer_test.go
+++ b/cloudflare/import_cloudflare_load_balancer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccCloudFlareLoadBalancer_Import(t *testing.T) {
+func TestAccCloudflareLoadBalancer_Import(t *testing.T) {
 	t.Parallel()
 	var loadBalancer cloudflare.LoadBalancer
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -23,10 +23,10 @@ func TestAccCloudFlareLoadBalancer_Import(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Config: testAccCheckCloudflareLoadBalancerConfigBasic(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
-					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zone),
 				),
 			},
 			{
@@ -35,8 +35,8 @@ func TestAccCloudFlareLoadBalancer_Import(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
-					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zone),
 				),
 			},
 		},

--- a/cloudflare/import_cloudflare_page_rule_test.go
+++ b/cloudflare/import_cloudflare_page_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccCloudFlarePageRule_Import(t *testing.T) {
+func TestAccCloudflarePageRule_Import(t *testing.T) {
 	t.Parallel()
 	var pageRule cloudflare.PageRule
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -20,12 +20,12 @@ func TestAccCloudFlarePageRule_Import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlarePageRuleDestroy,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigFullySpecified(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigFullySpecified(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists(name, &pageRule),
+					testAccCheckCloudflarePageRuleExists(name, &pageRule),
 				),
 			},
 			{
@@ -34,7 +34,7 @@ func TestAccCloudFlarePageRule_Import(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists(name, &pageRule),
+					testAccCheckCloudflarePageRuleExists(name, &pageRule),
 				),
 			},
 		},

--- a/cloudflare/import_cloudflare_rate_limit_test.go
+++ b/cloudflare/import_cloudflare_rate_limit_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccCloudFlareRateLimit_Import(t *testing.T) {
+func TestAccCloudflareRateLimit_Import(t *testing.T) {
 	t.Parallel()
 	var rateLimit cloudflare.RateLimit
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -23,10 +23,10 @@ func TestAccCloudFlareRateLimit_Import(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRateLimitConfigMatchingUrl(zone, rnd),
+				Config: testAccCheckCloudflareRateLimitConfigMatchingUrl(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRateLimitExists(name, &rateLimit),
-					testAccCheckCloudFlareRateLimitIDIsValid(name, zone),
+					testAccCheckCloudflareRateLimitExists(name, &rateLimit),
+					testAccCheckCloudflareRateLimitIDIsValid(name, zone),
 				),
 			},
 			{
@@ -35,8 +35,8 @@ func TestAccCloudFlareRateLimit_Import(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRateLimitExists(name, &rateLimit),
-					testAccCheckCloudFlareRateLimitIDIsValid(name, zone),
+					testAccCheckCloudflareRateLimitExists(name, &rateLimit),
+					testAccCheckCloudflareRateLimitIDIsValid(name, zone),
 				),
 			},
 		},

--- a/cloudflare/import_resource_cloudflare_record_test.go
+++ b/cloudflare/import_resource_cloudflare_record_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccCloudFlareRecord_Import(t *testing.T) {
+func TestAccCloudflareRecord_Import(t *testing.T) {
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	name := "cloudflare_record.foobar"
 
@@ -17,7 +17,7 @@ func TestAccCloudFlareRecord_Import(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigBasic(zone, name),
+				Config: testAccCheckCloudflareRecordConfigBasic(zone, name),
 			},
 			{
 				ResourceName:        name,

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -18,7 +18,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_EMAIL", nil),
-				Description: "A registered CloudFlare email address.",
+				Description: "A registered Cloudflare email address.",
 			},
 
 			"token": &schema.Schema{
@@ -83,13 +83,13 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"cloudflare_load_balancer_monitor":  resourceCloudFlareLoadBalancerMonitor(),
-			"cloudflare_page_rule":              resourceCloudFlarePageRule(),
-			"cloudflare_record":                 resourceCloudFlareRecord(),
-			"cloudflare_rate_limit":             resourceCloudFlareRateLimit(),
-			"cloudflare_load_balancer":          resourceCloudFlareLoadBalancer(),
-			"cloudflare_load_balancer_pool":     resourceCloudFlareLoadBalancerPool(),
-			"cloudflare_zone_settings_override": resourceCloudFlareZoneSettingsOverride(),
+			"cloudflare_load_balancer_monitor":  resourceCloudflareLoadBalancerMonitor(),
+			"cloudflare_page_rule":              resourceCloudflarePageRule(),
+			"cloudflare_record":                 resourceCloudflareRecord(),
+			"cloudflare_rate_limit":             resourceCloudflareRateLimit(),
+			"cloudflare_load_balancer":          resourceCloudflareLoadBalancer(),
+			"cloudflare_load_balancer_pool":     resourceCloudflareLoadBalancerPool(),
+			"cloudflare_zone_settings_override": resourceCloudflareZoneSettingsOverride(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -116,7 +116,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	if orgId, ok := d.GetOk("org_id"); ok {
-		log.Printf("[INFO] Using specified organization id %s in CloudFlare provider", orgId.(string))
+		log.Printf("[INFO] Using specified organization id %s in Cloudflare provider", orgId.(string))
 		options = append(options, cloudflare.UsingOrganization(orgId.(string)))
 	} else if zoneName, ok := d.GetOk("use_org_from_zone"); ok {
 		zoneId, err := client.ZoneIDByName(zoneName.(string))
@@ -142,10 +142,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 
 		if contains(orgIds, zone.Owner.ID) {
-			log.Printf("[INFO] Using organization %#v in CloudFlare provider", zone.Owner)
+			log.Printf("[INFO] Using organization %#v in Cloudflare provider", zone.Owner)
 			options = append(options, cloudflare.UsingOrganization(zone.Owner.ID))
 		} else {
-			log.Printf("[INFO] Zone ownership specified but organization owner not found. Falling back to using user API for CloudFlare provider")
+			log.Printf("[INFO] Zone ownership specified but organization owner not found. Falling back to using user API for Cloudflare provider")
 		}
 	} else {
 		return client, err

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -13,14 +13,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func resourceCloudFlareLoadBalancer() *schema.Resource {
+func resourceCloudflareLoadBalancer() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudFlareLoadBalancerCreate,
-		Read:   resourceCloudFlareLoadBalancerRead,
-		Update: resourceCloudFlareLoadBalancerUpdate,
-		Delete: resourceCloudFlareLoadBalancerDelete,
+		Create: resourceCloudflareLoadBalancerCreate,
+		Read:   resourceCloudflareLoadBalancerRead,
+		Update: resourceCloudflareLoadBalancerUpdate,
+		Delete: resourceCloudflareLoadBalancerDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudFlareLoadBalancerImport,
+			State: resourceCloudflareLoadBalancerImport,
 		},
 
 		SchemaVersion: 0,
@@ -148,7 +148,7 @@ var localPoolElems = map[string]*schema.Resource{
 	"region": regionPoolElem,
 }
 
-func resourceCloudFlareLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	newLoadBalancer := cloudflare.LoadBalancer{
@@ -190,7 +190,7 @@ func resourceCloudFlareLoadBalancerCreate(d *schema.ResourceData, meta interface
 	}
 	d.Set("zone_id", zoneId)
 
-	log.Printf("[INFO] Creating CloudFlare Load Balancer from struct: %+v", newLoadBalancer)
+	log.Printf("[INFO] Creating Cloudflare Load Balancer from struct: %+v", newLoadBalancer)
 
 	r, err := client.CreateLoadBalancer(zoneId, newLoadBalancer)
 	if err != nil {
@@ -203,12 +203,12 @@ func resourceCloudFlareLoadBalancerCreate(d *schema.ResourceData, meta interface
 
 	d.SetId(r.ID)
 
-	log.Printf("[INFO] CloudFlare Load Balancer ID: %s", d.Id())
+	log.Printf("[INFO] Cloudflare Load Balancer ID: %s", d.Id())
 
-	return resourceCloudFlareLoadBalancerRead(d, meta)
+	return resourceCloudflareLoadBalancerRead(d, meta)
 }
 
-func resourceCloudFlareLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error {
 	// since api only supports replace, update looks a lot like create...
 	client := meta.(*cloudflare.API)
 	zoneId := d.Get("zone_id").(string)
@@ -242,14 +242,14 @@ func resourceCloudFlareLoadBalancerUpdate(d *schema.ResourceData, meta interface
 		loadBalancer.PopPools = expandedPopPools
 	}
 
-	log.Printf("[INFO] Updating CloudFlare Load Balancer from struct: %+v", loadBalancer)
+	log.Printf("[INFO] Updating Cloudflare Load Balancer from struct: %+v", loadBalancer)
 
 	_, err := client.ModifyLoadBalancer(zoneId, loadBalancer)
 	if err != nil {
 		return errors.Wrap(err, "error creating load balancer for zone")
 	}
 
-	return resourceCloudFlareLoadBalancerRead(d, meta)
+	return resourceCloudflareLoadBalancerRead(d, meta)
 }
 
 func expandGeoPools(pool interface{}, geoType string) (map[string][]string, error) {
@@ -268,7 +268,7 @@ func expandGeoPools(pool interface{}, geoType string) (map[string][]string, erro
 	return expanded, nil
 }
 
-func resourceCloudFlareLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneId := d.Get("zone_id").(string)
 	loadBalancerId := d.Id()
@@ -319,22 +319,22 @@ func flattenGeoPools(pools map[string][]string, geoType string) *schema.Set {
 	return schema.NewSet(schema.HashResource(localPoolElems[geoType]), flattened)
 }
 
-func resourceCloudFlareLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneId := d.Get("zone_id").(string)
 	loadBalancerId := d.Id()
 
-	log.Printf("[INFO] Deleting CloudFlare Load Balancer: %s in zone: %s", loadBalancerId, zoneId)
+	log.Printf("[INFO] Deleting Cloudflare Load Balancer: %s in zone: %s", loadBalancerId, zoneId)
 
 	err := client.DeleteLoadBalancer(zoneId, loadBalancerId)
 	if err != nil {
-		return fmt.Errorf("error deleting CloudFlare Load Balancer: %s", err)
+		return fmt.Errorf("error deleting Cloudflare Load Balancer: %s", err)
 	}
 
 	return nil
 }
 
-func resourceCloudFlareLoadBalancerImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareLoadBalancerImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 
 	// split the id so we can lookup

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -13,12 +13,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func resourceCloudFlareLoadBalancerMonitor() *schema.Resource {
+func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudFlareLoadBalancerPoolMonitorCreate,
-		Read:   resourceCloudFlareLoadBalancerPoolMonitorRead,
-		Update: resourceCloudFlareLoadBalancerPoolMonitorUpdate,
-		Delete: resourceCloudFlareLoadBalancerPoolMonitorDelete,
+		Create: resourceCloudflareLoadBalancerPoolMonitorCreate,
+		Read:   resourceCloudflareLoadBalancerPoolMonitorRead,
+		Update: resourceCloudflareLoadBalancerPoolMonitorUpdate,
+		Delete: resourceCloudflareLoadBalancerPoolMonitorDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -115,7 +115,7 @@ func resourceCloudFlareLoadBalancerMonitor() *schema.Resource {
 	}
 }
 
-func resourceCloudFlareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerMonitor := cloudflare.LoadBalancerMonitor{
@@ -137,7 +137,7 @@ func resourceCloudFlareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 		loadBalancerMonitor.Description = description.(string)
 	}
 
-	log.Printf("[DEBUG] Creating CloudFlare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
+	log.Printf("[DEBUG] Creating Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	r, err := client.CreateLoadBalancerMonitor(loadBalancerMonitor)
 	if err != nil {
@@ -150,12 +150,12 @@ func resourceCloudFlareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 
 	d.SetId(r.ID)
 
-	log.Printf("[INFO] New CloudFlare Load Balancer Monitor created with  ID: %s", d.Id())
+	log.Printf("[INFO] New Cloudflare Load Balancer Monitor created with  ID: %s", d.Id())
 
-	return resourceCloudFlareLoadBalancerPoolMonitorRead(d, meta)
+	return resourceCloudflareLoadBalancerPoolMonitorRead(d, meta)
 }
 
-func resourceCloudFlareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerMonitor := cloudflare.LoadBalancerMonitor{
@@ -178,16 +178,16 @@ func resourceCloudFlareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, met
 		loadBalancerMonitor.Description = description.(string)
 	}
 
-	log.Printf("[DEBUG] Update CloudFlare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
+	log.Printf("[DEBUG] Update Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	_, err := client.ModifyLoadBalancerMonitor(loadBalancerMonitor)
 	if err != nil {
 		return errors.Wrap(err, "error modifying load balancer monitor")
 	}
 
-	log.Printf("[INFO] CloudFlare Load Balancer Monitor %q was modified", d.Id())
+	log.Printf("[INFO] Cloudflare Load Balancer Monitor %q was modified", d.Id())
 
-	return resourceCloudFlareLoadBalancerPoolMonitorRead(d, meta)
+	return resourceCloudflareLoadBalancerPoolMonitorRead(d, meta)
 }
 
 func expandLoadBalancerMonitorHeader(cfgSet interface{}) map[string][]string {
@@ -200,7 +200,7 @@ func expandLoadBalancerMonitorHeader(cfgSet interface{}) map[string][]string {
 	return header
 }
 
-func resourceCloudFlareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerMonitor, err := client.LoadBalancerMonitorDetails(d.Id())
@@ -214,7 +214,7 @@ func resourceCloudFlareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta 
 				fmt.Sprintf("Error reading load balancer monitor from API for resource %s ", d.Id()))
 		}
 	}
-	log.Printf("[DEBUG] Read CloudFlare Load Balancer Monitor from API as struct: %+v", loadBalancerMonitor)
+	log.Printf("[DEBUG] Read Cloudflare Load Balancer Monitor from API as struct: %+v", loadBalancerMonitor)
 
 	d.Set("expected_body", loadBalancerMonitor.ExpectedBody)
 	d.Set("expected_codes", loadBalancerMonitor.ExpectedCodes)
@@ -247,10 +247,10 @@ func flattenLoadBalancerMonitorHeader(header map[string][]string) *schema.Set {
 	return schema.NewSet(HashByMapKey("header"), flattened)
 }
 
-func resourceCloudFlareLoadBalancerPoolMonitorDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolMonitorDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
-	log.Printf("[INFO] Deleting CloudFlare Load Balancer Monitor: %s ", d.Id())
+	log.Printf("[INFO] Deleting Cloudflare Load Balancer Monitor: %s ", d.Id())
 
 	err := client.DeleteLoadBalancerMonitor(d.Id())
 	if err != nil {

--- a/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccCloudFlareLoadBalancerMonitor_Basic(t *testing.T) {
+func TestAccCloudflareLoadBalancerMonitor_Basic(t *testing.T) {
 	// multiple instances of this config would conflict but we only use it once
 	t.Parallel()
 	testStartTime := time.Now().UTC()
@@ -21,25 +21,25 @@ func TestAccCloudFlareLoadBalancerMonitor_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerMonitorDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Config: testAccCheckCloudflareLoadBalancerMonitorConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					testAccCheckCloudflareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
 					// dont check that specified values are set, this will be evident by lack of plan diff
 					// some values will get empty values
 					resource.TestCheckResourceAttr(name, "description", ""),
 					resource.TestCheckResourceAttr(name, "header.#", "0"),
 					// also expect api to generate some values
-					testAccCheckCloudFlareLoadBalancerMonitorDates(name, &loadBalancerMonitor, testStartTime),
+					testAccCheckCloudflareLoadBalancerMonitorDates(name, &loadBalancerMonitor, testStartTime),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCloudFlareLoadBalancerMonitor_FullySpecified(t *testing.T) {
+func TestAccCloudflareLoadBalancerMonitor_FullySpecified(t *testing.T) {
 	t.Parallel()
 	var loadBalancerMonitor cloudflare.LoadBalancerMonitor
 	name := "cloudflare_load_balancer_monitor.test"
@@ -47,12 +47,12 @@ func TestAccCloudFlareLoadBalancerMonitor_FullySpecified(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerMonitorDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigFullySpecified(),
+				Config: testAccCheckCloudflareLoadBalancerMonitorConfigFullySpecified(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					testAccCheckCloudflareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
 					// checking our overrides of default values worked
 					resource.TestCheckResourceAttr(name, "path", "/custom"),
 					resource.TestCheckResourceAttr(name, "header.#", "1"),
@@ -64,7 +64,7 @@ func TestAccCloudFlareLoadBalancerMonitor_FullySpecified(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareLoadBalancerMonitor_Update(t *testing.T) {
+func TestAccCloudflareLoadBalancerMonitor_Update(t *testing.T) {
 	t.Parallel()
 	var loadBalancerMonitor cloudflare.LoadBalancerMonitor
 	var initialId string
@@ -73,21 +73,21 @@ func TestAccCloudFlareLoadBalancerMonitor_Update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerMonitorDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Config: testAccCheckCloudflareLoadBalancerMonitorConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					testAccCheckCloudflareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
 				),
 			},
 			{
 				PreConfig: func() {
 					initialId = loadBalancerMonitor.ID
 				},
-				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigFullySpecified(),
+				Config: testAccCheckCloudflareLoadBalancerMonitorConfigFullySpecified(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					testAccCheckCloudflareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
 					func(state *terraform.State) error {
 						if initialId != loadBalancerMonitor.ID {
 							return fmt.Errorf("wanted update but monitor got recreated (id changed %q -> %q)",
@@ -101,7 +101,7 @@ func TestAccCloudFlareLoadBalancerMonitor_Update(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareLoadBalancerMonitor_CreateAfterManualDestroy(t *testing.T) {
+func TestAccCloudflareLoadBalancerMonitor_CreateAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 	var loadBalancerMonitor cloudflare.LoadBalancerMonitor
 	var initialId string
@@ -110,20 +110,20 @@ func TestAccCloudFlareLoadBalancerMonitor_CreateAfterManualDestroy(t *testing.T)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerMonitorDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Config: testAccCheckCloudflareLoadBalancerMonitorConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					testAccCheckCloudflareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
 					testAccManuallyDeleteLoadBalancerMonitor(name, &loadBalancerMonitor, &initialId),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccCheckCloudFlareLoadBalancerMonitorConfigBasic(),
+				Config: testAccCheckCloudflareLoadBalancerMonitorConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
+					testAccCheckCloudflareLoadBalancerMonitorExists(name, &loadBalancerMonitor),
 					func(state *terraform.State) error {
 						if initialId == loadBalancerMonitor.ID {
 							return fmt.Errorf("load balancer monitor id is unchanged even after we thought we deleted it ( %s )",
@@ -137,7 +137,7 @@ func TestAccCloudFlareLoadBalancerMonitor_CreateAfterManualDestroy(t *testing.T)
 	})
 }
 
-func testAccCheckCloudFlareLoadBalancerMonitorDestroy(s *terraform.State) error {
+func testAccCheckCloudflareLoadBalancerMonitorDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -154,7 +154,7 @@ func testAccCheckCloudFlareLoadBalancerMonitorDestroy(s *terraform.State) error 
 	return nil
 }
 
-func testAccCheckCloudFlareLoadBalancerMonitorExists(n string, load *cloudflare.LoadBalancerMonitor) resource.TestCheckFunc {
+func testAccCheckCloudflareLoadBalancerMonitorExists(n string, load *cloudflare.LoadBalancerMonitor) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -177,7 +177,7 @@ func testAccCheckCloudFlareLoadBalancerMonitorExists(n string, load *cloudflare.
 	}
 }
 
-func testAccCheckCloudFlareLoadBalancerMonitorDates(n string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, testStartTime time.Time) resource.TestCheckFunc {
+func testAccCheckCloudflareLoadBalancerMonitorDates(n string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, _ := s.RootModule().Resources[n]
@@ -217,7 +217,7 @@ func testAccManuallyDeleteLoadBalancerMonitor(name string, loadBalancerMonitor *
 	}
 }
 
-func testAccCheckCloudFlareLoadBalancerMonitorConfigBasic() string {
+func testAccCheckCloudflareLoadBalancerMonitorConfigBasic() string {
 	return `
 resource "cloudflare_load_balancer_monitor" "test" {
   expected_body = "alive"
@@ -226,7 +226,7 @@ resource "cloudflare_load_balancer_monitor" "test" {
 }`
 }
 
-func testAccCheckCloudFlareLoadBalancerMonitorConfigFullySpecified() string {
+func testAccCheckCloudflareLoadBalancerMonitorConfigFullySpecified() string {
 	return `
 resource "cloudflare_load_balancer_monitor" "test" {
   expected_body = "dead" 

--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -15,11 +15,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-func resourceCloudFlareLoadBalancerPool() *schema.Resource {
+func resourceCloudflareLoadBalancerPool() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudFlareLoadBalancerPoolCreate,
-		Read:   resourceCloudFlareLoadBalancerPoolRead,
-		Delete: resourceCloudFlareLoadBalancerPoolDelete,
+		Create: resourceCloudflareLoadBalancerPoolCreate,
+		Read:   resourceCloudflareLoadBalancerPoolRead,
+		Delete: resourceCloudflareLoadBalancerPoolDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -121,7 +121,7 @@ var originsElem = &schema.Resource{
 	},
 }
 
-func resourceCloudFlareLoadBalancerPoolCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerPool := cloudflare.LoadBalancerPool{
@@ -147,7 +147,7 @@ func resourceCloudFlareLoadBalancerPoolCreate(d *schema.ResourceData, meta inter
 		loadBalancerPool.NotificationEmail = notificationEmail.(string)
 	}
 
-	log.Printf("[DEBUG] Creating CloudFlare Load Balancer Pool from struct: %+v", loadBalancerPool)
+	log.Printf("[DEBUG] Creating Cloudflare Load Balancer Pool from struct: %+v", loadBalancerPool)
 
 	r, err := client.CreateLoadBalancerPool(loadBalancerPool)
 	if err != nil {
@@ -160,9 +160,9 @@ func resourceCloudFlareLoadBalancerPoolCreate(d *schema.ResourceData, meta inter
 
 	d.SetId(r.ID)
 
-	log.Printf("[INFO] New CloudFlare Load Balancer Pool created with  ID: %s", d.Id())
+	log.Printf("[INFO] New Cloudflare Load Balancer Pool created with  ID: %s", d.Id())
 
-	return resourceCloudFlareLoadBalancerPoolRead(d, meta)
+	return resourceCloudflareLoadBalancerPoolRead(d, meta)
 }
 
 func expandLoadBalancerOrigins(originSet *schema.Set) (origins []cloudflare.LoadBalancerOrigin) {
@@ -178,7 +178,7 @@ func expandLoadBalancerOrigins(originSet *schema.Set) (origins []cloudflare.Load
 	return
 }
 
-func resourceCloudFlareLoadBalancerPoolRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerPool, err := client.LoadBalancerPoolDetails(d.Id())
@@ -192,7 +192,7 @@ func resourceCloudFlareLoadBalancerPoolRead(d *schema.ResourceData, meta interfa
 				fmt.Sprintf("Error reading load balancer pool from API for resource %s ", d.Id()))
 		}
 	}
-	log.Printf("[DEBUG] Read CloudFlare Load Balancer Pool from API as struct: %+v", loadBalancerPool)
+	log.Printf("[DEBUG] Read Cloudflare Load Balancer Pool from API as struct: %+v", loadBalancerPool)
 
 	d.Set("name", loadBalancerPool.Name)
 	d.Set("enabled", loadBalancerPool.Enabled)
@@ -227,14 +227,14 @@ func flattenLoadBalancerOrigins(origins []cloudflare.LoadBalancerOrigin) *schema
 	return schema.NewSet(schema.HashResource(originsElem), flattened)
 }
 
-func resourceCloudFlareLoadBalancerPoolDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
-	log.Printf("[INFO] Deleting CloudFlare Load Balancer Pool: %s ", d.Id())
+	log.Printf("[INFO] Deleting Cloudflare Load Balancer Pool: %s ", d.Id())
 
 	err := client.DeleteLoadBalancerPool(d.Id())
 	if err != nil {
-		return errors.Wrap(err, "error deleting CloudFlare Load Balancer Pool")
+		return errors.Wrap(err, "error deleting Cloudflare Load Balancer Pool")
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccCloudFlareLoadBalancerPool_Basic(t *testing.T) {
+func TestAccCloudflareLoadBalancerPool_Basic(t *testing.T) {
 	// multiple instances of this config would conflict but we only use it once
 	t.Parallel()
 	testStartTime := time.Now().UTC()
@@ -23,24 +23,24 @@ func TestAccCloudFlareLoadBalancerPool_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerPoolDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
 					// dont check that specified values are set, this will be evident by lack of plan diff
 					// some values will get empty values
 					resource.TestCheckResourceAttr(name, "check_regions.#", "0"),
 					// also expect api to generate some values
-					testAccCheckCloudFlareLoadBalancerPoolDates(name, &loadBalancerPool, testStartTime),
+					testAccCheckCloudflareLoadBalancerPoolDates(name, &loadBalancerPool, testStartTime),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCloudFlareLoadBalancerPool_FullySpecified(t *testing.T) {
+func TestAccCloudflareLoadBalancerPool_FullySpecified(t *testing.T) {
 	t.Parallel()
 	var loadBalancerPool cloudflare.LoadBalancerPool
 	rnd := acctest.RandString(10)
@@ -49,12 +49,12 @@ func TestAccCloudFlareLoadBalancerPool_FullySpecified(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerPoolDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerPoolConfigFullySpecified(rnd),
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigFullySpecified(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
 					// checking our overrides of default values worked
 					resource.TestCheckResourceAttr(name, "enabled", "false"),
 					resource.TestCheckResourceAttr(name, "description", "tfacc-fully-specified"),
@@ -70,7 +70,7 @@ func TestAccCloudFlareLoadBalancerPool_FullySpecified(t *testing.T) {
 Any change to a load balancer pool results in a new resource
 Although the API client contains a modify method, this always results in 405 status
 */
-func TestAccCloudFlareLoadBalancerPool_ForceNew(t *testing.T) {
+func TestAccCloudflareLoadBalancerPool_ForceNew(t *testing.T) {
 	t.Parallel()
 	var loadBalancerPool cloudflare.LoadBalancerPool
 	var initialId string
@@ -80,21 +80,21 @@ func TestAccCloudFlareLoadBalancerPool_ForceNew(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerPoolDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
 				),
 			},
 			{
 				PreConfig: func() {
 					initialId = loadBalancerPool.ID
 				},
-				Config: testAccCheckCloudFlareLoadBalancerPoolConfigFullySpecified(rnd),
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigFullySpecified(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
 					func(state *terraform.State) error {
 						if initialId == loadBalancerPool.ID {
 							return fmt.Errorf("id should be different after recreation, but is unchanged: %s ",
@@ -108,7 +108,7 @@ func TestAccCloudFlareLoadBalancerPool_ForceNew(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareLoadBalancerPool_CreateAfterManualDestroy(t *testing.T) {
+func TestAccCloudflareLoadBalancerPool_CreateAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 	var loadBalancerPool cloudflare.LoadBalancerPool
 	var initialId string
@@ -118,20 +118,20 @@ func TestAccCloudFlareLoadBalancerPool_CreateAfterManualDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerPoolDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
 					testAccManuallyDeleteLoadBalancerPool(name, &loadBalancerPool, &initialId),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccCheckCloudFlareLoadBalancerPoolConfigBasic(rnd),
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerPoolExists(name, &loadBalancerPool),
+					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
 					func(state *terraform.State) error {
 						if initialId == loadBalancerPool.ID {
 							return fmt.Errorf("load balancer pool id is unchanged even after we thought we deleted it ( %s )",
@@ -145,7 +145,7 @@ func TestAccCloudFlareLoadBalancerPool_CreateAfterManualDestroy(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudFlareLoadBalancerPoolDestroy(s *terraform.State) error {
+func testAccCheckCloudflareLoadBalancerPoolDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -162,7 +162,7 @@ func testAccCheckCloudFlareLoadBalancerPoolDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudFlareLoadBalancerPoolExists(n string, loadBalancerPool *cloudflare.LoadBalancerPool) resource.TestCheckFunc {
+func testAccCheckCloudflareLoadBalancerPoolExists(n string, loadBalancerPool *cloudflare.LoadBalancerPool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -185,7 +185,7 @@ func testAccCheckCloudFlareLoadBalancerPoolExists(n string, loadBalancerPool *cl
 	}
 }
 
-func testAccCheckCloudFlareLoadBalancerPoolDates(n string, loadBalancerPool *cloudflare.LoadBalancerPool, testStartTime time.Time) resource.TestCheckFunc {
+func testAccCheckCloudflareLoadBalancerPoolDates(n string, loadBalancerPool *cloudflare.LoadBalancerPool, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, _ := s.RootModule().Resources[n]
@@ -226,7 +226,7 @@ func testAccManuallyDeleteLoadBalancerPool(name string, loadBalancerPool *cloudf
 }
 
 // using IPs from 192.0.2.0/24 as per RFC5737
-func testAccCheckCloudFlareLoadBalancerPoolConfigBasic(id string) string {
+func testAccCheckCloudflareLoadBalancerPoolConfigBasic(id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_load_balancer_pool" "%[1]s" {
   name = "my-tf-pool-basic-%[1]s"
@@ -238,7 +238,7 @@ resource "cloudflare_load_balancer_pool" "%[1]s" {
 }`, id)
 }
 
-func testAccCheckCloudFlareLoadBalancerPoolConfigFullySpecified(id string) string {
+func testAccCheckCloudflareLoadBalancerPoolConfigFullySpecified(id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_load_balancer_pool" "%[1]s" {
   name = "my-tf-pool-basic-%[1]s"

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -16,7 +16,7 @@ import (
 	"regexp"
 )
 
-func TestAccCloudFlareLoadBalancer_Basic(t *testing.T) {
+func TestAccCloudflareLoadBalancer_Basic(t *testing.T) {
 	// multiple instances of this config would conflict but we only use it once
 	t.Parallel()
 	testStartTime := time.Now().UTC()
@@ -28,19 +28,19 @@ func TestAccCloudFlareLoadBalancer_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Config: testAccCheckCloudflareLoadBalancerConfigBasic(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
-					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zone),
 					// dont check that specified values are set, this will be evident by lack of plan diff
 					// some values will get empty values
 					resource.TestCheckResourceAttr(name, "pop_pools.#", "0"),
 					resource.TestCheckResourceAttr(name, "region_pools.#", "0"),
 					// also expect api to generate some values
-					testAccCheckCloudFlareLoadBalancerDates(name, &loadBalancer, testStartTime),
+					testAccCheckCloudflareLoadBalancerDates(name, &loadBalancer, testStartTime),
 					resource.TestCheckResourceAttr(name, "proxied", "false"), // default value
 					resource.TestCheckResourceAttr(name, "ttl", "30"),
 				),
@@ -49,7 +49,7 @@ func TestAccCloudFlareLoadBalancer_Basic(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareLoadBalancer_GeoBalanced(t *testing.T) {
+func TestAccCloudflareLoadBalancer_GeoBalanced(t *testing.T) {
 	t.Parallel()
 	var loadBalancer cloudflare.LoadBalancer
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -59,13 +59,13 @@ func TestAccCloudFlareLoadBalancer_GeoBalanced(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerConfigGeoBalanced(zone, rnd),
+				Config: testAccCheckCloudflareLoadBalancerConfigGeoBalanced(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
-					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zone),
 					// checking our overrides of default values worked
 					resource.TestCheckResourceAttr(name, "description", "tf-acctest load balancer using geo-balancing"),
 					resource.TestCheckResourceAttr(name, "proxied", "true"),
@@ -78,7 +78,7 @@ func TestAccCloudFlareLoadBalancer_GeoBalanced(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareLoadBalancer_DuplicatePool(t *testing.T) {
+func TestAccCloudflareLoadBalancer_DuplicatePool(t *testing.T) {
 	t.Parallel()
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := acctest.RandString(10)
@@ -86,10 +86,10 @@ func TestAccCloudFlareLoadBalancer_DuplicatePool(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckCloudFlareLoadBalancerConfigDuplicatePool(zone, rnd),
+				Config:      testAccCheckCloudflareLoadBalancerConfigDuplicatePool(zone, rnd),
 				ExpectError: regexp.MustCompile(regexp.QuoteMeta("duplicate entry specified for pop pool in location \"LAX\". each location must only be specified once")),
 			},
 		},
@@ -100,7 +100,7 @@ func TestAccCloudFlareLoadBalancer_DuplicatePool(t *testing.T) {
 Any change to a load balancer  results in a new resource
 Although the API client contains a modify method, this always results in 405 status
 */
-func TestAccCloudFlareLoadBalancer_Update(t *testing.T) {
+func TestAccCloudflareLoadBalancer_Update(t *testing.T) {
 	t.Parallel()
 	var loadBalancer cloudflare.LoadBalancer
 	var initialId string
@@ -111,23 +111,23 @@ func TestAccCloudFlareLoadBalancer_Update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Config: testAccCheckCloudflareLoadBalancerConfigBasic(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
-					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zone),
 				),
 			},
 			{
 				PreConfig: func() {
 					initialId = loadBalancer.ID
 				},
-				Config: testAccCheckCloudFlareLoadBalancerConfigGeoBalanced(zone, rnd),
+				Config: testAccCheckCloudflareLoadBalancerConfigGeoBalanced(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
-					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zone),
 					func(state *terraform.State) error {
 						if initialId != loadBalancer.ID {
 							// want in place update
@@ -142,7 +142,7 @@ func TestAccCloudFlareLoadBalancer_Update(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareLoadBalancer_CreateAfterManualDestroy(t *testing.T) {
+func TestAccCloudflareLoadBalancer_CreateAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 	var loadBalancer cloudflare.LoadBalancer
 	var initialId string
@@ -153,22 +153,22 @@ func TestAccCloudFlareLoadBalancer_CreateAfterManualDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareLoadBalancerDestroy,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Config: testAccCheckCloudflareLoadBalancerConfigBasic(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
-					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zone),
 					testAccManuallyDeleteLoadBalancer(name, &loadBalancer, &initialId),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccCheckCloudFlareLoadBalancerConfigBasic(zone, rnd),
+				Config: testAccCheckCloudflareLoadBalancerConfigBasic(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareLoadBalancerExists(name, &loadBalancer),
-					testAccCheckCloudFlareLoadBalancerIDIsValid(name, zone),
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zone),
 					func(state *terraform.State) error {
 						if initialId == loadBalancer.ID {
 							return fmt.Errorf("load balancer id is unchanged even after we thought we deleted it ( %s )",
@@ -182,7 +182,7 @@ func TestAccCloudFlareLoadBalancer_CreateAfterManualDestroy(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudFlareLoadBalancerDestroy(s *terraform.State) error {
+func testAccCheckCloudflareLoadBalancerDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -199,7 +199,7 @@ func testAccCheckCloudFlareLoadBalancerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudFlareLoadBalancerExists(n string, loadBalancer *cloudflare.LoadBalancer) resource.TestCheckFunc {
+func testAccCheckCloudflareLoadBalancerExists(n string, loadBalancer *cloudflare.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -222,7 +222,7 @@ func testAccCheckCloudFlareLoadBalancerExists(n string, loadBalancer *cloudflare
 	}
 }
 
-func testAccCheckCloudFlareLoadBalancerIDIsValid(n, expectedZone string) resource.TestCheckFunc {
+func testAccCheckCloudflareLoadBalancerIDIsValid(n, expectedZone string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -248,7 +248,7 @@ func testAccCheckCloudFlareLoadBalancerIDIsValid(n, expectedZone string) resourc
 	}
 }
 
-func testAccCheckCloudFlareLoadBalancerDates(n string, loadBalancer *cloudflare.LoadBalancer, testStartTime time.Time) resource.TestCheckFunc {
+func testAccCheckCloudflareLoadBalancerDates(n string, loadBalancer *cloudflare.LoadBalancer, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, _ := s.RootModule().Resources[n]
@@ -289,8 +289,8 @@ func testAccManuallyDeleteLoadBalancer(name string, loadBalancer *cloudflare.Loa
 	}
 }
 
-func testAccCheckCloudFlareLoadBalancerConfigBasic(zone, id string) string {
-	return testAccCheckCloudFlareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
+func testAccCheckCloudflareLoadBalancerConfigBasic(zone, id string) string {
+	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
 resource "cloudflare_load_balancer" "%[2]s" {
   zone = "%[1]s"
   name = "tf-testacc-lb-%[2]s"
@@ -299,8 +299,8 @@ resource "cloudflare_load_balancer" "%[2]s" {
 }`, zone, id)
 }
 
-func testAccCheckCloudFlareLoadBalancerConfigGeoBalanced(zone, id string) string {
-	return testAccCheckCloudFlareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
+func testAccCheckCloudflareLoadBalancerConfigGeoBalanced(zone, id string) string {
+	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
 resource "cloudflare_load_balancer" "%[2]s" {
   zone = "%[1]s"
   name = "tf-testacc-lb-%[2]s"
@@ -319,8 +319,8 @@ resource "cloudflare_load_balancer" "%[2]s" {
 }`, zone, id)
 }
 
-func testAccCheckCloudFlareLoadBalancerConfigDuplicatePool(zone, id string) string {
-	return testAccCheckCloudFlareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
+func testAccCheckCloudflareLoadBalancerConfigDuplicatePool(zone, id string) string {
+	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
 resource "cloudflare_load_balancer" "%[2]s" {
   zone = "%[1]s"
   name = "tf-testacc-lb-%[2]s"

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -11,14 +11,14 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 )
 
-func resourceCloudFlarePageRule() *schema.Resource {
+func resourceCloudflarePageRule() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudFlarePageRuleCreate,
-		Read:   resourceCloudFlarePageRuleRead,
-		Update: resourceCloudFlarePageRuleUpdate,
-		Delete: resourceCloudFlarePageRuleDelete,
+		Create: resourceCloudflarePageRuleCreate,
+		Read:   resourceCloudflarePageRuleRead,
+		Update: resourceCloudflarePageRuleUpdate,
+		Delete: resourceCloudflarePageRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudFlarePageRuleImport,
+			State: resourceCloudflarePageRuleImport,
 		},
 
 		SchemaVersion: 0,
@@ -301,7 +301,7 @@ func suppressEquivalentURLs(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
-func resourceCloudFlarePageRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflarePageRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zone := d.Get("zone").(string)
 
@@ -324,7 +324,7 @@ func resourceCloudFlarePageRuleCreate(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Actions found in config: %#v", actions)
 	for _, action := range actions {
 		for id, value := range action.(map[string]interface{}) {
-			newPageRuleAction, err := transformToCloudFlarePageRuleAction(id, value)
+			newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value)
 			if err != nil {
 				return err
 			} else if newPageRuleAction.Value == nil {
@@ -351,7 +351,7 @@ func resourceCloudFlarePageRuleCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("zone_id", zoneID)
-	log.Printf("[DEBUG] CloudFlare Page Rule create configuration: %#v", newPageRule)
+	log.Printf("[DEBUG] Cloudflare Page Rule create configuration: %#v", newPageRule)
 
 	r, err := client.CreatePageRule(zoneID, newPageRule)
 	if err != nil {
@@ -364,7 +364,7 @@ func resourceCloudFlarePageRuleCreate(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(r.ID)
 
-	return resourceCloudFlarePageRuleRead(d, meta)
+	return resourceCloudflarePageRuleRead(d, meta)
 }
 
 func pageRuleActionsToMap(vs []cloudflare.PageRuleAction) map[string]interface{} {
@@ -375,7 +375,7 @@ func pageRuleActionsToMap(vs []cloudflare.PageRuleAction) map[string]interface{}
 	return vsm
 }
 
-func resourceCloudFlarePageRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflarePageRuleRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -390,7 +390,7 @@ func resourceCloudFlarePageRuleRead(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error finding page rule %q: %s", d.Id(), err)
 		}
 	}
-	log.Printf("[DEBUG] CloudFlare Page Rule read configuration: %#v", pageRule)
+	log.Printf("[DEBUG] Cloudflare Page Rule read configuration: %#v", pageRule)
 
 	// Cloudflare presently only has one target type, and its Operator is always
 	// "matches"; so we can just read the first element's Value.
@@ -401,13 +401,13 @@ func resourceCloudFlarePageRuleRead(d *schema.ResourceData, meta interface{}) er
 
 	actions := map[string]interface{}{}
 	for _, pageRuleAction := range pageRule.Actions {
-		key, value, err := transformFromCloudFlarePageRuleAction(&pageRuleAction)
+		key, value, err := transformFromCloudflarePageRuleAction(&pageRuleAction)
 		if err != nil {
 			return fmt.Errorf("Failed to parse page rule action: %s", err)
 		}
 		actions[key] = value
 	}
-	log.Printf("[DEBUG] CloudFlare Page Rule actions configuration: %#v", actions)
+	log.Printf("[DEBUG] Cloudflare Page Rule actions configuration: %#v", actions)
 
 	if err := d.Set("actions", []map[string]interface{}{actions}); err != nil {
 		log.Printf("[WARN] Error setting actions in page rule %q: %s", d.Id(), err)
@@ -416,7 +416,7 @@ func resourceCloudFlarePageRuleRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceCloudFlarePageRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflarePageRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -443,7 +443,7 @@ func resourceCloudFlarePageRuleUpdate(d *schema.ResourceData, meta interface{}) 
 
 		for _, action := range actions {
 			for id, value := range action.(map[string]interface{}) {
-				newPageRuleAction, err := transformToCloudFlarePageRuleAction(id, value)
+				newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value)
 				if err != nil {
 					return err
 				} else if newPageRuleAction.Value == nil {
@@ -472,10 +472,10 @@ func resourceCloudFlarePageRuleUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Failed to update Cloudflare Page Rule: %s", err)
 	}
 
-	return resourceCloudFlarePageRuleRead(d, meta)
+	return resourceCloudflarePageRuleRead(d, meta)
 }
 
-func resourceCloudFlarePageRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflarePageRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	zone := d.Get("zone").(string)
@@ -523,7 +523,7 @@ var pageRuleAPIStringFields = []string{
 	"ssl",
 }
 
-func transformFromCloudFlarePageRuleAction(pageRuleAction *cloudflare.PageRuleAction) (key string, value interface{}, err error) {
+func transformFromCloudflarePageRuleAction(pageRuleAction *cloudflare.PageRuleAction) (key string, value interface{}, err error) {
 	key = pageRuleAction.ID
 
 	switch {
@@ -555,7 +555,7 @@ func transformFromCloudFlarePageRuleAction(pageRuleAction *cloudflare.PageRuleAc
 	return
 }
 
-func transformToCloudFlarePageRuleAction(id string, value interface{}) (pageRuleAction cloudflare.PageRuleAction, err error) {
+func transformToCloudflarePageRuleAction(id string, value interface{}) (pageRuleAction cloudflare.PageRuleAction, err error) {
 
 	pageRuleAction.ID = id
 
@@ -606,7 +606,7 @@ func transformToCloudFlarePageRuleAction(id string, value interface{}) (pageRule
 	return
 }
 
-func resourceCloudFlarePageRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflarePageRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 
 	// split the id so we can lookup

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -15,7 +15,7 @@ import (
 
 // TODO parallel tests run into rate limiting, update after client limiting is merged
 
-func TestAccCloudFlarePageRule_Basic(t *testing.T) {
+func TestAccCloudflarePageRule_Basic(t *testing.T) {
 	var pageRule cloudflare.PageRule
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	target := fmt.Sprintf("test-basic.%s", zone)
@@ -23,13 +23,13 @@ func TestAccCloudFlarePageRule_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlarePageRuleDestroy,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigBasic(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigBasic(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-					testAccCheckCloudFlarePageRuleAttributesBasic(&pageRule),
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+					testAccCheckCloudflarePageRuleAttributesBasic(&pageRule),
 					resource.TestCheckResourceAttr(
 						"cloudflare_page_rule.test", "zone", zone),
 					resource.TestCheckResourceAttr(
@@ -40,7 +40,7 @@ func TestAccCloudFlarePageRule_Basic(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlarePageRule_FullySpecified(t *testing.T) {
+func TestAccCloudflarePageRule_FullySpecified(t *testing.T) {
 	var pageRule cloudflare.PageRule
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	target := fmt.Sprintf("test-fully-specified.%s", zone)
@@ -48,13 +48,13 @@ func TestAccCloudFlarePageRule_FullySpecified(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlarePageRuleDestroy,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigFullySpecified(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigFullySpecified(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-					testAccCheckCloudFlarePageRuleAttributesFullySpecified(&pageRule),
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+					testAccCheckCloudflarePageRuleAttributesFullySpecified(&pageRule),
 					resource.TestCheckResourceAttr(
 						"cloudflare_page_rule.test", "zone", zone),
 					resource.TestCheckResourceAttr(
@@ -65,7 +65,7 @@ func TestAccCloudFlarePageRule_FullySpecified(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlarePageRule_ForwardingOnly(t *testing.T) {
+func TestAccCloudflarePageRule_ForwardingOnly(t *testing.T) {
 	var pageRule cloudflare.PageRule
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	target := fmt.Sprintf("test-fwd-only.%s", zone)
@@ -73,13 +73,13 @@ func TestAccCloudFlarePageRule_ForwardingOnly(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlarePageRuleDestroy,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigForwardingOnly(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigForwardingOnly(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-					//testAccCheckCloudFlarePageRuleAttributes(&pageRule),
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+					//testAccCheckCloudflarePageRuleAttributes(&pageRule),
 					resource.TestCheckResourceAttr(
 						"cloudflare_page_rule.test", "zone", zone),
 					resource.TestCheckResourceAttr(
@@ -95,7 +95,7 @@ func TestAccCloudFlarePageRule_ForwardingOnly(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlarePageRule_ForwardingAndOthers(t *testing.T) {
+func TestAccCloudflarePageRule_ForwardingAndOthers(t *testing.T) {
 	var pageRule cloudflare.PageRule
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	target := fmt.Sprintf("test-fwd-others.%s", zone)
@@ -103,12 +103,12 @@ func TestAccCloudFlarePageRule_ForwardingAndOthers(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlarePageRuleDestroy,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigForwardingAndOthers(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigForwardingAndOthers(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
 					resource.TestCheckResourceAttr(
 						"cloudflare_page_rule.test", "zone", zone),
 					resource.TestCheckResourceAttr(
@@ -123,7 +123,7 @@ func TestAccCloudFlarePageRule_ForwardingAndOthers(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlarePageRule_Updated(t *testing.T) {
+func TestAccCloudflarePageRule_Updated(t *testing.T) {
 	var before, after cloudflare.PageRule
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	target := fmt.Sprintf("test-updated.%s", zone)
@@ -131,20 +131,20 @@ func TestAccCloudFlarePageRule_Updated(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlarePageRuleDestroy,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigBasic(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigBasic(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists("cloudflare_page_rule.test", &before),
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &before),
 				),
 			},
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigNewValue(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigNewValue(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists("cloudflare_page_rule.test", &after),
-					testAccCheckCloudFlarePageRuleAttributesUpdated(&after),
-					testAccCheckCloudFlarePageRuleIDUnchanged(&before, &after),
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &after),
+					testAccCheckCloudflarePageRuleAttributesUpdated(&after),
+					testAccCheckCloudflarePageRuleIDUnchanged(&before, &after),
 					resource.TestCheckResourceAttr(
 						"cloudflare_page_rule.test", "target", fmt.Sprintf("%s/updated", target)),
 				),
@@ -153,7 +153,7 @@ func TestAccCloudFlarePageRule_Updated(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlarePageRule_CreateAfterManualDestroy(t *testing.T) {
+func TestAccCloudflarePageRule_CreateAfterManualDestroy(t *testing.T) {
 	var before, after cloudflare.PageRule
 	var initialID string
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -162,21 +162,21 @@ func TestAccCloudFlarePageRule_CreateAfterManualDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlarePageRuleDestroy,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigBasic(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigBasic(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists("cloudflare_page_rule.test", &before),
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &before),
 					testAccManuallyDeletePageRule("cloudflare_page_rule.test", &initialID),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccCheckCloudFlarePageRuleConfigNewValue(zone, target),
+				Config: testAccCheckCloudflarePageRuleConfigNewValue(zone, target),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlarePageRuleExists("cloudflare_page_rule.test", &after),
-					testAccCheckCloudFlarePageRuleRecreated(&before, &after),
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &after),
+					testAccCheckCloudflarePageRuleRecreated(&before, &after),
 					resource.TestCheckResourceAttr(
 						"cloudflare_page_rule.test", "target", fmt.Sprintf("%s/updated", target)),
 					resource.TestCheckResourceAttr(
@@ -194,7 +194,7 @@ func TestAccCloudFlarePageRule_CreateAfterManualDestroy(t *testing.T) {
 }
 
 func TestTranformForwardingURL(t *testing.T) {
-	key, val, err := transformFromCloudFlarePageRuleAction(&cloudflare.PageRuleAction{
+	key, val, err := transformFromCloudflarePageRuleAction(&cloudflare.PageRuleAction{
 		ID: "forwarding_url",
 		Value: map[string]interface{}{
 			"url":         "http://test.com/forward",
@@ -220,7 +220,7 @@ func TestTranformForwardingURL(t *testing.T) {
 	}
 }
 
-func testAccCheckCloudFlarePageRuleRecreated(before, after *cloudflare.PageRule) resource.TestCheckFunc {
+func testAccCheckCloudflarePageRuleRecreated(before, after *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if before.ID == after.ID {
 			return fmt.Errorf("Expected change of PageRule Ids, but both were %v", before.ID)
@@ -229,7 +229,7 @@ func testAccCheckCloudFlarePageRuleRecreated(before, after *cloudflare.PageRule)
 	}
 }
 
-func testAccCheckCloudFlarePageRuleIDUnchanged(before, after *cloudflare.PageRule) resource.TestCheckFunc {
+func testAccCheckCloudflarePageRuleIDUnchanged(before, after *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if before.ID != after.ID {
 			return fmt.Errorf("ID should not change suring in place update, but got change %s -> %s", before.ID, after.ID)
@@ -238,7 +238,7 @@ func testAccCheckCloudFlarePageRuleIDUnchanged(before, after *cloudflare.PageRul
 	}
 }
 
-func testAccCheckCloudFlarePageRuleDestroy(s *terraform.State) error {
+func testAccCheckCloudflarePageRuleDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -255,7 +255,7 @@ func testAccCheckCloudFlarePageRuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudFlarePageRuleAttributesBasic(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
+func testAccCheckCloudflarePageRuleAttributesBasic(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		// check the api only has attributes we set non-empty values for
@@ -296,7 +296,7 @@ func testAccCheckCloudFlarePageRuleAttributesBasic(pageRule *cloudflare.PageRule
 	}
 }
 
-func testAccCheckCloudFlarePageRuleAttributesFullySpecified(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
+func testAccCheckCloudflarePageRuleAttributesFullySpecified(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		// check boolean variables get set correctly
@@ -327,7 +327,7 @@ func testAccCheckCloudFlarePageRuleAttributesFullySpecified(pageRule *cloudflare
 	}
 }
 
-func testAccCheckCloudFlarePageRuleAttributesUpdated(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
+func testAccCheckCloudflarePageRuleAttributesUpdated(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		actionMap := pageRuleActionsToMap(pageRule.Actions)
@@ -377,7 +377,7 @@ func testAccCheckCloudFlarePageRuleAttributesUpdated(pageRule *cloudflare.PageRu
 	}
 }
 
-func testAccCheckCloudFlarePageRuleExists(n string, pageRule *cloudflare.PageRule) resource.TestCheckFunc {
+func testAccCheckCloudflarePageRuleExists(n string, pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -421,7 +421,7 @@ func testAccManuallyDeletePageRule(name string, initialID *string) resource.Test
 	}
 }
 
-func testAccCheckCloudFlarePageRuleConfigBasic(zone, target string) string {
+func testAccCheckCloudflarePageRuleConfigBasic(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -434,7 +434,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudFlarePageRuleConfigNewValue(zone, target string) string {
+func testAccCheckCloudflarePageRuleConfigNewValue(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -449,7 +449,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudFlarePageRuleConfigFullySpecified(zone, target string) string {
+func testAccCheckCloudflarePageRuleConfigFullySpecified(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -472,7 +472,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudFlarePageRuleConfigForwardingOnly(zone, target string) string {
+func testAccCheckCloudflarePageRuleConfigForwardingOnly(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -487,7 +487,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudFlarePageRuleConfigForwardingAndOthers(zone, target string) string {
+func testAccCheckCloudflarePageRuleConfigForwardingAndOthers(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -11,14 +11,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func resourceCloudFlareRateLimit() *schema.Resource {
+func resourceCloudflareRateLimit() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudFlareRateLimitCreate,
-		Read:   resourceCloudFlareRateLimitRead,
-		Update: resourceCloudFlareRateLimitUpdate,
-		Delete: resourceCloudFlareRateLimitDelete,
+		Create: resourceCloudflareRateLimitCreate,
+		Read:   resourceCloudflareRateLimitRead,
+		Update: resourceCloudflareRateLimitUpdate,
+		Delete: resourceCloudflareRateLimitDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudFlareRateLimitImport,
+			State: resourceCloudflareRateLimitImport,
 		},
 
 		SchemaVersion: 0,
@@ -180,7 +180,7 @@ func resourceCloudFlareRateLimit() *schema.Resource {
 	}
 }
 
-func resourceCloudFlareRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	newRateLimit := cloudflare.RateLimit{
@@ -213,7 +213,7 @@ func resourceCloudFlareRateLimitCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
 	}
 
-	log.Printf("[DEBUG] Creating CloudFlare Rate Limit from struct: %+v", newRateLimit)
+	log.Printf("[DEBUG] Creating Cloudflare Rate Limit from struct: %+v", newRateLimit)
 
 	r, err := client.CreateRateLimit(zoneId, newRateLimit)
 	if err != nil {
@@ -228,12 +228,12 @@ func resourceCloudFlareRateLimitCreate(d *schema.ResourceData, meta interface{})
 	// assume ids are immutable, not going to look it up from the api again
 	d.Set("zone_id", zoneId)
 
-	log.Printf("[INFO] CloudFlare Rate Limit ID: %s", d.Id())
+	log.Printf("[INFO] Cloudflare Rate Limit ID: %s", d.Id())
 
-	return resourceCloudFlareRateLimitRead(d, meta)
+	return resourceCloudflareRateLimitRead(d, meta)
 }
 
-func resourceCloudFlareRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 	// since api only supports replace, update looks a lot like create...
 	client := meta.(*cloudflare.API)
 	zoneId := d.Get("zone_id").(string)
@@ -267,7 +267,7 @@ func resourceCloudFlareRateLimitUpdate(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return errors.Wrap(err, "error creating rate limit for zone")
 	}
-	return resourceCloudFlareRateLimitRead(d, meta)
+	return resourceCloudflareRateLimitRead(d, meta)
 }
 
 func expandRateLimitTrafficMatcher(d *schema.ResourceData) (matcher cloudflare.RateLimitTrafficMatcher, err error) {
@@ -331,7 +331,7 @@ func expandRateLimitAction(d *schema.ResourceData) cloudflare.RateLimitAction {
 	}
 
 	if _, ok := tfAction["response"]; ok && len(tfAction["response"].([]interface{})) > 0 {
-		log.Printf("[DEBUG] CloudFlare Rate Limit specified action: %+v \n", tfAction)
+		log.Printf("[DEBUG] Cloudflare Rate Limit specified action: %+v \n", tfAction)
 		tfActionResponse := tfAction["response"].([]interface{})[0].(map[string]interface{})
 
 		action.Response = &cloudflare.RateLimitActionResponse{
@@ -353,7 +353,7 @@ func expandRateLimitBypass(bypassUrlPatterns *schema.Set) []cloudflare.RateLimit
 	return bypass
 }
 
-func resourceCloudFlareRateLimitRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRateLimitRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneId := d.Get("zone_id").(string)
 	rateLimitId := d.Id()
@@ -369,7 +369,7 @@ func resourceCloudFlareRateLimitRead(d *schema.ResourceData, meta interface{}) e
 				fmt.Sprintf("Error reading rate limit resource from API for resource %s in zone %s", zoneId, rateLimitId))
 		}
 	}
-	log.Printf("[DEBUG] Read CloudFlare Rate Limit from API as struct: %+v", rateLimit)
+	log.Printf("[DEBUG] Read Cloudflare Rate Limit from API as struct: %+v", rateLimit)
 
 	d.Set("threshold", rateLimit.Threshold)
 	d.Set("period", rateLimit.Period)
@@ -450,22 +450,22 @@ func flattenRateLimitAction(cfg cloudflare.RateLimitAction) []map[string]interfa
 	return []map[string]interface{}{action}
 }
 
-func resourceCloudFlareRateLimitDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRateLimitDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneId := d.Get("zone_id").(string)
 	rateLimitId := d.Id()
 
-	log.Printf("[INFO] Deleting CloudFlare Rate Limit: %s for zone: %s", rateLimitId, zoneId)
+	log.Printf("[INFO] Deleting Cloudflare Rate Limit: %s for zone: %s", rateLimitId, zoneId)
 
 	err := client.DeleteRateLimit(zoneId, rateLimitId)
 	if err != nil {
-		return fmt.Errorf("error deleting CloudFlare Rate Limit for zone: %s", err)
+		return fmt.Errorf("error deleting Cloudflare Rate Limit for zone: %s", err)
 	}
 
 	return nil
 }
 
-func resourceCloudFlareRateLimitImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareRateLimitImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 
 	// split the id so we can lookup

--- a/cloudflare/resource_cloudflare_rate_limit_test.go
+++ b/cloudflare/resource_cloudflare_rate_limit_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccCloudFlareRateLimit_Basic(t *testing.T) {
+func TestAccCloudflareRateLimit_Basic(t *testing.T) {
 	// multiple instances of this config would conflict but we only use it once
 	t.Parallel()
 	var rateLimit cloudflare.RateLimit
@@ -24,13 +24,13 @@ func TestAccCloudFlareRateLimit_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRateLimitDestroy,
+		CheckDestroy: testAccCheckCloudflareRateLimitDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRateLimitConfigBasic(zone, rnd),
+				Config: testAccCheckCloudflareRateLimitConfigBasic(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRateLimitExists(name, &rateLimit),
-					testAccCheckCloudFlareRateLimitIDIsValid(name, zone),
+					testAccCheckCloudflareRateLimitExists(name, &rateLimit),
+					testAccCheckCloudflareRateLimitIDIsValid(name, zone),
 					// dont check that specified values are set, this will be evident by lack of plan diff
 					// some values will get empty values
 					resource.TestCheckResourceAttr(name, "action.0.response.#", "0"),
@@ -50,7 +50,7 @@ func TestAccCloudFlareRateLimit_Basic(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRateLimit_FullySpecified(t *testing.T) {
+func TestAccCloudflareRateLimit_FullySpecified(t *testing.T) {
 	t.Parallel()
 	var rateLimit cloudflare.RateLimit
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -60,13 +60,13 @@ func TestAccCloudFlareRateLimit_FullySpecified(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRateLimitDestroy,
+		CheckDestroy: testAccCheckCloudflareRateLimitDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRateLimitConfigFullySpecified(zone, rnd),
+				Config: testAccCheckCloudflareRateLimitConfigFullySpecified(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRateLimitExists(name, &rateLimit),
-					testAccCheckCloudFlareRateLimitIDIsValid(name, zone),
+					testAccCheckCloudflareRateLimitExists(name, &rateLimit),
+					testAccCheckCloudflareRateLimitIDIsValid(name, zone),
 					// checking our overrides of default values worked
 					resource.TestCheckResourceAttr(name, "action.0.response.#", "1"),
 					resource.TestCheckResourceAttr(name, "action.0.response.0.content_type", "text/plain"),
@@ -84,7 +84,7 @@ func TestAccCloudFlareRateLimit_FullySpecified(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRateLimit_Update(t *testing.T) {
+func TestAccCloudflareRateLimit_Update(t *testing.T) {
 	t.Parallel()
 	var rateLimit cloudflare.RateLimit
 	var initialRateLimitId string
@@ -95,23 +95,23 @@ func TestAccCloudFlareRateLimit_Update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRateLimitDestroy,
+		CheckDestroy: testAccCheckCloudflareRateLimitDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRateLimitConfigMatchingUrl(zone, rnd),
+				Config: testAccCheckCloudflareRateLimitConfigMatchingUrl(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRateLimitExists(name, &rateLimit),
-					testAccCheckCloudFlareRateLimitIDIsValid(name, zone),
+					testAccCheckCloudflareRateLimitExists(name, &rateLimit),
+					testAccCheckCloudflareRateLimitIDIsValid(name, zone),
 				),
 			},
 			{
 				PreConfig: func() {
 					initialRateLimitId = rateLimit.ID
 				},
-				Config: testAccCheckCloudFlareRateLimitConfigFullySpecified(zone, rnd),
+				Config: testAccCheckCloudflareRateLimitConfigFullySpecified(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRateLimitExists(name, &rateLimit),
-					testAccCheckCloudFlareRateLimitIDIsValid(name, zone),
+					testAccCheckCloudflareRateLimitExists(name, &rateLimit),
+					testAccCheckCloudflareRateLimitIDIsValid(name, zone),
 					func(state *terraform.State) error {
 						if initialRateLimitId != rateLimit.ID {
 							// rate limit change shows resource was recreated, we want in place update
@@ -126,7 +126,7 @@ func TestAccCloudFlareRateLimit_Update(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRateLimit_CreateAfterManualDestroy(t *testing.T) {
+func TestAccCloudflareRateLimit_CreateAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 	var rateLimit cloudflare.RateLimit
 	var initialRateLimitId string
@@ -137,22 +137,22 @@ func TestAccCloudFlareRateLimit_CreateAfterManualDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRateLimitDestroy,
+		CheckDestroy: testAccCheckCloudflareRateLimitDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRateLimitConfigMatchingUrl(zone, rnd),
+				Config: testAccCheckCloudflareRateLimitConfigMatchingUrl(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRateLimitExists(name, &rateLimit),
-					testAccCheckCloudFlareRateLimitIDIsValid(name, zone),
+					testAccCheckCloudflareRateLimitExists(name, &rateLimit),
+					testAccCheckCloudflareRateLimitIDIsValid(name, zone),
 					testAccManuallyDeleteRateLimit(name, &rateLimit, &initialRateLimitId),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccCheckCloudFlareRateLimitConfigMatchingUrl(zone, rnd),
+				Config: testAccCheckCloudflareRateLimitConfigMatchingUrl(zone, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRateLimitExists(name, &rateLimit),
-					testAccCheckCloudFlareRateLimitIDIsValid(name, zone),
+					testAccCheckCloudflareRateLimitExists(name, &rateLimit),
+					testAccCheckCloudflareRateLimitIDIsValid(name, zone),
 					func(state *terraform.State) error {
 						if initialRateLimitId == rateLimit.ID {
 							return fmt.Errorf("rate limit id is unchanged even after we thought we deleted it ( %s )",
@@ -166,7 +166,7 @@ func TestAccCloudFlareRateLimit_CreateAfterManualDestroy(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudFlareRateLimitDestroy(s *terraform.State) error {
+func testAccCheckCloudflareRateLimitDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -183,7 +183,7 @@ func testAccCheckCloudFlareRateLimitDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudFlareRateLimitExists(n string, rateLimit *cloudflare.RateLimit) resource.TestCheckFunc {
+func testAccCheckCloudflareRateLimitExists(n string, rateLimit *cloudflare.RateLimit) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -210,7 +210,7 @@ func testAccCheckCloudFlareRateLimitExists(n string, rateLimit *cloudflare.RateL
 	}
 }
 
-func testAccCheckCloudFlareRateLimitIDIsValid(n, expectedZone string) resource.TestCheckFunc {
+func testAccCheckCloudflareRateLimitIDIsValid(n, expectedZone string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -249,7 +249,7 @@ func testAccManuallyDeleteRateLimit(name string, rateLimit *cloudflare.RateLimit
 	}
 }
 
-func testAccCheckCloudFlareRateLimitConfigBasic(zone, id string) string {
+func testAccCheckCloudflareRateLimitConfigBasic(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
@@ -262,7 +262,7 @@ resource "cloudflare_rate_limit" "%[1]s" {
 }`, id, zone)
 }
 
-func testAccCheckCloudFlareRateLimitConfigMatchingUrl(zone, id string) string {
+func testAccCheckCloudflareRateLimitConfigMatchingUrl(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
@@ -280,7 +280,7 @@ resource "cloudflare_rate_limit" "%[1]s" {
 }`, id, zone)
 }
 
-func testAccCheckCloudFlareRateLimitConfigFullySpecified(zone, id string) string {
+func testAccCheckCloudflareRateLimitConfigFullySpecified(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -10,18 +10,18 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func resourceCloudFlareRecord() *schema.Resource {
+func resourceCloudflareRecord() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudFlareRecordCreate,
-		Read:   resourceCloudFlareRecordRead,
-		Update: resourceCloudFlareRecordUpdate,
-		Delete: resourceCloudFlareRecordDelete,
+		Create: resourceCloudflareRecordCreate,
+		Read:   resourceCloudflareRecordRead,
+		Update: resourceCloudflareRecordUpdate,
+		Delete: resourceCloudflareRecordDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudFlareRecordImport,
+			State: resourceCloudflareRecordImport,
 		},
 
 		SchemaVersion: 1,
-		MigrateState:  resourceCloudFlareRecordMigrateState,
+		MigrateState:  resourceCloudflareRecordMigrateState,
 		Schema: map[string]*schema.Schema{
 			"domain": {
 				Type:     schema.TypeString,
@@ -107,7 +107,7 @@ func resourceCloudFlareRecord() *schema.Resource {
 	}
 }
 
-func resourceCloudFlareRecordCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	newRecord := cloudflare.DNSRecord{
@@ -159,7 +159,7 @@ func resourceCloudFlareRecordCreate(d *schema.ResourceData, meta interface{}) er
 	d.Set("zone_id", zoneID)
 	newRecord.ZoneID = zoneID
 
-	log.Printf("[DEBUG] CloudFlare Record create configuration: %#v", newRecord)
+	log.Printf("[DEBUG] Cloudflare Record create configuration: %#v", newRecord)
 
 	r, err := client.CreateDNSRecord(zoneID, newRecord)
 	if err != nil {
@@ -174,12 +174,12 @@ func resourceCloudFlareRecordCreate(d *schema.ResourceData, meta interface{}) er
 
 	d.SetId(r.Result.ID)
 
-	log.Printf("[INFO] CloudFlare Record ID: %s", d.Id())
+	log.Printf("[INFO] Cloudflare Record ID: %s", d.Id())
 
-	return resourceCloudFlareRecordRead(d, meta)
+	return resourceCloudflareRecordRead(d, meta)
 }
 
-func resourceCloudFlareRecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -212,7 +212,7 @@ func resourceCloudFlareRecordRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceCloudFlareRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -238,24 +238,24 @@ func resourceCloudFlareRecordUpdate(d *schema.ResourceData, meta interface{}) er
 		updateRecord.TTL = ttl.(int)
 	}
 
-	log.Printf("[DEBUG] CloudFlare Record update configuration: %#v", updateRecord)
+	log.Printf("[DEBUG] Cloudflare Record update configuration: %#v", updateRecord)
 	err := client.UpdateDNSRecord(zoneID, d.Id(), updateRecord)
 	if err != nil {
-		return fmt.Errorf("Failed to update CloudFlare Record: %s", err)
+		return fmt.Errorf("Failed to update Cloudflare Record: %s", err)
 	}
 
-	return resourceCloudFlareRecordRead(d, meta)
+	return resourceCloudflareRecordRead(d, meta)
 }
 
-func resourceCloudFlareRecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRecordDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	log.Printf("[INFO] Deleting CloudFlare Record: %s, %s", zoneID, d.Id())
+	log.Printf("[INFO] Deleting Cloudflare Record: %s, %s", zoneID, d.Id())
 
 	err := client.DeleteDNSRecord(zoneID, d.Id())
 	if err != nil {
-		return fmt.Errorf("Error deleting CloudFlare Record: %s", err)
+		return fmt.Errorf("Error deleting Cloudflare Record: %s", err)
 	}
 
 	return nil
@@ -275,7 +275,7 @@ func expandStringMap(inVal interface{}) map[string]string {
 	return outVal
 }
 
-func resourceCloudFlareRecordImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareRecordImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 
 	// split the id so we can lookup

--- a/cloudflare/resource_cloudflare_record_migrate.go
+++ b/cloudflare/resource_cloudflare_record_migrate.go
@@ -9,18 +9,18 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func resourceCloudFlareRecordMigrateState(
+func resourceCloudflareRecordMigrateState(
 	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
-		log.Println("[INFO] Found CloudFlare Record State v0; migrating to v1")
-		return migrateCloudFlareRecordStateV0toV1(is, meta)
+		log.Println("[INFO] Found Cloudflare Record State v0; migrating to v1")
+		return migrateCloudflareRecordStateV0toV1(is, meta)
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}
 }
 
-func migrateCloudFlareRecordStateV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func migrateCloudflareRecordStateV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	if is.Empty() {
 		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
 		return is, nil
@@ -52,7 +52,7 @@ func migrateCloudFlareRecordStateV0toV1(is *terraform.InstanceState, meta interf
 		if is.Attributes["ttl"] != "" {
 			v, err := strconv.Atoi(is.Attributes["ttl"])
 			if err != nil {
-				return is, fmt.Errorf("Error converting ttl to int in CloudFlare Record Migration")
+				return is, fmt.Errorf("Error converting ttl to int in Cloudflare Record Migration")
 			}
 
 			if v != r.TTL {
@@ -63,7 +63,7 @@ func migrateCloudFlareRecordStateV0toV1(is *terraform.InstanceState, meta interf
 		if is.Attributes["proxied"] != "" {
 			b, err := strconv.ParseBool(is.Attributes["proxied"])
 			if err != nil {
-				return is, fmt.Errorf("Error converting proxied to bool in CloudFlare Record Migration")
+				return is, fmt.Errorf("Error converting proxied to bool in Cloudflare Record Migration")
 			}
 
 			if b != r.Proxied {
@@ -74,7 +74,7 @@ func migrateCloudFlareRecordStateV0toV1(is *terraform.InstanceState, meta interf
 		if is.Attributes["priority"] != "" {
 			v, err := strconv.Atoi(is.Attributes["priority"])
 			if err != nil {
-				return is, fmt.Errorf("Error converting priority to int in CloudFlare Record Migration")
+				return is, fmt.Errorf("Error converting priority to int in Cloudflare Record Migration")
 			}
 
 			if v != r.Priority {

--- a/cloudflare/resource_cloudflare_record_migrate_test.go
+++ b/cloudflare/resource_cloudflare_record_migrate_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestCloudFlareRecordMigrateState(t *testing.T) {
+func TestCloudflareRecordMigrateState(t *testing.T) {
 	// create the test server for mocking the API calls
-	ts := mockCloudFlareEnv()
+	ts := mockCloudflareEnv()
 	defer ts.Close()
 
-	// Create a CloudFlare client, overriding the BaseURL
+	// Create a Cloudflare client, overriding the BaseURL
 	cfMeta, err := cloudflare.New(
 		"sometoken",
 		"someemail",
@@ -25,7 +25,7 @@ func TestCloudFlareRecordMigrateState(t *testing.T) {
 	)
 
 	if err != nil {
-		t.Fatalf("Error building CloudFlare API: %s", err)
+		t.Fatalf("Error building Cloudflare API: %s", err)
 	}
 
 	cases := map[string]struct {
@@ -135,7 +135,7 @@ func TestCloudFlareRecordMigrateState(t *testing.T) {
 			ID:         tc.ID,
 			Attributes: tc.Attributes,
 		}
-		is, err := resourceCloudFlareRecordMigrateState(
+		is, err := resourceCloudflareRecordMigrateState(
 			tc.StateVersion, is, cfMeta)
 
 		if err != nil {
@@ -152,9 +152,9 @@ func TestCloudFlareRecordMigrateState(t *testing.T) {
 	}
 }
 
-// cloudflareEnv establishes a httptest server to mock out the CloudFlare API
+// cloudflareEnv establishes a httptest server to mock out the Cloudflare API
 // endpoints that we'll be calling.
-func mockCloudFlareEnv() *httptest.Server {
+func mockCloudflareEnv() *httptest.Server {
 	endpoints := mockEndpoints()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
@@ -176,7 +176,7 @@ func mockCloudFlareEnv() *httptest.Server {
 	return ts
 }
 
-// Stub out the two CloudFlare API routes that will be called
+// Stub out the two Cloudflare API routes that will be called
 func mockEndpoints() []*endpoint {
 	return []*endpoint{
 		&endpoint{

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccCloudFlareRecord_Basic(t *testing.T) {
+func TestAccCloudflareRecord_Basic(t *testing.T) {
 	t.Parallel()
 	var record cloudflare.DNSRecord
 	testStartTime := time.Now().UTC()
@@ -24,14 +24,14 @@ func TestAccCloudFlareRecord_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigBasic(domain, "tf-acctest-basic"),
+				Config: testAccCheckCloudflareRecordConfigBasic(domain, "tf-acctest-basic"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
-					testAccCheckCloudFlareRecordAttributes(&record),
-					testAccCheckCloudFlareRecordDates(resourceName, &record, testStartTime),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordAttributes(&record),
+					testAccCheckCloudflareRecordDates(resourceName, &record, testStartTime),
 					resource.TestCheckResourceAttr(
 						resourceName, "name", "tf-acctest-basic"),
 					resource.TestCheckResourceAttr(
@@ -56,7 +56,7 @@ func TestAccCloudFlareRecord_Basic(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRecord_CaseInsensitive(t *testing.T) {
+func TestAccCloudflareRecord_CaseInsensitive(t *testing.T) {
 	t.Parallel()
 	var record cloudflare.DNSRecord
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -65,23 +65,23 @@ func TestAccCloudFlareRecord_CaseInsensitive(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigBasic(domain, "tf-acctest-case-insensitive"),
+				Config: testAccCheckCloudflareRecordConfigBasic(domain, "tf-acctest-case-insensitive"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
-					testAccCheckCloudFlareRecordAttributes(&record),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordAttributes(&record),
 					resource.TestCheckResourceAttr(
 						resourceName, "name", "tf-acctest-case-insensitive"),
 				),
 			},
 			{
-				Config:   testAccCheckCloudFlareRecordConfigBasic(domain, "tf-acctest-CASE-INSENSITIVE"),
+				Config:   testAccCheckCloudflareRecordConfigBasic(domain, "tf-acctest-CASE-INSENSITIVE"),
 				PlanOnly: true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
-					testAccCheckCloudFlareRecordAttributes(&record),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordAttributes(&record),
 					resource.TestCheckResourceAttr(
 						resourceName, "name", "tf-acctest-case-insensitive"),
 				),
@@ -90,7 +90,7 @@ func TestAccCloudFlareRecord_CaseInsensitive(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRecord_Apex(t *testing.T) {
+func TestAccCloudflareRecord_Apex(t *testing.T) {
 	t.Parallel()
 	var record cloudflare.DNSRecord
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -99,13 +99,13 @@ func TestAccCloudFlareRecord_Apex(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigApex(domain),
+				Config: testAccCheckCloudflareRecordConfigApex(domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
-					testAccCheckCloudFlareRecordAttributes(&record),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordAttributes(&record),
 					resource.TestCheckResourceAttr(
 						resourceName, "name", "@"),
 					resource.TestCheckResourceAttr(
@@ -118,7 +118,7 @@ func TestAccCloudFlareRecord_Apex(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRecord_LOC(t *testing.T) {
+func TestAccCloudflareRecord_LOC(t *testing.T) {
 	t.Parallel()
 	var record cloudflare.DNSRecord
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -127,12 +127,12 @@ func TestAccCloudFlareRecord_LOC(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigLOC(domain),
+				Config: testAccCheckCloudflareRecordConfigLOC(domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
 					resource.TestCheckResourceAttr(
 						resourceName, "value", "37 46 46.000 N 122 23 35.000 W 0m 100m 0m 0m"),
 					resource.TestCheckResourceAttr(
@@ -145,7 +145,7 @@ func TestAccCloudFlareRecord_LOC(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRecord_SRV(t *testing.T) {
+func TestAccCloudflareRecord_SRV(t *testing.T) {
 	t.Parallel()
 	var record cloudflare.DNSRecord
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -154,12 +154,12 @@ func TestAccCloudFlareRecord_SRV(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigSRV(domain),
+				Config: testAccCheckCloudflareRecordConfigSRV(domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
 					resource.TestCheckResourceAttr(
 						resourceName, "hostname", fmt.Sprintf("_xmpp-client._tcp.%s", domain)),
 					resource.TestCheckResourceAttr(
@@ -174,7 +174,7 @@ func TestAccCloudFlareRecord_SRV(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRecord_Proxied(t *testing.T) {
+func TestAccCloudflareRecord_Proxied(t *testing.T) {
 	t.Parallel()
 	var record cloudflare.DNSRecord
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -183,12 +183,12 @@ func TestAccCloudFlareRecord_Proxied(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigProxied(domain, "tf-acctest-proxied"),
+				Config: testAccCheckCloudflareRecordConfigProxied(domain, "tf-acctest-proxied"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
 					resource.TestCheckResourceAttr(
 						resourceName, "proxiable", "true"),
 					resource.TestCheckResourceAttr(
@@ -205,7 +205,7 @@ func TestAccCloudFlareRecord_Proxied(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareRecord_Updated(t *testing.T) {
+func TestAccCloudflareRecord_Updated(t *testing.T) {
 	t.Parallel()
 	var record cloudflare.DNSRecord
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -215,27 +215,27 @@ func TestAccCloudFlareRecord_Updated(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigBasic(domain, recordName),
+				Config: testAccCheckCloudflareRecordConfigBasic(domain, recordName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
-					testAccCheckCloudFlareRecordAttributes(&record),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordAttributes(&record),
 				),
 			},
 			{
-				Config: testAccCheckCloudFlareRecordConfigNewValue(domain, recordName),
+				Config: testAccCheckCloudflareRecordConfigNewValue(domain, recordName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &record),
-					testAccCheckCloudFlareRecordAttributesUpdated(&record),
+					testAccCheckCloudflareRecordExists(resourceName, &record),
+					testAccCheckCloudflareRecordAttributesUpdated(&record),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCloudFlareRecord_typeForceNewRecord(t *testing.T) {
+func TestAccCloudflareRecord_typeForceNewRecord(t *testing.T) {
 	t.Parallel()
 	var afterCreate, afterUpdate cloudflare.DNSRecord
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -245,26 +245,26 @@ func TestAccCloudFlareRecord_typeForceNewRecord(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigBasic(domain, recordName),
+				Config: testAccCheckCloudflareRecordConfigBasic(domain, recordName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &afterCreate),
+					testAccCheckCloudflareRecordExists(resourceName, &afterCreate),
 				),
 			},
 			{
-				Config: testAccCheckCloudFlareRecordConfigChangeType(domain, recordName),
+				Config: testAccCheckCloudflareRecordConfigChangeType(domain, recordName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &afterUpdate),
-					testAccCheckCloudFlareRecordRecreated(&afterCreate, &afterUpdate),
+					testAccCheckCloudflareRecordExists(resourceName, &afterUpdate),
+					testAccCheckCloudflareRecordRecreated(&afterCreate, &afterUpdate),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCloudFlareRecord_hostnameForceNewRecord(t *testing.T) {
+func TestAccCloudflareRecord_hostnameForceNewRecord(t *testing.T) {
 	t.Parallel()
 	var afterCreate, afterUpdate cloudflare.DNSRecord
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -274,26 +274,26 @@ func TestAccCloudFlareRecord_hostnameForceNewRecord(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigBasic(domain, recordName),
+				Config: testAccCheckCloudflareRecordConfigBasic(domain, recordName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &afterCreate),
+					testAccCheckCloudflareRecordExists(resourceName, &afterCreate),
 				),
 			},
 			{
-				Config: testAccCheckCloudFlareRecordConfigChangeHostname(domain, recordName),
+				Config: testAccCheckCloudflareRecordConfigChangeHostname(domain, recordName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(resourceName, &afterUpdate),
-					testAccCheckCloudFlareRecordRecreated(&afterCreate, &afterUpdate),
+					testAccCheckCloudflareRecordExists(resourceName, &afterUpdate),
+					testAccCheckCloudflareRecordRecreated(&afterCreate, &afterUpdate),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCloudFlareRecord_CreateAfterManualDestroy(t *testing.T) {
+func TestAccCloudflareRecord_CreateAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 	var afterCreate, afterRecreate cloudflare.DNSRecord
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -302,28 +302,28 @@ func TestAccCloudFlareRecord_CreateAfterManualDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFlareRecordDestroy,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareRecordConfigBasic(zone, name),
+				Config: testAccCheckCloudflareRecordConfigBasic(zone, name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(name, &afterCreate),
+					testAccCheckCloudflareRecordExists(name, &afterCreate),
 					testAccManuallyDeleteRecord(&afterCreate),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccCheckCloudFlareRecordConfigBasic(zone, name),
+				Config: testAccCheckCloudflareRecordConfigBasic(zone, name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareRecordExists(name, &afterRecreate),
-					testAccCheckCloudFlareRecordRecreated(&afterCreate, &afterRecreate),
+					testAccCheckCloudflareRecordExists(name, &afterRecreate),
+					testAccCheckCloudflareRecordRecreated(&afterCreate, &afterRecreate),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckCloudFlareRecordRecreated(before, after *cloudflare.DNSRecord) resource.TestCheckFunc {
+func testAccCheckCloudflareRecordRecreated(before, after *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if before.ID == after.ID {
 			return fmt.Errorf("Expected change of Record Ids, but both were %v", before.ID)
@@ -332,7 +332,7 @@ func testAccCheckCloudFlareRecordRecreated(before, after *cloudflare.DNSRecord) 
 	}
 }
 
-func testAccCheckCloudFlareRecordDestroy(s *terraform.State) error {
+func testAccCheckCloudflareRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -360,7 +360,7 @@ func testAccManuallyDeleteRecord(record *cloudflare.DNSRecord) resource.TestChec
 	}
 }
 
-func testAccCheckCloudFlareRecordAttributes(record *cloudflare.DNSRecord) resource.TestCheckFunc {
+func testAccCheckCloudflareRecordAttributes(record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if record.Content != "192.168.0.10" {
@@ -371,7 +371,7 @@ func testAccCheckCloudFlareRecordAttributes(record *cloudflare.DNSRecord) resour
 	}
 }
 
-func testAccCheckCloudFlareRecordAttributesUpdated(record *cloudflare.DNSRecord) resource.TestCheckFunc {
+func testAccCheckCloudflareRecordAttributesUpdated(record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if record.Content != "192.168.0.11" {
@@ -382,7 +382,7 @@ func testAccCheckCloudFlareRecordAttributesUpdated(record *cloudflare.DNSRecord)
 	}
 }
 
-func testAccCheckCloudFlareRecordDates(n string, record *cloudflare.DNSRecord, testStartTime time.Time) resource.TestCheckFunc {
+func testAccCheckCloudflareRecordDates(n string, record *cloudflare.DNSRecord, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, _ := s.RootModule().Resources[n]
@@ -410,7 +410,7 @@ func testAccCheckCloudFlareRecordDates(n string, record *cloudflare.DNSRecord, t
 	}
 }
 
-func testAccCheckCloudFlareRecordExists(n string, record *cloudflare.DNSRecord) resource.TestCheckFunc {
+func testAccCheckCloudflareRecordExists(n string, record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -437,7 +437,7 @@ func testAccCheckCloudFlareRecordExists(n string, record *cloudflare.DNSRecord) 
 	}
 }
 
-func testAccCheckCloudFlareRecordConfigBasic(zone, name string) string {
+func testAccCheckCloudflareRecordConfigBasic(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%s"
@@ -449,7 +449,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudFlareRecordConfigApex(zone string) string {
+func testAccCheckCloudflareRecordConfigApex(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%s"
@@ -460,7 +460,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone)
 }
 
-func testAccCheckCloudFlareRecordConfigLOC(zone string) string {
+func testAccCheckCloudflareRecordConfigLOC(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%[1]s"
@@ -484,7 +484,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone)
 }
 
-func testAccCheckCloudFlareRecordConfigSRV(zone string) string {
+func testAccCheckCloudflareRecordConfigSRV(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%[1]s"
@@ -503,7 +503,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone)
 }
 
-func testAccCheckCloudFlareRecordConfigProxied(zone, name string) string {
+func testAccCheckCloudflareRecordConfigProxied(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%[1]s"
@@ -515,7 +515,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudFlareRecordConfigNewValue(zone, name string) string {
+func testAccCheckCloudflareRecordConfigNewValue(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%s"
@@ -527,7 +527,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudFlareRecordConfigChangeType(zone, name string) string {
+func testAccCheckCloudflareRecordConfigChangeType(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%[1]s"
@@ -539,7 +539,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudFlareRecordConfigChangeHostname(zone, name string) string {
+func testAccCheckCloudflareRecordConfigChangeHostname(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%s"

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -16,12 +16,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func resourceCloudFlareZoneSettingsOverride() *schema.Resource {
+func resourceCloudflareZoneSettingsOverride() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudFlareZoneSettingsOverrideCreate,
-		Read:   resourceCloudFlareZoneSettingsOverrideRead,
-		Update: resourceCloudFlareZoneSettingsOverrideUpdate,
-		Delete: resourceCloudFlareZoneSettingsOverrideDelete,
+		Create: resourceCloudflareZoneSettingsOverrideCreate,
+		Read:   resourceCloudflareZoneSettingsOverrideRead,
+		Update: resourceCloudflareZoneSettingsOverrideUpdate,
+		Delete: resourceCloudflareZoneSettingsOverrideDelete,
 
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
@@ -37,7 +37,7 @@ func resourceCloudFlareZoneSettingsOverride() *schema.Resource {
 				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: resourceCloudFlareZoneSettingsSchema,
+					Schema: resourceCloudflareZoneSettingsSchema,
 				},
 			},
 
@@ -46,7 +46,7 @@ func resourceCloudFlareZoneSettingsOverride() *schema.Resource {
 				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: resourceCloudFlareZoneSettingsSchema,
+					Schema: resourceCloudflareZoneSettingsSchema,
 				},
 			},
 
@@ -76,7 +76,7 @@ func resourceCloudFlareZoneSettingsOverride() *schema.Resource {
 	}
 }
 
-var resourceCloudFlareZoneSettingsSchema = map[string]*schema.Schema{
+var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 	"advanced_ddos": {
 		Type:         schema.TypeString,
 		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
@@ -459,7 +459,7 @@ var resourceCloudFlareZoneSettingsSchema = map[string]*schema.Schema{
 	},
 }
 
-func resourceCloudFlareZoneSettingsOverrideCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneSettingsOverrideCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	zoneId, err := client.ZoneIDByName(d.Get("name").(string))
@@ -476,7 +476,7 @@ func resourceCloudFlareZoneSettingsOverrideCreate(d *schema.ResourceData, meta i
 		return errors.Wrap(err, fmt.Sprintf("Error reading initial settings for zone %q", d.Id()))
 	}
 
-	log.Printf("[DEBUG] Read CloudFlareZone initial settings: %#v", zoneSettings)
+	log.Printf("[DEBUG] Read CloudflareZone initial settings: %#v", zoneSettings)
 
 	if err := d.Set("initial_settings", flattenZoneSettings(d, zoneSettings.Result, true)); err != nil {
 		log.Printf("[WARN] Error setting initial_settings for zone %q: %s", d.Id(), err)
@@ -488,12 +488,12 @@ func resourceCloudFlareZoneSettingsOverrideCreate(d *schema.ResourceData, meta i
 		log.Printf("[WARN] Error setting readonly_settings for zone %q: %s", d.Id(), err)
 	}
 
-	log.Printf("[DEBUG] Saved CloudFlareZone initial settings: %#v", d.Get("initial_settings"))
+	log.Printf("[DEBUG] Saved CloudflareZone initial settings: %#v", d.Get("initial_settings"))
 
-	return resourceCloudFlareZoneSettingsOverrideUpdate(d, meta)
+	return resourceCloudflareZoneSettingsOverrideUpdate(d, meta)
 }
 
-func resourceCloudFlareZoneSettingsOverrideRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneSettingsOverrideRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	zone, err := client.ZoneDetails(d.Id())
@@ -514,7 +514,7 @@ func resourceCloudFlareZoneSettingsOverrideRead(d *schema.ResourceData, meta int
 		return errors.Wrap(err, fmt.Sprintf("Error reading settings for zone %q", d.Id()))
 	}
 
-	log.Printf("[DEBUG] Read CloudFlareZone Settings: %#v", zoneSettings)
+	log.Printf("[DEBUG] Read CloudflareZone Settings: %#v", zoneSettings)
 
 	d.Set("status", zone.Status)
 	d.Set("type", zone.Type)
@@ -561,13 +561,13 @@ func flattenZoneSettings(d *schema.ResourceData, settings []cloudflare.ZoneSetti
 		}
 	}
 
-	log.Printf("[DEBUG] Flattened CloudFlare Zone Settings: %#v", cfg)
+	log.Printf("[DEBUG] Flattened Cloudflare Zone Settings: %#v", cfg)
 
 	return []map[string]interface{}{cfg}
 }
 
 func settingInSchema(val string) bool {
-	for k, _ := range resourceCloudFlareZoneSettingsSchema {
+	for k, _ := range resourceCloudflareZoneSettingsSchema {
 		if val == k {
 			return true
 		}
@@ -582,12 +582,12 @@ func flattenReadOnlyZoneSettings(settings []cloudflare.ZoneSetting) []string {
 			ids = append(ids, zs.ID)
 		}
 	}
-	log.Printf("[DEBUG] Flattened CloudFlare Read Only Zone Settings: %#v", ids)
+	log.Printf("[DEBUG] Flattened Cloudflare Read Only Zone Settings: %#v", ids)
 
 	return ids
 }
 
-func resourceCloudFlareZoneSettingsOverrideUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneSettingsOverrideUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	if cfg, ok := d.GetOk("settings"); ok && cfg != nil && len(cfg.([]interface{})) > 0 {
@@ -598,7 +598,7 @@ func resourceCloudFlareZoneSettingsOverrideUpdate(d *schema.ResourceData, meta i
 			return err
 		}
 
-		log.Printf("[DEBUG] CloudFlare Zone Settings update configuration: %#v", zoneSettings)
+		log.Printf("[DEBUG] Cloudflare Zone Settings update configuration: %#v", zoneSettings)
 
 		if len(zoneSettings) > 0 {
 			_, err = client.UpdateZoneSettings(d.Id(), zoneSettings)
@@ -610,7 +610,7 @@ func resourceCloudFlareZoneSettingsOverrideUpdate(d *schema.ResourceData, meta i
 		}
 	}
 
-	return resourceCloudFlareZoneSettingsOverrideRead(d, meta)
+	return resourceCloudflareZoneSettingsOverrideRead(d, meta)
 }
 
 func expandOverriddenZoneSettings(d *schema.ResourceData, settingsKey string, readOnlySettings []string) ([]cloudflare.ZoneSetting, error) {
@@ -618,7 +618,7 @@ func expandOverriddenZoneSettings(d *schema.ResourceData, settingsKey string, re
 
 	keyFormat := fmt.Sprintf("%s.0.%%s", settingsKey)
 
-	for k, _ := range resourceCloudFlareZoneSettingsSchema {
+	for k, _ := range resourceCloudflareZoneSettingsSchema {
 
 		// we only update if the user set the value non-empty before, and its different from the read value
 		// note that if user removes an attribute, we don't do anything
@@ -686,7 +686,7 @@ func expandZoneSetting(d *schema.ResourceData, keyFormatString, k string, settin
 	return zoneSettingValue, nil
 }
 
-func resourceCloudFlareZoneSettingsOverrideDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneSettingsOverrideDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
 	if cfg, ok := d.GetOk("settings"); ok && cfg != nil && len(cfg.([]interface{})) > 0 {
@@ -698,7 +698,7 @@ func resourceCloudFlareZoneSettingsOverrideDelete(d *schema.ResourceData, meta i
 			return err
 		}
 
-		log.Printf("[DEBUG] Reverting CloudFlare Zone Settings to initial settings with update configuration: %#v", zoneSettings)
+		log.Printf("[DEBUG] Reverting Cloudflare Zone Settings to initial settings with update configuration: %#v", zoneSettings)
 
 		if len(zoneSettings) > 0 {
 			_, err = client.UpdateZoneSettings(d.Id(), zoneSettings)
@@ -717,7 +717,7 @@ func expandRevertibleZoneSettings(d *schema.ResourceData, readOnlySettings []str
 
 	keyFormat := fmt.Sprintf("%s.0.%%s", "initial_settings")
 
-	for k, _ := range resourceCloudFlareZoneSettingsSchema {
+	for k, _ := range resourceCloudflareZoneSettingsSchema {
 
 		initialKey := fmt.Sprintf("initial_settings.0.%s", k)
 		initialVal := d.Get(initialKey)

--- a/cloudflare/resource_cloudflare_zone_settings_override_test.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-func TestAccCloudFlareZoneSettingsOverride_Empty(t *testing.T) {
+func TestAccCloudflareZoneSettingsOverride_Empty(t *testing.T) {
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	name := "cloudflare_zone_settings_override.test"
 
@@ -21,16 +21,16 @@ func TestAccCloudFlareZoneSettingsOverride_Empty(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareZoneSettingsOverrideConfigEmpty(zoneName),
+				Config: testAccCheckCloudflareZoneSettingsOverrideConfigEmpty(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareZoneSettingsEmpty(name),
+					testAccCheckCloudflareZoneSettingsEmpty(name),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCloudFlareZoneSettingsOverride_Full(t *testing.T) {
+func TestAccCloudflareZoneSettingsOverride_Full(t *testing.T) {
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	name := "cloudflare_zone_settings_override.test"
 
@@ -40,15 +40,15 @@ func TestAccCloudFlareZoneSettingsOverride_Full(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareZoneSettingsOverrideConfigEmpty(zoneName),
+				Config: testAccCheckCloudflareZoneSettingsOverrideConfigEmpty(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGetInitialZoneSettings(t, zoneName, initialSettings),
 				),
 			},
 			{
-				Config: testAccCheckCloudFlareZoneSettingsOverrideConfigNormal(zoneName),
+				Config: testAccCheckCloudflareZoneSettingsOverrideConfigNormal(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareZoneSettings(name),
+					testAccCheckCloudflareZoneSettings(name),
 					resource.TestCheckResourceAttr(
 						name, "settings.0.brotli", "on"),
 					resource.TestCheckResourceAttr(
@@ -62,7 +62,7 @@ func TestAccCloudFlareZoneSettingsOverride_Full(t *testing.T) {
 	})
 }
 
-func TestAccCloudFlareZoneSettingsOverride_RemoveAttributes(t *testing.T) {
+func TestAccCloudflareZoneSettingsOverride_RemoveAttributes(t *testing.T) {
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	name := "cloudflare_zone_settings_override.test"
 
@@ -72,21 +72,21 @@ func TestAccCloudFlareZoneSettingsOverride_RemoveAttributes(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudFlareZoneSettingsOverrideConfigEmpty(zoneName),
+				Config: testAccCheckCloudflareZoneSettingsOverrideConfigEmpty(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGetInitialZoneSettings(t, zoneName, initialSettings),
 				),
 			},
 			{
-				Config: testAccCheckCloudFlareZoneSettingsOverrideConfigNormal(zoneName),
+				Config: testAccCheckCloudflareZoneSettingsOverrideConfigNormal(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareZoneSettings(name),
+					testAccCheckCloudflareZoneSettings(name),
 				),
 			},
 			{
-				Config: testAccCheckCloudFlareZoneSettingsOverrideConfigEmpty(zoneName),
+				Config: testAccCheckCloudflareZoneSettingsOverrideConfigEmpty(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFlareZoneSettings(name),
+					testAccCheckCloudflareZoneSettings(name),
 				),
 			},
 		},
@@ -94,7 +94,7 @@ func TestAccCloudFlareZoneSettingsOverride_RemoveAttributes(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudFlareZoneSettingsEmpty(n string) resource.TestCheckFunc {
+func testAccCheckCloudflareZoneSettingsEmpty(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -120,7 +120,7 @@ func testAccCheckCloudFlareZoneSettingsEmpty(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckCloudFlareZoneSettings(n string) resource.TestCheckFunc {
+func testAccCheckCloudflareZoneSettings(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -209,14 +209,14 @@ func testAccCheckInitialZoneSettings(zoneName string, initialSettings map[string
 	}
 }
 
-func testAccCheckCloudFlareZoneSettingsOverrideConfigEmpty(zone string) string {
+func testAccCheckCloudflareZoneSettingsOverrideConfigEmpty(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_zone_settings_override" "test" {
 	name = "%s"
 }`, zone)
 }
 
-func testAccCheckCloudFlareZoneSettingsOverrideConfigNormal(zone string) string {
+func testAccCheckCloudflareZoneSettingsOverrideConfigNormal(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_zone_settings_override" "test" {
 	name = "%s"

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -3,12 +3,12 @@ layout: "cloudflare"
 page_title: "Cloudflare: cloudflare_zone_settings_override"
 sidebar_current: "docs-cloudflare-resource-zone-settings-override"
 description: |-
-  Provides a resource which customizes CloudFlare zone settings.
+  Provides a resource which customizes Cloudflare zone settings.
 ---
 
 # cloudflare_zone_settings_override
 
-Provides a resource which customizes CloudFlare zone settings. Note that after destroying this resource Zone Settings will be reset to their initial values.
+Provides a resource which customizes Cloudflare zone settings. Note that after destroying this resource Zone Settings will be reset to their initial values.
 
 ## Example Usage
 


### PR DESCRIPTION
This PR updates the usage of Cloudflare to accurately reflect their name.

Cloudflare is a single word, not two as CloudFlare usages suggest.