### PR TITLE
Update rocket loader page rules options

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -257,7 +257,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 						"rocket_loader": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"off", "manual", "automatic"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"off", "on"}, false),
 						},
 
 						"security_level": {

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -184,7 +184,7 @@ func TestAccCloudflarePageRule_CreateAfterManualDestroy(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cloudflare_page_rule.test", "actions.0.browser_check", "on"),
 					resource.TestCheckResourceAttr(
-						"cloudflare_page_rule.test", "actions.0.rocket_loader", "automatic"),
+						"cloudflare_page_rule.test", "actions.0.rocket_loader", "on"),
 					resource.TestCheckResourceAttr(
 						"cloudflare_page_rule.test", "actions.0.ssl", "strict"),
 				),
@@ -361,7 +361,7 @@ func testAccCheckCloudflarePageRuleAttributesUpdated(pageRule *cloudflare.PageRu
 		}
 
 		if val, ok := actionMap["rocket_loader"]; ok {
-			if _, ok := val.(string); !ok || val != "automatic" {
+			if _, ok := val.(string); !ok || val != "on" {
 				return fmt.Errorf("'rocket_loader' not specified correctly at api, found: %q", val)
 			}
 		} else {
@@ -444,7 +444,7 @@ resource "cloudflare_page_rule" "test" {
 		browser_check = "on"
 		disable_apps = false
 		ssl = "strict"
-		rocket_loader = "automatic"
+		rocket_loader = "on"
 	}
 }`, zone, target)
 }

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -58,7 +58,7 @@ Action blocks support the following:
 * `forwarding_url` - (Optional) The URL to forward to, and with what status. See below.
 * `host_header_override` - (Optional) Value of the Host header to send.
 * `resolve_override` - (Optional) Overridden origin server name.
-* `rocket_loader` - (Optional) Whether to set the rocket loader to `"off"`, `"manual"`, or `"automatic"`.
+* `rocket_loader` - (Optional) Whether to set the rocket loader to `"on"` or `"off"`.
 * `security_level` - (Optional) Whether to set the security level to `"off"`, `"essentially_off"`, `"low"`, `"medium"`, `"high"`, or `"under_attack"`.
 * `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, or `"strict"`.
 * `waf` - (Optional) Whether this action is `"on"` or `"off"`.


### PR DESCRIPTION
The rocket loader options have changed and needs updating on the page rules options. This PR updates the rocket loader to the new options of "on" and "off", as well as updating tests and the website documents.