### PR TITLE
Fix page rule example

### DIFF
--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -16,7 +16,7 @@ Provides a Cloudflare page rule resource.
 # Add a page rule to the domain
 resource "cloudflare_page_rule" "foobar" {
   zone = "${var.cloudflare_domain}"
-  target = "sub.${self.domain}/page"
+  target = "sub.${var.cloudflare_domain}/page"
   priority = 1
 
   actions = {


### PR DESCRIPTION
I believe that `self.domain` is invalid here. I tried using the example and it errors.