### PR TITLE
Remove validation for `cloudflare_load_balancer_monitor` interval

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -55,10 +55,9 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 			},
 
 			"interval": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      60,
-				ValidateFunc: validation.IntBetween(60, 3600),
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  60,
 			},
 			// interval has to be larger than (retries+1) * probe_timeout:
 


### PR DESCRIPTION
#136 introduced some basic validation based on the publicly documented
API to provide some safety rails for new users (originally addressing
#133). Unfortunately the `interval` attribute minimum can be lowered for
Enterprise users below the documented defaults and the validation [gets
in the way of the Enterprise users](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/133#issuecomment-433359115). We could have just lowered the
minimum but I feel this would have created a game of whack-a-mole
whereby we would be slowly decreasing this until it was no longer
useful. Instead, I've just opted to remove it and keep the default and
documentation pointing to the supported defaults.