### PR TITLE
Implement `Update` for `cloudflare_load_balancer_pool`

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -18,6 +18,7 @@ import (
 func resourceCloudflareLoadBalancerPool() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudflareLoadBalancerPoolCreate,
+		Update: resourceCloudflareLoadBalancerPoolUpdate,
 		Read:   resourceCloudflareLoadBalancerPoolRead,
 		Delete: resourceCloudflareLoadBalancerPoolDelete,
 		Importer: &schema.ResourceImporter{
@@ -153,6 +154,43 @@ func resourceCloudflareLoadBalancerPoolCreate(d *schema.ResourceData, meta inter
 	d.SetId(r.ID)
 
 	log.Printf("[INFO] New Cloudflare Load Balancer Pool created with  ID: %s", d.Id())
+
+	return resourceCloudflareLoadBalancerPoolRead(d, meta)
+}
+
+func resourceCloudflareLoadBalancerPoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	loadBalancerPool := cloudflare.LoadBalancerPool{
+		ID:             d.Id(),
+		Name:           d.Get("name").(string),
+		Origins:        expandLoadBalancerOrigins(d.Get("origins").(*schema.Set)),
+		Enabled:        d.Get("enabled").(bool),
+		MinimumOrigins: d.Get("minimum_origins").(int),
+	}
+
+	if checkRegions, ok := d.GetOk("check_regions"); ok {
+		loadBalancerPool.CheckRegions = expandInterfaceToStringList(checkRegions.(*schema.Set).List())
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		loadBalancerPool.Description = description.(string)
+	}
+
+	if monitor, ok := d.GetOk("monitor"); ok {
+		loadBalancerPool.Monitor = monitor.(string)
+	}
+
+	if notificationEmail, ok := d.GetOk("notification_email"); ok {
+		loadBalancerPool.NotificationEmail = notificationEmail.(string)
+	}
+
+	log.Printf("[DEBUG] Updating Cloudflare Load Balancer Pool from struct: %+v", loadBalancerPool)
+
+	_, err := client.ModifyLoadBalancerPool(loadBalancerPool)
+	if err != nil {
+		return errors.Wrap(err, "error updating load balancer pool")
+	}
 
 	return resourceCloudflareLoadBalancerPoolRead(d, meta)
 }

--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -29,14 +29,12 @@ func resourceCloudflareLoadBalancerPool() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile("[-_a-zA-Z0-9]+"), "Only alphanumeric characters, hyphens and underscores are allowed."),
 			},
 
 			"origins": {
 				Type:     schema.TypeSet,
 				Required: true,
-				ForceNew: true,
 				Elem:     originsElem,
 			},
 
@@ -44,14 +42,12 @@ func resourceCloudflareLoadBalancerPool() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-				ForceNew: true,
 			},
 
 			"minimum_origins": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  1,
-				ForceNew: true,
 			},
 
 			"check_regions": {
@@ -61,27 +57,23 @@ func resourceCloudflareLoadBalancerPool() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				ForceNew: true,
 			},
 
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1024),
-				ForceNew:     true,
 			},
 
 			"monitor": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 32),
-				ForceNew:     true,
 			},
 
 			"notification_email": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"created_on": {

--- a/cloudflare/resource_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool_test.go
@@ -66,48 +66,6 @@ func TestAccCloudflareLoadBalancerPool_FullySpecified(t *testing.T) {
 	})
 }
 
-/**
-Any change to a load balancer pool results in a new resource
-Although the API client contains a modify method, this always results in 405 status
-*/
-func TestAccCloudflareLoadBalancerPool_ForceNew(t *testing.T) {
-	t.Parallel()
-	var loadBalancerPool cloudflare.LoadBalancerPool
-	var initialId string
-	rnd := acctest.RandString(10)
-	name := "cloudflare_load_balancer_pool." + rnd
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudflareLoadBalancerPoolDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
-				),
-			},
-			{
-				PreConfig: func() {
-					initialId = loadBalancerPool.ID
-				},
-				Config: testAccCheckCloudflareLoadBalancerPoolConfigFullySpecified(rnd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
-					func(state *terraform.State) error {
-						if initialId == loadBalancerPool.ID {
-							return fmt.Errorf("id should be different after recreation, but is unchanged: %s ",
-								loadBalancerPool.ID)
-						}
-						return nil
-					},
-				),
-			},
-		},
-	})
-}
-
 func TestAccCloudflareLoadBalancerPool_CreateAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 	var loadBalancerPool cloudflare.LoadBalancerPool


### PR DESCRIPTION
Until recently, the `cloudflare_load_balancer_pool` resource didn't
support in-place updates. The resource was added in #40 and at the time,
didn't implement it. It's unclear what the driver was however I can't
find any reason why it shouldn't exist now as the public API supports
it.

This implements the ability to perform in place updates without
replacing the entire resource unless another prerequisite resource is
forcing a new resource.

Something to note here is that the provider relies on the **user** API
for load balancers, no organisation support. This is something that will
I will address in another PR.

@puckey @SteveGoldthorpe-Work I don't have a personal account with load
balancing enabled so testing this on your own account is important to
confirm.

Fixes #66
Fixes #108