### PR TITLE
Make `cloudflare_access_rule` importable for all rule types

### DIFF
--- a/website/docs/r/access_rule.html.markdown
+++ b/website/docs/r/access_rule.html.markdown
@@ -81,12 +81,17 @@ The following attributes are exported:
 
 ## Import
 
-Records can be imported using a composite ID formed of zone name and record ID, e.g.
+Records can be imported using a composite ID formed of access rule type,
+access rule type identifier and identifer value, e.g.
 
 ```
-$ terraform import cloudflare_access_rule.default d41d8cd98f00b204e9800998ecf8427e
+$ terraform import cloudflare_access_rule.default zone/cb029e245cfdd66dc8d2e570d5dd3322/d41d8cd98f00b204e9800998ecf8427e
 ```
 
 where:
 
-* `d41d8cd98f00b204e9800998ecf8427e` - access rule ID as returned by [API](https://api.cloudflare.com/#user-level-firewall-access-rule-list-access-rules)
+* `zone` - access rule type (`account`, `zone` or `user`)
+* `cb029e245cfdd66dc8d2e570d5dd3322` - access rule type ID (i.e the zone ID
+  or account ID you wish to target)
+* `d41d8cd98f00b204e9800998ecf8427e` - access rule ID as returned by
+  respective API endpoint for the type you are attempting to import.


### PR DESCRIPTION
There are currently three different levels of firewall access rules:

- `user`: Applied to a personal account
- `zone`: Applied to an account but restricted to a single zone
- `account`: Applied to all sites within an account

Prior to this commit, importing was only available for the user type
which made it unusable for organisations or users with multiple zones
that they wanted to manage.

As a result of this change, the import identifier has changed. It now
requires:

- `accessRuleType`: Either `account`, `zone` or `user` (`user is pretty
  much a noop`)
- `accessRuleIdentifier`: The ID of the access rule type you intend to
  use (`zone.id` or `account.id`).
- `identifierValue`: The access rule ID from the API.

I've attempted to make this wording explain the different pieces that
are needed however I'm open to suggestions if someone has something
better.

Included here is an update to the documentation for the provider
website for the new identifier values and import usage.

Fixes #118