### PR TITLE
Fix import of zone lockdowns

### DIFF
--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -257,6 +257,7 @@ func resourceCloudflareZoneLockdownImport(d *schema.ResourceData, meta interface
 	if err != nil {
 		return nil, fmt.Errorf("couldn't find zone %q while trying to import zone lockdown %q : %q", zoneName, d.Id(), err)
 	}
+	d.Set("zone_id", zoneID)
 	log.Printf("[DEBUG] zone: %s", zoneName)
 	log.Printf("[DEBUG] zoneID: %s", zoneID)
 	log.Printf("[DEBUG] Resource ID : %s", zoneLockdownID)

--- a/cloudflare/resource_cloudflare_zone_lockdown_test.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown_test.go
@@ -34,6 +34,29 @@ func TestCloudflareZoneLockdown(t *testing.T) {
 	})
 }
 
+func TestCloudflareZoneLockdown_Import(t *testing.T) {
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_zone_lockdown." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareWAFRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCloudflareZoneLockdownConfig(rnd, zone, "false", "this is notes", rnd+"."+zone+"/*", "ip", "198.51.100.4"),
+			},
+			{
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", zone),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func testCloudflareZoneLockdownConfig(resourceID, zone, paused, description, url, target, value string) string {
 	return fmt.Sprintf(`
 				resource "cloudflare_zone_lockdown" "%[1]s" {


### PR DESCRIPTION
As mentioned in #134, zone lockdowns imports are failing, and the regression is caused by https://github.com/terraform-providers/terraform-provider-cloudflare/commit/4bc4aa2cbf18a92adbadea9b3e6f47e7d23df482#diff-0e4cc11a1763d8ef0318546d3027d928

Sadly, I do not have a test account with the appropriate subscription level to run the acceptance tests:

```
                * cloudflare_zone_lockdown.zuwfrow271: error creating zone lockdown for zone "myzone.org": error from makeRequest: HTTP status 400: content "{\n  \"result\": null,\n  \"success\": false,\n  \"errors\": [\n    {\n      \"code\": 10012,\n      \"messag
e\": \"zonelockdown.api.not_entitled.max_rules\"\n    }\n  ],\n  \"messages\": []\n}\n"                                                                                                                                                                                  
```

(and I'd rather not run acceptance tests on production accounts)