### PR TITLE
Adds validation to cloudflare_record to ensure TTL is not set while proxied is true

### DIFF
--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -321,6 +321,10 @@ func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if ttl, ok := d.GetOk("ttl"); ok {
+		if ttl.(int) != 1 && newRecord.Proxied {
+			return fmt.Errorf("error validating record %s: ttl cannot be set when `proxied` is true", newRecord.Name)
+		}
+
 		newRecord.TTL = ttl.(int)
 	}
 
@@ -437,6 +441,10 @@ func resourceCloudflareRecordUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if ttl, ok := d.GetOk("ttl"); ok {
+		if ttl.(int) != 1 && updateRecord.Proxied {
+			return fmt.Errorf("error validating record %s: ttl cannot be set when `proxied` is true", updateRecord.Name)
+		}
+
 		updateRecord.TTL = ttl.(int)
 	}
 

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -442,7 +442,7 @@ func resourceCloudflareRecordUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if ttl, ok := d.GetOk("ttl"); ok {
 		if ttl.(int) != 1 && updateRecord.Proxied {
-			return fmt.Errorf("error validating record %s: ttl cannot be set when `proxied` is true", updateRecord.Name)
+			return fmt.Errorf("error validating record %s: ttl must be set to 1 when `proxied` is true", updateRecord.Name)
 		}
 
 		updateRecord.TTL = ttl.(int)

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -322,7 +322,7 @@ func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) er
 
 	if ttl, ok := d.GetOk("ttl"); ok {
 		if ttl.(int) != 1 && newRecord.Proxied {
-			return fmt.Errorf("error validating record %s: ttl cannot be set when `proxied` is true", newRecord.Name)
+			return fmt.Errorf("error validating record %s: ttl must be set to 1 when `proxied` is true", newRecord.Name)
 		}
 
 		newRecord.TTL = ttl.(int)

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -335,7 +335,7 @@ func TestAccCloudflareRecord_TtlValidation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckCloudflareRecordConfigTtlValidation(domain, recordName),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("error validating record %s:ttl must be set to 1 when `proxied` is true", recordName)),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("error validating record %s: ttl must be set to 1 when `proxied` is true", recordName)),
 			},
 		},
 	})

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -335,7 +335,7 @@ func TestAccCloudflareRecord_TtlValidation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckCloudflareRecordConfigTtlValidation(domain, recordName),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("error validating record %s: ttl cannot be set when `proxied` is true", recordName)),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("error validating record %s:ttl must be set to 1 when `proxied` is true", recordName)),
 			},
 		},
 	})

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -360,7 +360,7 @@ func TestAccCloudflareRecord_TtlValidationUpdate(t *testing.T) {
 			},
 			{
 				Config:      testAccCheckCloudflareRecordConfigTtlValidation(domain, recordName),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("error validating record %s: ttl cannot be set when `proxied` is true", recordName)),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("error validating record %s: ttl must be set to 1 when `proxied` is true", recordName)),
 			},
 		},
 	})

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -323,6 +323,49 @@ func TestAccCloudflareRecord_CreateAfterManualDestroy(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareRecord_TtlValidation(t *testing.T) {
+	t.Parallel()
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	recordName := "tf-acctest-ttl-validation"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckCloudflareRecordConfigTtlValidation(domain, recordName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("error validating record %s: ttl cannot be set when `proxied` is true", recordName)),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRecord_TtlValidationUpdate(t *testing.T) {
+	t.Parallel()
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	recordName := "tf-acctest-ttl-validation"
+	name := "cloudflare_record.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRecordConfigProxied(domain, recordName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareRecordExists(name, &cloudflare.DNSRecord{}),
+				),
+			},
+			{
+				Config:      testAccCheckCloudflareRecordConfigTtlValidation(domain, recordName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("error validating record %s: ttl cannot be set when `proxied` is true", recordName)),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareRecordRecreated(before, after *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if before.ID == after.ID {
@@ -547,6 +590,19 @@ resource "cloudflare_record" "foobar" {
 	name = "%s-changed"
 	value = "192.168.0.10"
 	type = "A"
+	ttl = 3600
+}`, zone, name)
+}
+
+func testAccCheckCloudflareRecordConfigTtlValidation(zone, name string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_record" "foobar" {
+	domain = "%[1]s"
+
+	name = "%[2]s"
+	value = "%[1]s"
+	type = "CNAME"
+	proxied = true
 	ttl = 3600
 }`, zone, name)
 }


### PR DESCRIPTION
Closes #126 

Tests:

```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccCloudflareRecord_TtlValidation* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-cloudflare	[no test files]
=== RUN   TestAccCloudflareRecord_TtlValidation
=== PAUSE TestAccCloudflareRecord_TtlValidation
=== RUN   TestAccCloudflareRecord_TtlValidationUpdate
=== PAUSE TestAccCloudflareRecord_TtlValidationUpdate
=== CONT  TestAccCloudflareRecord_TtlValidation
=== CONT  TestAccCloudflareRecord_TtlValidationUpdate
--- PASS: TestAccCloudflareRecord_TtlValidation (0.02s)
--- PASS: TestAccCloudflareRecord_TtlValidationUpdate (3.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-cloudflare/cloudflare	3.738s
```