### PR TITLE
Add support for importing `account_members`

### DIFF
--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -15,6 +15,9 @@ func resourceCloudflareAccountMember() *schema.Resource {
 		Read:   resourceCloudflareAccountMemberRead,
 		Update: resourceCloudflareAccountMemberUpdate,
 		Delete: resourceCloudflareAccountMemberDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareAccountMemberImport,
+		},
 
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
@@ -107,4 +110,37 @@ func resourceCloudflareAccountMemberUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	return resourceCloudflareAccountMemberRead(d, meta)
+}
+
+func resourceCloudflareAccountMemberImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*cloudflare.API)
+
+	// split the id so we can lookup the account member
+	idAttr := strings.SplitN(d.Id(), "/", 2)
+	var accountID string
+	var accountMemberID string
+	if len(idAttr) == 2 {
+		accountID = idAttr[0]
+		accountMemberID = idAttr[1]
+	} else {
+		return nil, fmt.Errorf("invalid id %q specified, should be in format \"accountID/accountMemberID\" for import", d.Id())
+	}
+
+	member, err := client.AccountMember(accountID, accountMemberID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find account member with ID %q: %q", accountMemberID, err)
+	}
+
+	log.Printf("[INFO] Found account member: %s", member.User.Email)
+
+	var memberIDs []string
+	for _, role := range member.Roles {
+		memberIDs = append(memberIDs, role.ID)
+	}
+
+	d.Set("email_address", member.User.Email)
+	d.Set("role_ids", memberIDs)
+	d.SetId(accountMemberID)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/account_member.markdown
+++ b/website/docs/r/account_member.markdown
@@ -28,3 +28,16 @@ The following arguments are supported:
 
 * `email_address` - (Required) The email address of the user who you wish to manage. Note: Following creation, this field becomes read only via the API and cannot be updated.
 * `role_ids` - (Required) Array of account role IDs that you want to assign to a member.
+
+## Import
+
+Account members can be imported using a composite ID formed of account ID and account member ID, e.g.
+
+```
+$ terraform import cloudflare_access_rule.example_user d41d8cd98f00b204e9800998ecf8427e/b58c6f14d292556214bd64909bcdb118
+```
+
+where:
+
+* `d41d8cd98f00b204e9800998ecf8427e` - account ID as returned by the [API](https://api.cloudflare.com/#accounts-account-details)
+* `b58c6f14d292556214bd64909bcdb118` - account member ID as returned by the [API](https://api.cloudflare.com/#account-members-member-details)


### PR DESCRIPTION
Creates the ability to use Terraform's import functionality for the
`account_member` resource.