### PR TITLE
Update `cloudflare_load_balancer_monitor` interval validation

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -55,9 +55,10 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 			},
 
 			"interval": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  60,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      60,
+				ValidateFunc: validation.IntBetween(60, 3600),
 			},
 			// interval has to be larger than (retries+1) * probe_timeout:
 

--- a/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
@@ -229,12 +229,12 @@ resource "cloudflare_load_balancer_monitor" "test" {
 func testAccCheckCloudflareLoadBalancerMonitorConfigFullySpecified() string {
 	return `
 resource "cloudflare_load_balancer_monitor" "test" {
-  expected_body = "dead" 
-  expected_codes = "5xx" 
+  expected_body = "dead"
+  expected_codes = "5xx"
   method = "HEAD"
   timeout = 9
   path = "/custom"
-  interval = 55
+  interval = 60
   retries = 5
   description = "this is a very weird load balancer"
   header {

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -19,7 +19,7 @@ resource "cloudflare_load_balancer_monitor" "test" {
   method = "GET"
   timeout = 7
   path = "/health"
-  interval = 55
+  interval = 60
   retries = 5
   description = "example load balancer"
   header {


### PR DESCRIPTION
Updates the `cloudflare_load_balancer_monitor` document and schema
validation for the `interval` argument to only accept values between 60
and 3600 seconds.

Fixes #133