### PR TITLE
Allow `zone_id` to set `zone` and vice versa

### DIFF
--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -25,6 +25,7 @@ func resourceCloudflareFilter() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"zone_id": {
 				Type:     schema.TypeString,

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -111,6 +111,26 @@ func resourceCloudflareFilterCreate(d *schema.ResourceData, meta interface{}) er
 func resourceCloudflareFilterRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
+	zoneName := d.Get("zone").(string)
+
+	if zoneID == "" {
+		zoneID, _ = client.ZoneIDByName(zoneName)
+	} else {
+		zones, err := client.ListZones()
+		if err != nil {
+			return fmt.Errorf("failed to lookup all zones: %s", err)
+		}
+
+		for _, zone := range zones {
+			if zone.ID == zoneID {
+				zoneName = zone.Name
+			}
+		}
+
+		if zoneName == "" {
+			return fmt.Errorf("failed to find zone name")
+		}
+	}
 
 	log.Printf("[DEBUG] Getting a Filter record for zone %q, id %s", zoneID, d.Id())
 	filter, err := client.Filter(zoneID, d.Id())
@@ -129,6 +149,8 @@ func resourceCloudflareFilterRead(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Cloudflare Filter read configuration: %#v", filter)
 
+	d.Set("zone", zoneName)
+	d.Set("zone_id", zoneID)
 	d.Set("paused", filter.Paused)
 	d.Set("description", filter.Description)
 	d.Set("expression", filter.Expression)

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -127,10 +127,6 @@ func resourceCloudflareFilterRead(d *schema.ResourceData, meta interface{}) erro
 				zoneName = zone.Name
 			}
 		}
-
-		if zoneName == "" {
-			return fmt.Errorf("failed to find zone name")
-		}
 	}
 
 	log.Printf("[DEBUG] Getting a Filter record for zone %q, id %s", zoneID, d.Id())

--- a/cloudflare/resource_cloudflare_filter_test.go
+++ b/cloudflare/resource_cloudflare_filter_test.go
@@ -27,6 +27,8 @@ func TestFilterSimple(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "description", "this is notes"),
 					resource.TestCheckResourceAttr(name, "expression", filterUnquoted),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
+					resource.TestCheckResourceAttr(name, "zone", zone),
+					resource.TestCheckResourceAttrSet(name, "zone_id"),
 				),
 			},
 		},


### PR DESCRIPTION
During an import of the `clouflare_filter` resource, the `zone_id` is
defined within the composite ID. This value is then populated and synced
within `resourceCloudflareFilterRead` to match the expected schema
resource. However, we don't currently set `zone` (the zone name)
anywhere. This becomes problematic on subsequent terraform operations as
the `Read` attempts to sync the schema with the filter and ends up
attempting to recreate the resource due to detecting a change.

Initially I thought we could just iterate over all zones and pull out
the one that matched the zone ID but this only works _if_ the zone ID
has been provided (which isn't guaranteed since both fields are optional
but one is required). Instead, I've opted to ensure we update both the
`zone` and `zone_id` properties when we have one of them. I.e when we
only have the `zone_id`, use that value to find and set the `zone` value
(and vice versa). This will ensure that both values are defined and a
change in either will retrigger the update.

Fixes #161.