### PR TITLE
[WIP] New Resource: cloudflare_spectrum_app

### DIFF
--- a/cloudflare/import_cloudflare_spectrum_application_test.go
+++ b/cloudflare/import_cloudflare_spectrum_application_test.go
@@ -1,0 +1,44 @@
+package cloudflare
+
+import (
+	"os"
+	"testing"
+
+	"fmt"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccCloudflareSpectrumApplication_Import(t *testing.T) {
+	t.Parallel()
+	var application cloudflare.SpectrumApplication
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &application),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+				),
+			},
+			{
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", zone),
+				ImportState:         true,
+				ImportStateVerify:   true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &application),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+				),
+			},
+		},
+	})
+}

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -100,6 +100,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_page_rule":              resourceCloudflarePageRule(),
 			"cloudflare_rate_limit":             resourceCloudflareRateLimit(),
 			"cloudflare_record":                 resourceCloudflareRecord(),
+			"cloudflare_spectrum_application":   resourceCloudflareSpectrumApplication(),
 			"cloudflare_waf_rule":               resourceCloudflareWAFRule(),
 			"cloudflare_worker_route":           resourceCloudflareWorkerRoute(),
 			"cloudflare_worker_script":          resourceCloudflareWorkerScript(),

--- a/cloudflare/resource_cloudflare_spectrum_application.go
+++ b/cloudflare/resource_cloudflare_spectrum_application.go
@@ -1,0 +1,292 @@
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudflareSpectrumApplication() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareSpectrumApplicationCreate,
+		Read:   resourceCloudflareSpectrumApplicationRead,
+		Update: resourceCloudflareSpectrumApplicationUpdate,
+		Delete: resourceCloudflareSpectrumApplicationDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareSpectrumApplicationImport,
+		},
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"protocol": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"dns": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"origin_direct": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"origin_dns": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"origin_port": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"tls": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "off",
+				ValidateFunc: validation.StringInSlice([]string{
+					"off", "flexible", "full", "strict",
+				}, false),
+			},
+
+			"ip_firewall": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"proxy_protocol": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceCloudflareSpectrumApplicationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	newSpectrumApp := applicationFromResource(d)
+	zoneID := d.Get("zone_id").(string)
+
+	log.Printf("[INFO] Creating Cloudflare Spectrum Application from struct: %+v", newSpectrumApp)
+
+	r, err := client.CreateSpectrumApplication(zoneID, newSpectrumApp)
+	if err != nil {
+		return errors.Wrap(err, "error creating spectrum application for zone")
+	}
+
+	if r.ID == "" {
+		return fmt.Errorf("failed to find id in Create response; resource was empty")
+	}
+
+	d.SetId(r.ID)
+
+	log.Printf("[INFO] Cloudflare Spectrum Application ID: %s", d.Id())
+
+	return resourceCloudflareSpectrumApplicationRead(d, meta)
+}
+
+func resourceCloudflareSpectrumApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+
+	application := applicationFromResource(d)
+
+	log.Printf("[INFO] Updating Cloudflare Spectrum Application from struct: %+v", application)
+
+	_, err := client.UpdateSpectrumApplication(zoneID, application.ID, application)
+	if err != nil {
+		return errors.Wrap(err, "error creating spectrum application for zone")
+	}
+
+	return resourceCloudflareSpectrumApplicationRead(d, meta)
+}
+
+func resourceCloudflareSpectrumApplicationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	applicationID := d.Id()
+
+	application, err := client.SpectrumApplication(zoneID, applicationID)
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP status 404") {
+			log.Printf("[INFO] Spectrum application %s in zone %s not found", applicationID, zoneID)
+			d.SetId("")
+			return nil
+		}
+		return errors.Wrap(err,
+			fmt.Sprintf("Error reading spectrum application resource from API for resource %s in zone %s", zoneID, applicationID))
+	}
+
+	d.Set("protocol", application.Protocol)
+
+	if err := d.Set("dns", flattenDns(application.DNS)); err != nil {
+		log.Printf("[WARN] Error setting dns on spectrum application %q: %s", d.Id(), err)
+	}
+
+	if len(application.OriginDirect) > 0 {
+		if err := d.Set("origin_direct", application.OriginDirect); err != nil {
+			log.Printf("[WARN] Error setting origin direct on spectrum application %q: %s", d.Id(), err)
+		}
+	}
+
+	if application.OriginDNS != nil {
+		if err := d.Set("origin_dns", flattenOriginDns(application.OriginDNS)); err != nil {
+			log.Printf("[WARN] Error setting origin dns on spectrum application %q: %s", d.Id(), err)
+		}
+	}
+
+	d.Set("origin_port", application.OriginPort)
+	d.Set("tls", application.TLS)
+	d.Set("ip_firewall", application.IPFirewall)
+	d.Set("proxy_protocol", application.ProxyProtocol)
+
+	return nil
+}
+
+func resourceCloudflareSpectrumApplicationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	applicationID := d.Id()
+
+	log.Printf("[INFO] Deleting Cloudflare Spectrum Application: %s in zone: %s", applicationID, zoneID)
+
+	err := client.DeleteSpectrumApplication(zoneID, applicationID)
+	if err != nil {
+		return fmt.Errorf("error deleting Cloudflare Spectrum Application: %s", err)
+	}
+
+	return nil
+}
+
+func resourceCloudflareSpectrumApplicationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*cloudflare.API)
+
+	// split the id so we can lookup
+	idAttr := strings.SplitN(d.Id(), "/", 2)
+	var zoneName string
+	var applicationID string
+	if len(idAttr) == 2 {
+		zoneName = idAttr[0]
+		applicationID = idAttr[1]
+	} else {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneName/applicationID\"", d.Id())
+	}
+	zoneID, err := client.ZoneIDByName(zoneName)
+
+	if err != nil {
+		return nil, fmt.Errorf("error finding zoneName %q: %s", zoneName, err)
+	}
+
+	d.Set("zone_id", zoneID)
+	d.SetId(applicationID)
+	return []*schema.ResourceData{d}, nil
+}
+
+func expandDns(d interface{}) cloudflare.SpectrumApplicationDNS {
+	cfg := d.([]interface{})
+	dns := cloudflare.SpectrumApplicationDNS{}
+
+	m := cfg[0].(map[string]interface{})
+	dns.Type = m["type"].(string)
+	dns.Name = m["name"].(string)
+
+	return dns
+}
+
+func expandOriginDns(d interface{}) *cloudflare.SpectrumApplicationOriginDNS {
+	cfg := d.([]interface{})
+	dns := &cloudflare.SpectrumApplicationOriginDNS{}
+
+	m := cfg[0].(map[string]interface{})
+	dns.Name = m["name"].(string)
+
+	return dns
+}
+
+func flattenDns(dns cloudflare.SpectrumApplicationDNS) []map[string]interface{} {
+	flattened := map[string]interface{}{}
+	flattened["type"] = dns.Type
+	flattened["name"] = dns.Name
+
+	return []map[string]interface{}{flattened}
+}
+
+func flattenOriginDns(dns *cloudflare.SpectrumApplicationOriginDNS) []map[string]interface{} {
+	flattened := map[string]interface{}{}
+	flattened["name"] = dns.Name
+
+	return []map[string]interface{}{flattened}
+}
+
+func applicationFromResource(d *schema.ResourceData) cloudflare.SpectrumApplication {
+	application := cloudflare.SpectrumApplication{
+		ID:       d.Id(),
+		Protocol: d.Get("protocol").(string),
+		DNS:      expandDns(d.Get("dns")),
+	}
+
+	if originDirect, ok := d.GetOk("origin_direct"); ok {
+		application.OriginDirect = expandInterfaceToStringList(originDirect.([]interface{}))
+	}
+
+	if originDns, ok := d.GetOk("origin_dns"); ok {
+		application.OriginDNS = expandOriginDns(originDns)
+	}
+
+	if originPort, ok := d.GetOk("origin_port"); ok {
+		application.OriginPort = originPort.(int)
+	}
+
+	if tls, ok := d.GetOk("tls"); ok {
+		application.TLS = tls.(string)
+	}
+
+	if ipFirewall, ok := d.GetOk("ip_firewall"); ok {
+		application.IPFirewall = ipFirewall.(bool)
+	}
+
+	if proxyProtocol, ok := d.GetOk("proxy_protocol"); ok {
+		application.ProxyProtocol = proxyProtocol.(bool)
+	}
+
+	return application
+}

--- a/cloudflare/resource_cloudflare_spectrum_application_test.go
+++ b/cloudflare/resource_cloudflare_spectrum_application_test.go
@@ -31,7 +31,7 @@ func TestAccCloudflareSpectrumApplication_Basic(t *testing.T) {
 					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
 					resource.TestCheckResourceAttr(name, "protocol", "tcp/22"),
 					resource.TestCheckResourceAttr(name, "origin_direct.#", "1"),
-					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://120.120.102.10:23"),
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://192.0.2.1:23"),
 					resource.TestCheckResourceAttr(name, "origin_port", "22"),
 				),
 			},
@@ -82,7 +82,7 @@ func TestAccCloudflareSpectrumApplication_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
 					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
-					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://120.120.102.10:23"),
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://192.0.2.1:23"),
 				),
 			},
 			{
@@ -101,7 +101,7 @@ func TestAccCloudflareSpectrumApplication_Update(t *testing.T) {
 						}
 						return nil
 					},
-					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://81.120.102.10:23"),
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://192.0.2.2:23"),
 				),
 			},
 		},
@@ -227,13 +227,13 @@ func testAccCheckCloudflareSpectrumApplicationConfigBasic(zoneName, ID string) s
 resource "cloudflare_spectrum_application" "%[2]s" {
   zone_id  = "${data.cloudflare_zone.test.id}"
   protocol = "tcp/22"
-  
+
   dns = {
     "type" = "CNAME"
     "name" = "ssh.${data.cloudflare_zone.test.zone}"
   }
-  
-  origin_direct = ["tcp://120.120.102.10:23"]
+
+  origin_direct = ["tcp://192.0.2.1:23"]
   origin_port   = 22
 }
 
@@ -248,12 +248,12 @@ func testAccCheckCloudflareSpectrumApplicationConfigOriginDNS(zoneName, ID strin
 resource "cloudflare_spectrum_application" "%[2]s" {
   zone_id  = "${data.cloudflare_zone.test.id}"
   protocol = "tcp/22"
-  
+
   dns = {
     "type" = "CNAME"
     "name" = "ssh.${data.cloudflare_zone.test.zone}"
   }
-  
+
   origin_dns = {
     name = "ssh.origin.${data.cloudflare_zone.test.zone}"
   }
@@ -277,7 +277,7 @@ resource "cloudflare_spectrum_application" "%[2]s" {
 	"name" = "ssh.${data.cloudflare_zone.test.zone}"
   }
 
-  origin_direct = ["tcp://81.120.102.10:23"]
+  origin_direct = ["tcp://192.0.2.2:23"]
   origin_port   = 22
 }
 

--- a/cloudflare/resource_cloudflare_spectrum_application_test.go
+++ b/cloudflare/resource_cloudflare_spectrum_application_test.go
@@ -1,0 +1,287 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"os"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudflareSpectrumApplication_Basic(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareSpectrumApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "protocol", "tcp/22"),
+					resource.TestCheckResourceAttr(name, "origin_direct.#", "1"),
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://120.120.102.10:23"),
+					resource.TestCheckResourceAttr(name, "origin_port", "22"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_OriginDNS(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareSpectrumApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigOriginDNS(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "protocol", "tcp/22"),
+					resource.TestCheckResourceAttr(name, "origin_dns.#", "1"),
+					resource.TestCheckResourceAttr(name, "origin_dns.0.name", fmt.Sprintf("ssh.origin.%s", zone)),
+					resource.TestCheckResourceAttr(name, "origin_port", "22"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_Update(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	var initialId string
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareSpectrumApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://120.120.102.10:23"),
+				),
+			},
+			{
+				PreConfig: func() {
+					initialId = spectrumApp.ID
+				},
+				Config: testAccCheckCloudflareSpectrumApplicationConfigBasicUpdated(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					func(state *terraform.State) error {
+						if initialId != spectrumApp.ID {
+							// want in place update
+							return fmt.Errorf("spectrum application id is different after second config applied ( %s -> %s )",
+								initialId, spectrumApp.ID)
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://81.120.102.10:23"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_CreateAfterManualDestroy(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	var initialId string
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareSpectrumApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					testAccManuallyDeleteSpectrumApplication(name, &spectrumApp, &initialId),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigBasic(zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					func(state *terraform.State) error {
+						if initialId == spectrumApp.ID {
+							return fmt.Errorf("spectrum application id is unchanged even after we thought we deleted it ( %s )",
+								spectrumApp.ID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareSpectrumApplicationDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_spectrum_application" {
+			continue
+		}
+
+		_, err := client.SpectrumApplication(rs.Primary.Attributes["zone_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("spectrum application still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudflareSpectrumApplicationExists(n string, spectrumApp *cloudflare.SpectrumApplication) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Load Balancer ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+		foundSpectrumApplication, err := client.SpectrumApplication(rs.Primary.Attributes["zone_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*spectrumApp = foundSpectrumApplication
+
+		return nil
+	}
+}
+
+func testAccCheckCloudflareSpectrumApplicationIDIsValid(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		if len(rs.Primary.ID) != 32 {
+			return fmt.Errorf("invalid id %q, should be a string of length 32", rs.Primary.ID)
+		}
+
+		if zoneId, ok := rs.Primary.Attributes["zone_id"]; !ok || len(zoneId) < 1 {
+			return errors.New("zone_id is unset, should always be set with id")
+		}
+		return nil
+	}
+}
+
+func testAccManuallyDeleteSpectrumApplication(name string, spectrumApp *cloudflare.SpectrumApplication, initialId *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[name]
+		client := testAccProvider.Meta().(*cloudflare.API)
+		*initialId = spectrumApp.ID
+		err := client.DeleteSpectrumApplication(rs.Primary.Attributes["zone_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigBasic(zoneName, ID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_spectrum_application" "%[2]s" {
+  zone_id  = "${data.cloudflare_zone.test.id}"
+  protocol = "tcp/22"
+  
+  dns = {
+    "type" = "CNAME"
+    "name" = "ssh.${data.cloudflare_zone.test.zone}"
+  }
+  
+  origin_direct = ["tcp://120.120.102.10:23"]
+  origin_port   = 22
+}
+
+data "cloudflare_zone" "test" {
+  zone = "%[1]s"
+}
+`, zoneName, ID)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigOriginDNS(zoneName, ID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_spectrum_application" "%[2]s" {
+  zone_id  = "${data.cloudflare_zone.test.id}"
+  protocol = "tcp/22"
+  
+  dns = {
+    "type" = "CNAME"
+    "name" = "ssh.${data.cloudflare_zone.test.zone}"
+  }
+  
+  origin_dns = {
+    name = "ssh.origin.${data.cloudflare_zone.test.zone}"
+  }
+  origin_port   = 22
+}
+
+data "cloudflare_zone" "test" {
+  zone = "%[1]s"
+}
+`, zoneName, ID)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigBasicUpdated(zoneName, ID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_spectrum_application" "%[2]s" {
+  zone_id  = "${data.cloudflare_zone.test.id}"
+  protocol = "tcp/22"
+
+  dns = {
+	"type" = "CNAME"
+	"name" = "ssh.${data.cloudflare_zone.test.zone}"
+  }
+
+  origin_direct = ["tcp://81.120.102.10:23"]
+  origin_port   = 22
+}
+
+data "cloudflare_zone" "test" {
+	zone = "%[1]s"
+}`, zoneName, ID)
+}

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -61,6 +61,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-record") %>>
               <a href="/docs/providers/cloudflare/r/record.html">cloudflare_record</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-spectrum-application") %>>
+              <a href="/docs/providers/cloudflare/r/spectrum_application.html">cloudflare_spectrum_application</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-waf-rule") %>>
               <a href="/docs/providers/cloudflare/r/waf_rule.html">cloudflare_waf_rule</a>
             </li>

--- a/website/docs/r/spectrum_application.html.markdown
+++ b/website/docs/r/spectrum_application.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_spectrum_application"
+sidebar_current: "docs-cloudflare-resource-load-balancer"
+description: |-
+  Provides a Cloudflare Spectrum Application resource.
+---
+
+# cloudflare_spectrum_application
+
+Provides a Cloudflare Spectrum Application. You can extend the power of Cloudflare's DDoS, TLS, and IP Firewall to your other TCP-based services.
+
+## Example Usage
+
+```hcl
+# Define a spectrum application proxies ssh traffic
+resource "cloudflare_spectrum_application" "ssh_proxy" {
+  protocol = "tcp/22"
+  dns = {
+    type = "CNAME"
+    name = "ssh.example.com"
+  }
+  
+  origin_direct = [
+    "tcp://109.151.40.129:22"
+  ]
+}
+```
+
+## Argument Reference
+
+* `protocol`  - (Required) The port configuration at Cloudflare’s edge. i.e. `tcp/22`.
+* `dns` - (Required) The name and type of DNS record for the Spectrum application. Fields documented below.
+* `origin_direct` - (Optional) A list of destination addresses to the origin. i.e. `tcp://192.0.2.1:22`.
+* `origin_dns` - (Optional) A destination DNS addresses to the origin. Fields documented below.
+* `origin_port` - (Optional) If using `origin_dns` this is a required attribute. Origin port to proxy traffice to i.e. `22`.
+* `tls` - (Optional) TLS configuration option for Cloudflare to connect to your origin. Valid values are: `off`, `flexible`, `full` and `strict`. Defaults to `off`.
+* `ip_firewall` - (Optional) Enables the IP Firewall for this application. Defaults to `true`.
+* `proxy_protocol` - (Optional) Enables Proxy Protocol v1 to the origin. Defaults to `false`.
+
+**dns**
+
+* `type` - (Requried) The type of DNS record associated with the application. Valid values: `CNAME`.
+* `name` - (Required) The name of the DNS record associated with the application.i.e. `ssh.example.com`.
+
+**origin_dns**
+
+* `name` - (Required) Fully qualified domain name of the origin i.e. origin-ssh.example.com.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Unique identifier in the API for the spectrum application.

--- a/website/docs/r/spectrum_application.html.markdown
+++ b/website/docs/r/spectrum_application.html.markdown
@@ -20,7 +20,7 @@ resource "cloudflare_spectrum_application" "ssh_proxy" {
     type = "CNAME"
     name = "ssh.example.com"
   }
-  
+
   origin_direct = [
     "tcp://109.151.40.129:22"
   ]
@@ -29,11 +29,11 @@ resource "cloudflare_spectrum_application" "ssh_proxy" {
 
 ## Argument Reference
 
-* `protocol`  - (Required) The port configuration at Cloudflare’s edge. i.e. `tcp/22`.
+* `protocol`  - (Required) The port configuration at Cloudflare’s edge. e.g. `tcp/22`.
 * `dns` - (Required) The name and type of DNS record for the Spectrum application. Fields documented below.
-* `origin_direct` - (Optional) A list of destination addresses to the origin. i.e. `tcp://192.0.2.1:22`.
+* `origin_direct` - (Optional) A list of destination addresses to the origin. e.g. `tcp://192.0.2.1:22`.
 * `origin_dns` - (Optional) A destination DNS addresses to the origin. Fields documented below.
-* `origin_port` - (Optional) If using `origin_dns` this is a required attribute. Origin port to proxy traffice to i.e. `22`.
+* `origin_port` - (Optional) If using `origin_dns` this is a required attribute. Origin port to proxy traffice to e.g. `22`.
 * `tls` - (Optional) TLS configuration option for Cloudflare to connect to your origin. Valid values are: `off`, `flexible`, `full` and `strict`. Defaults to `off`.
 * `ip_firewall` - (Optional) Enables the IP Firewall for this application. Defaults to `true`.
 * `proxy_protocol` - (Optional) Enables Proxy Protocol v1 to the origin. Defaults to `false`.
@@ -45,10 +45,23 @@ resource "cloudflare_spectrum_application" "ssh_proxy" {
 
 **origin_dns**
 
-* `name` - (Required) Fully qualified domain name of the origin i.e. origin-ssh.example.com.
+* `name` - (Required) Fully qualified domain name of the origin e.g. origin-ssh.example.com.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - Unique identifier in the API for the spectrum application.
+
+## Import
+
+Spectrum resource can be imported using a zone ID and Application ID, e.g.
+
+```
+$ terraform import cloudflare_spectrum_application.example d41d8cd98f00b204e9800998ecf8427e/9a7806061c88ada191ed06f989cc3dac
+```
+
+where:
+
+* `d41d8cd98f00b204e9800998ecf8427e` - zone ID, as returned from [API](https://api.cloudflare.com/#zone-list-zones)
+* `9a7806061c88ada191ed06f989cc3dac` - Application ID


### PR DESCRIPTION
_Work in progress_ this PR is to add a new resource to automate cloudflare spectrum applications

Relates to #155 

## TODO
- [x] documentation
- [x] resource
- [x] import resource
- [x] resource test
- [x] manual test resource
- [x] manual verify documentation
- [x] merge PR https://github.com/cloudflare/cloudflare-go/pull/253
- [ ] merge PR #167 

# Test results
## resource cloudflare_spectrum_app
```
GOROOT=/usr/lib/go-1.10 #gosetup
GOPATH=/home/ewilde/data/go #gosetup
/usr/lib/go-1.10/bin/go test -c -i -o /tmp/___resource_cloudflare_spectrum_app_test_go github.com/terraform-providers/terraform-provider-cloudflare/cloudflare #gosetup
/usr/lib/go-1.10/bin/go tool test2json -t /tmp/___resource_cloudflare_spectrum_app_test_go -test.v -test.run "^TestAccCloudflareSpectrumApplication_Basic|TestAccCloudflareSpectrumApplication_Update|TestAccCloudflareSpectrumApplication_CreateAfterManualDestroy$" #gosetup
=== RUN   TestAccCloudflareSpectrumApplication_Basic
--- PASS: TestAccCloudflareSpectrumApplication_Basic (4.91s)
=== RUN   TestAccCloudflareSpectrumApplication_Update
--- PASS: TestAccCloudflareSpectrumApplication_Update (8.10s)
=== RUN   TestAccCloudflareSpectrumApplication_CreateAfterManualDestroy
--- PASS: TestAccCloudflareSpectrumApplication_CreateAfterManualDestroy (6.77s)
PASS

Process finished with exit code 0
```
## data cloudflare_zone
```
GOROOT=/usr/lib/go-1.10 #gosetup
GOPATH=/home/ewilde/data/go #gosetup
/usr/lib/go-1.10/bin/go test -c -i -o /tmp/___data_source_zone_test_go github.com/terraform-providers/terraform-provider-cloudflare/cloudflare #gosetup
/usr/lib/go-1.10/bin/go tool test2json -t /tmp/___data_source_zone_test_go -test.v -test.run ^TestAccCloudflareZone$ #gosetup
=== RUN   TestAccCloudflareZone
--- PASS: TestAccCloudflareZone (1.60s)
PASS

Process finished with exit code 0
```

## Import
```
=== RUN   TestAccCloudflareSpectrumApp_Import
=== PAUSE TestAccCloudflareSpectrumApp_Import
=== CONT  TestAccCloudflareSpectrumApp_Import
--- PASS: TestAccCloudflareSpectrumApp_Import (3.69s)
PASS

Process finished with exit code 0
```

## Website
`make website-test`

```
/home/ewilde/data/go/src/github.com/hashicorp/terraform-website/content/scripts/check-links.sh "http://127.0.0.1:4567/docs/providers/cloudflare/"
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/ [30474/30474] -> "index.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/robots.txt [44/44] -> "robots.txt.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/index.html [30474/30474] -> "index.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/d/ip_ranges.html [28144/28144] -> "ip_ranges.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/d/zone.html [28532/28532] -> "zone.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_application.html [28666/28666] -> "access_application.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_policy.html [32425/32425] -> "access_policy.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_rule.html [33161/33161] -> "access_rule.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/account_member.html [28646/28646] -> "account_member.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/custom_pages.html [29692/29692] -> "custom_pages.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/filter.html [29840/29840] -> "filter.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/firewall_rule.html [31002/31002] -> "firewall_rule.html.tmp.tmp" [1]
2018-11-19 14:29:41 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer.html [33943/33943] -> "load_balancer.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer_monitor.html [31101/31101] -> "load_balancer_monitor.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer_pool.html [31987/31987] -> "load_balancer_pool.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/page_rule.html [34666/34666] -> "page_rule.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/rate_limit.html [35649/35649] -> "rate_limit.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/record.html [30345/30345] -> "record.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/spectrum_app.html [30151/30151] -> "spectrum_app.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/waf_rule.html [28514/28514] -> "waf_rule.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/worker_route.html [31257/31257] -> "worker_route.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/worker_script.html [30246/30246] -> "worker_script.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone.html [29589/29589] -> "zone.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone_lockdown.html [31058/31058] -> "zone_lockdown.html.tmp.tmp" [1]
2018-11-19 14:29:42 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone_settings_override.html [37775/37775] -> "zone_settings_override.html.tmp.tmp" [1]
Found no broken links.

FINISHED --2018-11-19 14:29:42--
Total wall clock time: 0.7s
Downloaded: 25 files, 730K in 0.04s (15.9 MB/s)
tf-website-cloudflare-temp
make[1]: Leaving directory '/home/ewilde/data/go/src/github.com/hashicorp/terraform-website'

```
### cloudflare_specturm_app
![image](https://user-images.githubusercontent.com/329397/48715054-05733880-ec0c-11e8-95ac-1d637355f3f0.png)

### data cloudflare_zone

![image](https://user-images.githubusercontent.com/329397/48715136-381d3100-ec0c-11e8-8480-bbda3f3a9e5d.png)

