### PR TITLE
Allow zones to be properly imported

### DIFF
--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -135,6 +135,7 @@ func resourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("type", zone.Type)
 	d.Set("name_servers", zone.NameServers)
 	d.Set("meta", flattenMeta(d, zone.Meta))
+	d.Set("zone", zone.Name)
 
 	return nil
 }


### PR DESCRIPTION
Without this change, when zones are imported they don't have the `zone`
attribute set inside the state. This causes the next plan to attempt to
recreate the resource because it thinks the existing resource has an
empty string for the zone attribute. The `zone` attribute is indeed set
when zones are created through Terraform which explains why this may
have gone unnoticed up until now.