### PR TITLE
Compare `cloudflare_record` name without the zone name

### DIFF
--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -37,6 +37,7 @@ func resourceCloudflareRecord() *schema.Resource {
 				StateFunc: func(i interface{}) string {
 					return strings.ToLower(i.(string))
 				},
+				DiffSuppressFunc: suppressNameDiff,
 			},
 
 			"hostname": {
@@ -577,4 +578,9 @@ func suppressPriority(k, old, new string, d *schema.ResourceData) bool {
 		return true
 	}
 	return false
+}
+
+func suppressNameDiff(k, old, new string, d *schema.ResourceData) bool {
+	zoneName := d.Get("domain").(string)
+	return strings.TrimSuffix(old, "."+zoneName) == strings.TrimSuffix(new, "."+zoneName)
 }


### PR DESCRIPTION
When importing `cloudflare_record` resources the `name` attribute is
[trimmed](https://github.com/terraform-providers/terraform-provider-cloudflare/blob/ef8e9abfdb12bfd200520771792089c2a7129af0/cloudflare/resource_cloudflare_record.go#L513) to exclude the `domain` value. This creates an issue if you
import the resources but use the full the domain as the `name` attribute
because the Terraform state file will never match what is stored and
will result in continuious changes wanting to be applied.

After a brief [discussion on the issue](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/148#issuecomment-438507279), it was decided that instead of
limiting to what can be passed into the `name` attribute, we should use
a `DiffSuppressFunc` that will allow the partial labels and full FQDNs
to work by trimming the zone name as a part of the comparison. This will
be the least amount of friction and maintain full backwards
compatibility.

Fixes #148.