### PR TITLE
Update rate limit validation to allow 1

### DIFF
--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -37,7 +37,7 @@ func resourceCloudflareRateLimit() *schema.Resource {
 			"threshold": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(2, 1000000),
+				ValidateFunc: validation.IntBetween(1, 1000000),
 			},
 
 			"period": {


### PR DESCRIPTION
Despite what the documentation states, 1 is valid here (at least for
Enterprise customers).

Have raised ticket 1589750 to get the documentation updated.