### PR TITLE
New Data Source: cloudflare_zone

### DIFF
--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -1,0 +1,91 @@
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func dataSourceCloudflareZone() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudflareZoneRead,
+
+		Schema: map[string]*schema.Schema{
+			"zone": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([a-zA-Z0-9][\\-a-zA-Z0-9]*\\.)+[\\-a-zA-Z0-9]{2,20}$"), ""),
+			},
+			"paused": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"vanity_name_servers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"meta": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"wildcard_proxiable": {
+							Type: schema.TypeBool,
+						},
+						"phishing_detected": {
+							Type: schema.TypeBool,
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name_servers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading Zone")
+	client := meta.(*cloudflare.API)
+	name := d.Get("zone").(string)
+	zones, err := client.ListZones(name)
+	if err != nil {
+		return fmt.Errorf("error listing Zone: %s", err)
+	}
+
+	if len(zones) > 1 {
+		return fmt.Errorf("multiple zones for name %q found", name)
+	}
+
+	zone := zones[0]
+	d.SetId(zone.ID)
+	d.Set("zone", zone.Name)
+	d.Set("paused", zone.Paused)
+	d.Set("vanity_name_servers", zone.VanityNS)
+	d.Set("status", zone.Status)
+	d.Set("type", zone.Type)
+	d.Set("name_servers", zone.NameServers)
+	d.Set("meta", flattenMeta(d, zone.Meta))
+
+	return nil
+}

--- a/cloudflare/data_source_zone_test.go
+++ b/cloudflare/data_source_zone_test.go
@@ -1,0 +1,50 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccCloudflareZone(t *testing.T) {
+	name := os.Getenv("CLOUDFLARE_DOMAIN")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareZoneConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareZoneDataSourceID("data.cloudflare_zone.example_dot_com"),
+					resource.TestCheckResourceAttr("data.cloudflare_zone.example_dot_com", "zone", name),
+					resource.TestCheckResourceAttr("data.cloudflare_zone.example_dot_com", "paused", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareZoneConfig(zoneName string) string {
+	return fmt.Sprintf(`
+data "cloudflare_zone" "example_dot_com" {
+	zone = "%[1]s"
+}`, zoneName)
+}
+
+func testAccCheckCloudflareZoneDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find zone data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot zone source ID not set")
+		}
+		return nil
+	}
+}

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -84,6 +84,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"cloudflare_ip_ranges": dataSourceCloudflareIPRanges(),
+			"cloudflare_zone":      dataSourceCloudflareZone(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -16,6 +16,9 @@
             <li<%= sidebar_current("docs-cloudflare-datasource-ip_ranges") %>>
               <a href="/docs/providers/cloudflare/d/ip_ranges.html">cloudflare_ip_ranges</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-datasource-zone") %>>
+              <a href="/docs/providers/cloudflare/d/zone.html">cloudflare_zone</a>
+            </li>
           </ul>
         </li>
 

--- a/website/docs/d/zone.html.md
+++ b/website/docs/d/zone.html.md
@@ -1,0 +1,45 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_zone"
+sidebar_current: "docs-cloudflare-datasource-zone"
+description: |-
+  Get information on a Cloudflare Zone.
+---
+
+# cloudflare_zone
+
+Use this data source to look up a [Zone][1] record.
+
+## Example Usage
+
+```hcl
+data "cloudflare_zone" "test" {
+  zone = "example.com"
+}
+
+resource "cloudflare_spectrum_application" "ssh" {
+  zone_id  = "${data.cloudflare_zone.test.id}"
+  protocol = "tcp/22"
+
+  dns = {
+    type = "CNAME"
+    name = "ssh.${data.cloudflare_zone.test.zone}"
+  }
+
+  origin_direct = ["tcp://81.120.102.10:23"]
+  origin_port   = 22
+}
+```
+
+## Argument Reference
+
+- `zone` - (Required) The name of the zone to match.
+
+## Attributes Reference
+
+- `id`           - Id of the zone
+- `status`       - Zone status. Valid values: active, pending, initializing, moved, deleted, deactivated and read only
+- `name_servers` - List of name servers
+- `type`         - Zone type. Valid values: full or partial
+
+[1]: https://api.cloudflare.com/#zone-properties


### PR DESCRIPTION
This PR introduces a new data source `cloudflare_zone`. Resolves #163 

1. Tested website manually
2. Tested website with `make website-test`
3. Tested new data source with new integration tests
`TestAccCloudflareZone`

## Test outputs

*manual website verification*
![image](https://user-images.githubusercontent.com/329397/48947495-4b404180-ef29-11e8-8f19-5d388109c55d.png)

*make website-test*
```
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/ [30335/30335] -> "index.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/robots.txt [44/44] -> "robots.txt.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/index.html [30335/30335] -> "index.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/d/ip_ranges.html [27990/27990] -> "ip_ranges.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/d/zone.html [28422/28422] -> "zone.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_application.html [28527/28527] -> "access_application.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_policy.html [32286/32286] -> "access_policy.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_rule.html [33022/33022] -> "access_rule.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/account_member.html [28507/28507] -> "account_member.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/custom_pages.html [29553/29553] -> "custom_pages.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/filter.html [29701/29701] -> "filter.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/firewall_rule.html [30863/30863] -> "firewall_rule.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer.html [33804/33804] -> "load_balancer.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer_monitor.html [30962/30962] -> "load_balancer_monitor.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer_pool.html [31848/31848] -> "load_balancer_pool.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/page_rule.html [34527/34527] -> "page_rule.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/rate_limit.html [35510/35510] -> "rate_limit.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/record.html [30206/30206] -> "record.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/waf_rule.html [28375/28375] -> "waf_rule.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/worker_route.html [31118/31118] -> "worker_route.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/worker_script.html [30107/30107] -> "worker_script.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone.html [29450/29450] -> "zone.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone_lockdown.html [30919/30919] -> "zone_lockdown.html.tmp.tmp" [1]
2018-11-23 14:02:46 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone_settings_override.html [37636/37636] -> "zone_settings_override.html.tmp.tmp" [1]
Found no broken links.

FINISHED --2018-11-23 14:02:46--
Total wall clock time: 0.7s
Downloaded: 24 files, 697K in 0.04s (15.4 MB/s)
tf-website-cloudflare-temp
make[1]: Leaving directory '/home/ewilde/data/go/src/github.com/hashicorp/terraform-website'
```
**Integration test**
```
GOROOT=/usr/local/go #gosetup
GOPATH=/home/ewilde/data/go #gosetup
/usr/local/go/bin/go test -c -i -o /tmp/___TestAccCloudflareZone_in_github_com_ewilde_terraform_provider_cloudflare_cloudflare github.com/ewilde/terraform-provider-cloudflare/cloudflare #gosetup
/usr/local/go/bin/go tool test2json -t /tmp/___TestAccCloudflareZone_in_github_com_ewilde_terraform_provider_cloudflare_cloudflare -test.v -test.run ^TestAccCloudflareZone$ #gosetup
=== RUN   TestAccCloudflareZone
--- PASS: TestAccCloudflareZone (1.31s)
PASS

Process finished with exit code 0
```

Signed-off-by: Edward Wilde <ewilde@gmail.com>