### PR TITLE
Add support for WAF Rule configuration

### DIFF
--- a/cloudflare/import_cloudflare_waf_rule_test.go
+++ b/cloudflare/import_cloudflare_waf_rule_test.go
@@ -1,0 +1,32 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccCloudflareWAFRule_Import(t *testing.T) {
+	t.Parallel()
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	ruleID := "100000"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareWAFRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareWAFRuleConfig(zone, ruleID, "block"),
+			},
+			{
+				ResourceName:        "cloudflare_waf_rule." + ruleID,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", zone),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -90,6 +90,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_load_balancer":          resourceCloudflareLoadBalancer(),
 			"cloudflare_load_balancer_pool":     resourceCloudflareLoadBalancerPool(),
 			"cloudflare_zone_settings_override": resourceCloudflareZoneSettingsOverride(),
+			"cloudflare_waf_rule":               resourceCloudflareWAFRule(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -1,0 +1,197 @@
+package cloudflare
+
+import (
+	"fmt"
+	"strings"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceCloudflareWAFRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareWAFRuleCreate,
+		Read:   resourceCloudflareWAFRuleRead,
+		Update: resourceCloudflareWAFRuleUpdate,
+		Delete: resourceCloudflareWAFRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareWAFRuleImport,
+		},
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"rule_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"zone": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"package_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceCloudflareWAFRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	ruleID := d.Get("rule_id").(string)
+	zoneID := d.Get("zone_id").(string)
+	packageID := d.Get("package_id").(string)
+
+	rule, err := client.WAFRule(zoneID, packageID, ruleID)
+	if err != nil {
+		return (err)
+	}
+
+	// Only need to set mode as that is the only attribute that could have changed
+	d.Set("mode", rule.Mode)
+	d.SetId(rule.ID)
+
+	return nil
+}
+
+func resourceCloudflareWAFRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	ruleID := d.Get("rule_id").(string)
+	zone := d.Get("zone").(string)
+	mode := d.Get("mode").(string)
+
+	zoneID, err := client.ZoneIDByName(zone)
+	if err != nil {
+		return err
+	}
+
+	packs, err := client.ListWAFPackages(zoneID)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range packs {
+		rule, err := client.WAFRule(zoneID, p.ID, ruleID)
+
+		if err == nil {
+			d.Set("zone", zone)
+			d.Set("zone_id", zoneID)
+			d.Set("package_id", rule.PackageID)
+			d.Set("mode", mode)
+
+			// Set the ID to the rule_id parameter passed in from the user.
+			// All WAF rules already exist so we already know the rule_id e.g. 100000.
+			//
+			// This is a work around as we are not really "creating" a WAF Rule,
+			// only associating it with our terraform config for future updates.
+			d.SetId(ruleID)
+
+			if rule.Mode != mode {
+				return resourceCloudflareWAFRuleUpdate(d, meta)
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Unable to find WAF Rule %s", ruleID)
+}
+
+func resourceCloudflareWAFRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	ruleID := d.Get("rule_id").(string)
+	zoneID := d.Get("zone_id").(string)
+	packageID := d.Get("package_id").(string)
+
+	rule, err := client.WAFRule(zoneID, packageID, ruleID)
+	if err != nil {
+		return err
+	}
+
+	// Can't delete WAF Rule so instead reset it to default
+	if rule.Mode != "default" {
+		_, err = client.UpdateWAFRule(zoneID, packageID, ruleID, "default")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceCloudflareWAFRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	ruleID := d.Get("rule_id").(string)
+	zoneID := d.Get("zone_id").(string)
+	mode := d.Get("mode").(string)
+	packageID := d.Get("package_id").(string)
+
+	// We can only update the mode of a WAF Rule
+	_, err := client.UpdateWAFRule(zoneID, packageID, ruleID, mode)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceCloudflareWAFRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*cloudflare.API)
+
+	// split the id so we can lookup
+	idAttr := strings.SplitN(d.Id(), "/", 2)
+	var zoneName string
+	var WAFID string
+	if len(idAttr) == 2 {
+		zoneName = idAttr[0]
+		WAFID = idAttr[1]
+	} else {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneName/WAFID\" for import", d.Id())
+	}
+
+	zoneID, err := client.ZoneIDByName(zoneName)
+	if err != nil {
+		return nil, fmt.Errorf("error finding zoneName %q: %s", zoneName, err)
+	}
+
+	packs, err := client.ListWAFPackages(zoneID)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, p := range packs {
+		rule, err := client.WAFRule(zoneID, p.ID, WAFID)
+		if err == nil {
+			d.Set("rule_id", rule.ID)
+			d.Set("zone", zoneName)
+			d.Set("zone_id", zoneID)
+			d.Set("package_id", rule.PackageID)
+			d.Set("mode", rule.Mode)
+
+			// The ID is known by the user in advance
+			d.SetId(WAFID)
+		}
+	}
+
+	if d.Id() != WAFID {
+		return nil, fmt.Errorf("Unable to find WAF Rule %s", WAFID)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/cloudflare/resource_cloudflare_waf_rule_test.go
+++ b/cloudflare/resource_cloudflare_waf_rule_test.go
@@ -1,0 +1,77 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudflareWAFRule_CreateThenUpdate(t *testing.T) {
+	t.Parallel()
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	ruleID := "100000"
+
+	name := "cloudflare_waf_rule." + ruleID
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareWAFRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareWAFRuleConfig(zone, ruleID, "simulate"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "rule_id", ruleID),
+					resource.TestCheckResourceAttr(name, "zone", zone),
+					resource.TestCheckResourceAttrSet(name, "zone_id"),
+					resource.TestCheckResourceAttrSet(name, "package_id"),
+					resource.TestCheckResourceAttr(name, "mode", "simulate"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareWAFRuleConfig(zone, ruleID, "challenge"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "rule_id", ruleID),
+					resource.TestCheckResourceAttr(name, "zone", zone),
+					resource.TestCheckResourceAttrSet(name, "zone_id"),
+					resource.TestCheckResourceAttrSet(name, "package_id"),
+					resource.TestCheckResourceAttr(name, "mode", "challenge"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareWAFRuleDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_waf_rule" {
+			continue
+		}
+
+		rule, err := client.WAFRule(rs.Primary.Attributes["zone_id"], rs.Primary.Attributes["package_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if rule.Mode != "default" {
+			return fmt.Errorf("Expected mode to be reset to default, got: %s", rule.Mode)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudflareWAFRuleConfig(zone, ruleID, mode string) string {
+	return fmt.Sprintf(`
+				resource "cloudflare_waf_rule" "%[2]s" {
+					rule_id = %[2]s
+					zone = "%[1]s"
+					mode = "%[3]s"
+				}`, zone, ruleID, mode)
+}

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_waf_rule"
+sidebar_current: "docs-cloudflare-resource-waf-rule"
+description: |-
+  Provides a Cloudflare WAF rule resource for a particular zone.
+---
+
+# cloudflare_waf_rule
+
+Provides a Cloudflare WAF rule resource for a particular zone. This can be used to configure firewall behaviour for pre-defined firewall rules.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_waf_rule" "100000" {
+  rule_id = "100000"
+  zone = "domain.com"
+  mode = "simulate"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone` - (Required) The DNS zone to apply to.
+* `rule_id` - (Required) The WAF Rule ID.
+* `mode` - (Required) The mode of the rule, can be one of ["block", "challenge", "default", "disable, "simulate"].
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The WAF Rule ID, the same as rule_id.
+* `zone_id` - The DNS zone ID.
+* `package_id` - The ID of the WAF Rule Package that contains the rule.
+
+## Import
+
+Rules can be imported using a composite ID formed of zone name and the WAF Rule ID, e.g.
+
+```
+$ terraform import cloudflare_waf_rule.100000 example.com/100000
+```


### PR DESCRIPTION
Note that since WAF rules already exist for an account we're not
really "creating" them, only pointing to them and storing their
state.

Since the ID is known at creation time and we need to "point"
to the actual WAF rule, I've added "rule_id" as an attribute that
the user can set based on the ID they can see in the UI.

An example configuration looks like this:

```
resource "cloudflare_waf_rule" "100000" {
  rule_id = "100000"
  zone = "domain.com"
  mode = "simulate"
}
```

The create function will look up the WAF rule 100000, update
it's state depending on the mode passed in by the user, then
store the result.

The read function checks for any updates to the mode of the WAF rule.

The update function attempts to modify the mode of a WAF rule.

The delete function attempts to set the WAF rule to its default
mode.

Import is also implemented and tested in the convention of other
import test files in the repo.