### PR TITLE
Origin traffic isn't default anymore

### DIFF
--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -453,8 +453,10 @@ func flattenRateLimitRequestMatcher(cfg cloudflare.RateLimitRequestMatcher) []ma
 }
 
 func flattenRateLimitResponseMatcher(cfg cloudflare.RateLimitResponseMatcher) []map[string]interface{} {
-	data := map[string]interface{}{
-		"origin_traffic": *cfg.OriginTraffic,
+	data := map[string]interface{}{}
+
+	if cfg.OriginTraffic != nil {
+		data["origin_traffic"] = *cfg.OriginTraffic
 	}
 
 	if len(cfg.Statuses) > 0 {


### PR DESCRIPTION
While porting existing rate limits into Terraform, I hit the following
nil pointer error.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1809d04]

goroutine 3 [running]:
github.com/terraform-providers/terraform-provider-cloudflare/cloudflare.flattenRateLimitResponseMatcher(0x0, 0x0, 0x0, 0x0, 0x1, 0x4, 0xc0005d5ce0)
/Users/jacob/src/go/src/github.com/terraform-providers/terraform-provider-cloudflare/cloudflare/resource_cloudflare_rate_limit.go:459 +0x34
github.com/terraform-providers/terraform-provider-cloudflare/cloudflare.flattenRateLimitTrafficMatcher(0xc00007c840, 0x1, 0x4, 0xc00007c880, 0x1, 0x4, 0xc0005d5ce0, 0x18, 0x0, 0x0, ...)
/Users/jacob/src/go/src/github.com/terraform-providers/terraform-provider-cloudflare/cloudflare/resource_cloudflare_rate_limit.go:441 +0xc6
github.com/terraform-providers/terraform-provider-cloudflare/cloudflare.resourceCloudflareRateLimitRead(0xc0001ce310, 0x1a1d060, 0xc0002271e0, 0xc0001ce310, 0x0)
/Users/jacob/src/go/src/github.com/terraform-providers/terraform-provider-cloudflare/cloudflare/resource_cloudflare_rate_limit.go:411 +0x311
github.com/terraform-providers/terraform-provider-cloudflare/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc0003510a0, 0xc000354050, 0x1a1d060, 0xc0002271e0, 0xc0003a2688, 0x10bed01, 0x18901e0)
/Users/jacob/src/go/src/github.com/terraform-providers/terraform-provider-cloudflare/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:352 +0x160
github.com/terraform-providers/terraform-provider-cloudflare/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Refresh(0xc0003a4c40, 0xc000354000, 0xc000354050, 0xc00009ac00, 0x18, 0x2514000)
/Users/jacob/src/go/src/github.com/terraform-providers/terraform-provider-cloudflare/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:308 +0x92
github.com/terraform-providers/terraform-provider-cloudflare/vendor/github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Refresh(0xc000352900, 0xc000030060, 0xc0000302b0, 0x0, 0x0)
/Users/jacob/src/go/src/github.com/terraform-providers/terraform-provider-cloudflare/vendor/github.com/hashicorp/terraform/plugin/resource_provider.go:549 +0x4e
reflect.Value.call(0xc000097560, 0xc00015a5a0, 0x13, 0x1a1f59d, 0x4, 0xc000065f18, 0x3, 0x3, 0xc0003d8000, 0x0, ...)
/usr/local/Cellar/go/1.11.1/libexec/src/reflect/value.go:447 +0x449
reflect.Value.Call(0xc000097560, 0xc00015a5a0, 0x13, 0xc000055718, 0x3, 0x3, 0x0, 0xc0000b2008, 0x0)
/usr/local/Cellar/go/1.11.1/libexec/src/reflect/value.go:308 +0xa4
net/rpc.(*service).call(0xc000151900, 0xc000172fa0, 0xc000306278, 0xc0003062a0, 0xc000168b00, 0xc0003ba320, 0x18901a0, 0xc000030060, 0x16, 0x18901e0, ...)
/usr/local/Cellar/go/1.11.1/libexec/src/net/rpc/server.go:384 +0x14e
```

Having a look into this, `cfg.OriginTraffic` _used_ to be defaulted in
the API response as `true` so `flattenRateLimitResponseMatcher` has
relied on it always being present however this doesn't seem to be the case with
recent rate limits as it's not even present when listing some our rate limit
rules.

To address this we need to first check if the `cfg.OriginTraffic` is
defined and then if it is, add it to the `data` map like it was
previously. Once we have the safety check in place, this works as
intended for both scenarios.