### PR TITLE
Add Access application and policy support

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -87,6 +87,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"cloudflare_access_application":     resourceCloudflareAccessApplication(),
 			"cloudflare_access_rule":            resourceCloudflareAccessRule(),
 			"cloudflare_account_member":         resourceCloudflareAccountMember(),
 			"cloudflare_custom_pages":           resourceCloudflareCustomPages(),

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -88,6 +88,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudflare_access_application":     resourceCloudflareAccessApplication(),
+			"cloudflare_access_policy":          resourceCloudflareAccessPolicy(),
 			"cloudflare_access_rule":            resourceCloudflareAccessRule(),
 			"cloudflare_account_member":         resourceCloudflareAccountMember(),
 			"cloudflare_custom_pages":           resourceCloudflareCustomPages(),

--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -1,0 +1,150 @@
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceCloudflareAccessApplication() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareAccessApplicationCreate,
+		Read:   resourceCloudflareAccessApplicationRead,
+		Update: resourceCloudflareAccessApplicationUpdate,
+		Delete: resourceCloudflareAccessApplicationDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareAccessApplicationImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"aud": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"session_duration": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "24h",
+				ValidateFunc: validation.StringInSlice([]string{"30m", "6h", "12h", "24h", "168h", "730h"}, false),
+			},
+		},
+	}
+}
+
+func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	newAccessApplication := cloudflare.AccessApplication{
+		Name:            d.Get("name").(string),
+		Domain:          d.Get("domain").(string),
+		SessionDuration: d.Get("session_duration").(string),
+	}
+
+	log.Printf("[DEBUG] Creating Cloudflare Access Application from struct: %+v", newAccessApplication)
+
+	accessApplication, err := client.CreateAccessApplication(zoneID, newAccessApplication)
+	if err != nil {
+		return fmt.Errorf("error creating Access Application for zone %q: %s", zoneID, err)
+	}
+
+	d.SetId(accessApplication.ID)
+
+	return resourceCloudflareAccessApplicationRead(d, meta)
+}
+
+func resourceCloudflareAccessApplicationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+
+	accessApplication, err := client.AccessApplication(zoneID, d.Id())
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP status 404") {
+			log.Printf("[INFO] Access Application %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error finding Access Application %q: %s", d.Id(), err)
+	}
+
+	d.Set("aud", accessApplication.AUD)
+	d.Set("session_duration", accessApplication.SessionDuration)
+	d.Set("domain", accessApplication.Domain)
+
+	return nil
+}
+
+func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	updatedAccessApplication := cloudflare.AccessApplication{
+		ID:              d.Id(),
+		Name:            d.Get("name").(string),
+		Domain:          d.Get("domain").(string),
+		SessionDuration: d.Get("session_duration").(string),
+	}
+
+	log.Printf("[DEBUG] Updating Cloudflare Access Application from struct: %+v", updatedAccessApplication)
+
+	accessApplication, err := client.UpdateAccessApplication(zoneID, updatedAccessApplication)
+	if err != nil {
+		return fmt.Errorf("error updating Access Application for zone %q: %s", zoneID, err)
+	}
+
+	if accessApplication.ID == "" {
+		return fmt.Errorf("failed to find Access Application ID in update response; resource was empty")
+	}
+
+	return resourceCloudflareAccessApplicationRead(d, meta)
+}
+
+func resourceCloudflareAccessApplicationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	appID := d.Id()
+
+	log.Printf("[DEBUG] Deleting Cloudflare Access Application using ID: %s", appID)
+
+	err := client.DeleteAccessApplication(zoneID, appID)
+	if err != nil {
+		return fmt.Errorf("error deleting Access Application for zone %q: %s", zoneID, err)
+	}
+
+	resourceCloudflareAccessApplicationRead(d, meta)
+
+	return nil
+}
+
+func resourceCloudflareAccessApplicationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	attributes := strings.SplitN(d.Id(), "/", 2)
+
+	if len(attributes) != 2 {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/accessApplicationID\"", d.Id())
+	}
+
+	zoneID, accessApplicationID := attributes[0], attributes[1]
+
+	log.Printf("[DEBUG] Importing Cloudflare Access Application: id %s for zone %s", accessApplicationID, zoneID)
+
+	d.Set("zone_id", zoneID)
+	d.SetId(accessApplicationID)
+
+	resourceCloudflareAccessApplicationRead(d, meta)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -1,0 +1,269 @@
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceCloudflareAccessPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareAccessPolicyCreate,
+		Read:   resourceCloudflareAccessPolicyRead,
+		Update: resourceCloudflareAccessPolicyUpdate,
+		Delete: resourceCloudflareAccessPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareAccessPolicyImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"zone_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"precedence": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"decision": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"allow", "deny", "bypass"}, false),
+			},
+			"require": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     policyOptionElement,
+			},
+			"exclude": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     policyOptionElement,
+			},
+			"include": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     policyOptionElement,
+			},
+		},
+	}
+}
+
+// policyOptionElement is used by `require`, `exclude` and `include`
+// attributes to build out the expected access conditions.
+var policyOptionElement = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"email": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"email_domain": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"ip": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"everyone": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+	},
+}
+
+func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	appID := d.Get("application_id").(string)
+
+	accessPolicy, err := client.AccessPolicy(zoneID, appID, d.Id())
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP status 404") {
+			log.Printf("[INFO] Access Policy %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error finding Access Policy %q: %s", d.Id(), err)
+	}
+
+	d.Set("name", accessPolicy.Name)
+	d.Set("decision", accessPolicy.Decision)
+	d.Set("precedence", accessPolicy.Precedence)
+	d.Set("require", accessPolicy.Require)
+	d.Set("exclude", accessPolicy.Exclude)
+	d.Set("include", accessPolicy.Include)
+
+	return nil
+}
+
+func resourceCloudflareAccessPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	appID := d.Get("application_id").(string)
+	zoneID := d.Get("zone_id").(string)
+	newAccessPolicy := cloudflare.AccessPolicy{
+		Name:       d.Get("name").(string),
+		Precedence: d.Get("precedence").(int),
+		Decision:   d.Get("decision").(string),
+	}
+
+	newAccessPolicy = appendConditionalAccessPolicyFields(newAccessPolicy, d)
+
+	log.Printf("[DEBUG] Creating Cloudflare Access Policy from struct: %+v", newAccessPolicy)
+
+	accessPolicy, err := client.CreateAccessPolicy(zoneID, appID, newAccessPolicy)
+	if err != nil {
+		return fmt.Errorf("error creating Access Policy for ID %q: %s", accessPolicy.ID, err)
+	}
+
+	d.SetId(accessPolicy.ID)
+
+	return nil
+}
+
+func resourceCloudflareAccessPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	appID := d.Get("application_id").(string)
+	updatedAccessPolicy := cloudflare.AccessPolicy{
+		Name:       d.Get("name").(string),
+		Precedence: d.Get("precedence").(int),
+		Decision:   d.Get("decision").(string),
+		ID:         d.Id(),
+	}
+
+	updatedAccessPolicy = appendConditionalAccessPolicyFields(updatedAccessPolicy, d)
+
+	log.Printf("[DEBUG] Updating Cloudflare Access Policy from struct: %+v", updatedAccessPolicy)
+
+	accessPolicy, err := client.UpdateAccessPolicy(zoneID, appID, updatedAccessPolicy)
+	if err != nil {
+		return fmt.Errorf("error updating Access Policy for ID %q: %s", d.Id(), err)
+	}
+
+	if accessPolicy.ID == "" {
+		return fmt.Errorf("failed to find Access Policy ID in update response; resource was empty")
+	}
+
+	return resourceCloudflareAccessPolicyRead(d, meta)
+}
+
+func resourceCloudflareAccessPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	appID := d.Get("application_id").(string)
+
+	log.Printf("[DEBUG] Deleting Cloudflare Access Policy using ID: %s", d.Id())
+
+	err := client.DeleteAccessPolicy(zoneID, appID, d.Id())
+	if err != nil {
+		return fmt.Errorf("error deleting Access Policy for ID %q: %s", d.Id(), err)
+	}
+
+	resourceCloudflareAccessPolicyRead(d, meta)
+
+	return nil
+}
+
+func resourceCloudflareAccessPolicyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	attributes := strings.SplitN(d.Id(), "/", 3)
+
+	if len(attributes) != 3 {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/accessApplicationID/accessPolicyID\"", d.Id())
+	}
+
+	zoneID, accessAppID, accessPolicyID := attributes[0], attributes[1], attributes[2]
+
+	log.Printf("[DEBUG] Importing Cloudflare Access Policy: zoneID %q, appID %q, accessPolicyID %q", zoneID, accessAppID, accessPolicyID)
+
+	d.Set("zone_id", zoneID)
+	d.Set("application_id", accessAppID)
+	d.SetId(accessPolicyID)
+
+	resourceCloudflareAccessPolicyRead(d, meta)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+// appendConditionalAccessPolicyFields determines which of the
+// conditional policy enforcement fields it should append to the
+// AccessPolicy by iterating over the provided values and generating the
+// correct structs.
+func appendConditionalAccessPolicyFields(policy cloudflare.AccessPolicy, d *schema.ResourceData) cloudflare.AccessPolicy {
+	exclude := d.Get("exclude").([]interface{})
+	for _, value := range exclude {
+		policy.Exclude = buildAccessPolicyCondition(value.(map[string]interface{}))
+	}
+
+	require := d.Get("require").([]interface{})
+	for _, value := range require {
+		policy.Require = buildAccessPolicyCondition(value.(map[string]interface{}))
+	}
+
+	include := d.Get("include").([]interface{})
+	for _, value := range include {
+		policy.Include = buildAccessPolicyCondition(value.(map[string]interface{}))
+	}
+
+	return policy
+}
+
+// buildAccessPolicyCondition iterates the provided `map` of values and
+// generates the required (repetitive) structs.
+//
+// Returns the intended combination structure of AccessPolicyEmail,
+// AccessPolicyEmailDomain, AccessPolicyIP and AccessPolicyEveryone
+// structs.
+func buildAccessPolicyCondition(options map[string]interface{}) []interface{} {
+	var policy []interface{}
+	for accessPolicyType, values := range options {
+		// Since AccessPolicyEveryone is a single boolean, we don't need to
+		// iterate over the values like the others so we treat it a little differently.
+		if accessPolicyType == "everyone" {
+			if values == true {
+				log.Printf("[DEBUG] values for everyone %s", values)
+				policy = append(policy, cloudflare.AccessPolicyEveryone{})
+			}
+		} else {
+			for _, value := range values.([]interface{}) {
+				switch accessPolicyType {
+				case "email":
+					policy = append(policy, cloudflare.AccessPolicyEmail{struct {
+						Email string `json:"email"`
+					}{Email: value.(string)}})
+				case "email_domain":
+					policy = append(policy, cloudflare.AccessPolicyEmailDomain{struct {
+						Domain string `json:"domain"`
+					}{Domain: value.(string)}})
+				case "ip":
+					policy = append(policy, cloudflare.AccessPolicyIP{struct {
+						IP string `json:"ip"`
+					}{IP: value.(string)}})
+				}
+			}
+		}
+	}
+
+	return policy
+}

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -44,7 +44,7 @@ func resourceCloudflareAccessPolicy() *schema.Resource {
 			},
 			"require": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Required: true,
 				Elem:     policyOptionElement,
 			},
 			"exclude": {

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -249,15 +249,15 @@ func buildAccessPolicyCondition(options map[string]interface{}) []interface{} {
 			for _, value := range values.([]interface{}) {
 				switch accessPolicyType {
 				case "email":
-					policy = append(policy, cloudflare.AccessPolicyEmail{struct {
+					policy = append(policy, cloudflare.AccessPolicyEmail{Email: struct {
 						Email string `json:"email"`
 					}{Email: value.(string)}})
 				case "email_domain":
-					policy = append(policy, cloudflare.AccessPolicyEmailDomain{struct {
+					policy = append(policy, cloudflare.AccessPolicyEmailDomain{EmailDomain: struct {
 						Domain string `json:"domain"`
 					}{Domain: value.(string)}})
 				case "ip":
-					policy = append(policy, cloudflare.AccessPolicyIP{struct {
+					policy = append(policy, cloudflare.AccessPolicyIP{IP: struct {
 						IP string `json:"ip"`
 					}{IP: value.(string)}})
 				}

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -22,6 +22,9 @@
         <li<%= sidebar_current("docs-cloudflare-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-cloudflare-resource-access-application") %>>
+              <a href="/docs/providers/cloudflare/r/access_application.html">cloudflare_access_application</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-access-rule") %>>
               <a href="/docs/providers/cloudflare/r/access_rule.html">cloudflare_access_rule</a>
             </li>

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -25,6 +25,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-access-application") %>>
               <a href="/docs/providers/cloudflare/r/access_application.html">cloudflare_access_application</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-access-policy") %>>
+              <a href="/docs/providers/cloudflare/r/access_policy.html">cloudflare_access_policy</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-access-rule") %>>
               <a href="/docs/providers/cloudflare/r/access_rule.html">cloudflare_access_rule</a>
             </li>

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_access_application
+sidebar_current: "docs-cloudflare-resource-access-application"
+description: |-
+  Provides a Cloudflare IP Firewall Access Application resource.
+---
+
+# cloudflare_access_application
+
+Provides a Cloudflare Access Application resource. Access Applications
+are used to restrict access to a whole application using an
+authorisation gateway managed by Cloudflare.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_access_application" "staging_app" {
+  zone_id          = "1d5fdc9e88c8a8c4518b068cd94331fe"
+  name             = "staging application"
+  domain           = "staging.example.com"
+  session_duration = "24h"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required) The DNS zone to which the access rule should be added.
+* `name` - (Required) Friendly name of the Access Application.
+* `domain` - (Required) The complete URL of the asset you wish to put
+  Cloudflare Access in front of. Can include subdomains or paths. Or both.
+* `session_duration` - (Optional) How often a user will be forced to
+  re-authorise. Must be one of `30m`, `6h`, `12h`, `24h`, `168h`, `730h`.
+
+## Import
+
+Access Applications can be imported using a composite ID formed of zone
+ID and application ID.
+
+```
+$ terraform import cloudflare_access_application.staging cb029e245cfdd66dc8d2e570d5dd3322/d41d8cd98f00b204e9800998ecf8427e
+```

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -1,9 +1,9 @@
 ---
 layout: "cloudflare"
-page_title: "Cloudflare: cloudflare_access_application
+page_title: "Cloudflare: cloudflare_access_application"
 sidebar_current: "docs-cloudflare-resource-access-application"
 description: |-
-  Provides a Cloudflare IP Firewall Access Application resource.
+  Provides a Cloudflare Access Application resource.
 ---
 
 # cloudflare_access_application

--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -1,0 +1,97 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_access_policy"
+sidebar_current: "docs-cloudflare-resource-access-policy"
+description: |-
+  Provides a Cloudflare Access Policy resource.
+---
+
+# cloudflare_access_policy
+
+Provides a Cloudflare Access Policy resource. Access Policies are used
+in conjunction with Access Applications to restrict access to a
+particular resource.
+
+## Example Usage
+
+```hcl
+# Allowing access to `test@example.com` email address only
+resource "cloudflare_access_policy" "test_policy" {
+  application_id = "cb029e245cfdd66dc8d2e570d5dd3322"
+  zone_id        = "d41d8cd98f00b204e9800998ecf8427e"
+  name           = "staging policy"
+  precedence     = "1"
+  decision       = "allow"
+
+  include = {
+    email = ["test@example.com"]
+  }
+}
+
+# Allowing `test@example.com` to access but only when coming from a
+# specific IP.
+resource "cloudflare_access_policy" "test_policy" {
+  application_id = "cb029e245cfdd66dc8d2e570d5dd3322"
+  zone_id        = "d41d8cd98f00b204e9800998ecf8427e"
+  name           = "staging policy"
+  precedence     = "1"
+  decision       = "allow"
+
+  include = {
+    email = ["test@example.com"]
+  }
+
+  require = {
+    ip = ["${var.office_ip}"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The ID of the application the policy is
+  associated with.
+* `zone_id` - (Required) The DNS zone to which the access rule should be
+  added.
+* `decision` - (Required) The complete URL of the asset you wish to put
+  Cloudflare Access in front of. Can include subdomains or paths. Or both.
+* `name` - (Required) Friendly name of the Access Application.
+* `precedence` - (Optional) Friendly name of the Access Application.
+* `require` - (Optional) A series of access conditions, see below for
+  full list.
+* `exclude` - (Optional) A series of access conditions, see below for
+  full list.
+* `include` - (Required) A series of access conditions, see below for
+  full list.
+
+## Conditions
+
+`require`, `exclude` and `include` arguments share the available
+conditions which can be applied. The conditions are:
+
+* `ip` - (Optional) A list of IP addresses or ranges. Example:
+  `ip = ["1.2.3.4", "10.0.0.0/2"]`
+* `email` - (Optional) A list of email addresses. Example:
+  `email = ["test@example.com"]`
+* `email_domain` - (Optional) A list of email domains. Example:
+  `email_domain = ["example.com"]`
+* `everyone` - (Optional) Boolean indicating permitting access for all
+  requests. Example: `everyone = true`
+
+
+## Import
+
+Access Policies can be imported using a composite ID formed of zone
+ID, application ID and policy ID.
+
+```
+$ terraform import cloudflare_access_policy.staging cb029e245cfdd66dc8d2e570d5dd3322/d41d8cd98f00b204e9800998ecf8427e/67ea780ce4982c1cfbe6b7293afc765d
+```
+
+where
+
+* `cb029e245cfdd66dc8d2e570d5dd3322` - Zone ID
+* `d41d8cd98f00b204e9800998ecf8427e` - Access Application ID
+* `67ea780ce4982c1cfbe6b7293afc765d` - Access Policy ID


### PR DESCRIPTION
This introduces two new resources for Cloudflare Access:

- `cloudflare_access_application`: An Access Application that covers the
  URL and a friendly name.
- `cloudflare_access_policy`: An Access Policy that enforces
  authorisation on aforementioned Application.

Initially I considered introducing a single resource
(`cloudflare_access_application`) however running over our existing
Access configuration showed that we would end up with quite a bit of
duplication if the policy was embedded in the resource. For example:

```hcl
resource "cloudflare_access_application" "test"
  zone_id = "1d5fdc9e88c8a8c4518b068cd94331fe"
  name    = "my test"
  domain  = "test.envato-staging.com"

  policy {
    name = "allow test user"
    precedence = "1"
    decision  = "allow"

    include = {
      email = ["jacob@test.com"]
    }
  }
}
```

While it looks sensible here, it gets a bit messy with multiple policies
for a single application.

```hcl
resource "cloudflare_access_application" "test"
  zone_id = "1d5fdc9e88c8a8c4518b068cd94331fe"
  name    = "my test"
  domain  = "test.envato-staging.com"

  policies = [
    {
      name = "prevent former employee access"
      precedence = "1"
      decision  = "deny"

      include = {
        email = ["someonelse@test.com"]
      }
    },
    {
      name = "allow all users"
      precedence = "2"
      decision  = "allow"

      include = {
        email_domains = ["test.com"]
      }
    }
  ]
}
```

(Yes, this _could_ be collapsed into a single policy block but bear with
me for the sake of the example)

Now, I'm not totally opposed to this approach however I was swayed away
from it since there are dedicated endpoints for the Application and
Policies and I thought this may cause some confusion if I coupled them
in the Terraform provider. If others think it should be embedded though,
I'm happy to update.

In it's current form, you'd need to create the two resources to
actually have a useful implementation. Example:

```hcl
resource "cloudflare_access_application" "test_app" {
  zone_id = "1d5fdc9e88c8a8c4518b068cd94331fe"
  name    = "my test"
  domain  = "staging.example.com"
}

resource "cloudflare_access_policy" "test_policy" {
  application_id = "${cloudflare_access_application.test_app.id}"
  zone_id        = "${cloudflare_access_application.test_app.zone_id}"
  name           = "test policy"
  precedence     = "1"
  decision       = "allow"

  include = {
    email = ["jacob@test.com"]
  }
}
```

#### Screenshots

Access Application: https://shares.jacobbednarz.com/dfs98jdsf.png
Access Policy: https://shares.jacobbednarz.com/dfgsgdwf.png

Depends on cloudflare/cloudflare-go#244
Closes #100

cc @AustinCorridor