### PR TITLE
Ignore `account_member` role ID ordering

### DIFF
--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -30,6 +30,14 @@ func resourceCloudflareAccountMember() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					roleIDs := d.Get("role_ids").([]interface{})
+					if arrayContains(old, roleIDs) && arrayContains(new, roleIDs) {
+						return true
+					}
+
+					return false
+				},
 			},
 		},
 	}
@@ -143,4 +151,13 @@ func resourceCloudflareAccountMemberImport(d *schema.ResourceData, meta interfac
 	d.SetId(accountMemberID)
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func arrayContains(a string, list []interface{}) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
After we imported our users to Terraform we ordered the roles
alphabetically using a variable map for readability. Once we started
applying changes we noticed that the resource would be marked as needing
replacement despite nothing changing. Turns out the reason was the role
ID ordering.

There are a few ways I could have solved this however I opted for the
simplest of just checking that the old and new values are both present
somewhere in the roles and if they were, suppress the change diff.

This doesn't impact any functionality however it does allow a little
more flexibility if you have a particular way you want the roles ordered
and not want to follow Cloudflare's API response of lexically sorting on
the ID.