### PR TITLE
New Data Source: cloudflare_zones

### DIFF
--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"fmt"
-	"github.com/cloudflare/cloudflare-go"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"regexp"
 	"time"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func dataSourceCloudflareZones() *schema.Resource {
@@ -21,7 +22,7 @@ func dataSourceCloudflareZones() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"zone": {
+						"name": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -63,8 +64,8 @@ func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) err
 	var zoneNames []string
 	for _, v := range zones {
 
-		if filter.zone != nil {
-			if !filter.zone.Match([]byte(v.Name)) {
+		if filter.name != nil {
+			if !filter.name.Match([]byte(v.Name)) {
 				continue
 			}
 		}
@@ -94,14 +95,14 @@ func expandFilter(d interface{}) (*searchFilter, error) {
 	filter := &searchFilter{}
 
 	m := cfg[0].(map[string]interface{})
-	zone, ok := m["zone"]
+	name, ok := m["name"]
 	if ok {
-		match, err := regexp.Compile(zone.(string))
+		match, err := regexp.Compile(name.(string))
 		if err != nil {
 			return nil, err
 		}
 
-		filter.zone = match
+		filter.name = match
 	}
 
 	paused, ok := m["paused"]
@@ -118,7 +119,7 @@ func expandFilter(d interface{}) (*searchFilter, error) {
 }
 
 type searchFilter struct {
-	zone   *regexp.Regexp
+	name   *regexp.Regexp
 	status string
 	paused bool
 }

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -1,0 +1,124 @@
+package cloudflare
+
+import (
+	"fmt"
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"regexp"
+	"time"
+)
+
+func dataSourceCloudflareZones() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudflareZonesRead,
+
+		Schema: map[string]*schema.Schema{
+
+			"filter": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"zone": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"paused": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+			"zones": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading Zones")
+	client := meta.(*cloudflare.API)
+	filter, err := expandFilter(d.Get("filter"))
+	if err != nil {
+		return err
+	}
+
+	zones, err := client.ListZones()
+	if err != nil {
+		return fmt.Errorf("error listing Zone: %s", err)
+	}
+
+	var zoneNames []string
+	for _, v := range zones {
+
+		if filter.zone != nil {
+			if !filter.zone.Match([]byte(v.Name)) {
+				continue
+			}
+		}
+
+		if filter.paused != v.Paused {
+			continue
+		}
+
+		if filter.status != "" && filter.status != v.Status {
+			continue
+		}
+
+		zoneNames = append(zoneNames, v.Name)
+	}
+
+	err = d.Set("zones", zoneNames)
+	if err != nil {
+		return fmt.Errorf("Error setting zones: %s", err)
+	}
+
+	d.SetId(time.Now().UTC().String())
+	return nil
+}
+
+func expandFilter(d interface{}) (*searchFilter, error) {
+	cfg := d.([]interface{})
+	filter := &searchFilter{}
+
+	m := cfg[0].(map[string]interface{})
+	zone, ok := m["zone"]
+	if ok {
+		match, err := regexp.Compile(zone.(string))
+		if err != nil {
+			return nil, err
+		}
+
+		filter.zone = match
+	}
+
+	paused, ok := m["paused"]
+	if ok {
+		filter.paused = paused.(bool)
+	}
+
+	status, ok := m["status"]
+	if ok {
+		filter.status = status.(string)
+	}
+
+	return filter, nil
+}
+
+type searchFilter struct {
+	zone   *regexp.Regexp
+	status string
+	paused bool
+}

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -1,0 +1,160 @@
+package cloudflare
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccCloudflareZonesMatchName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareZonesConfigMatchName(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareZonesDataSourceID("data.cloudflare_zones.examples_domains"),
+					resource.TestCheckResourceAttr("data.cloudflare_zones.examples_domains", "zones.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZonesMatchPaused(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareZonesConfigMatchPaused(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareZonesDataSourceID("data.cloudflare_zones.examples_domains"),
+					resource.TestCheckResourceAttr("data.cloudflare_zones.examples_domains", "zones.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZonesMatchStatus(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareZonesConfigMatchStatus(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareZonesDataSourceID("data.cloudflare_zones.examples_domains"),
+					testAccCheckCloudflareZonesReturned("data.cloudflare_zones.examples_domains", "zones.#", func(i int) bool {
+						return i >= 1 && i <= 2
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareZonesDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		all := s.RootModule().Resources
+		rs, ok := all[n]
+		if !ok {
+			return fmt.Errorf("Can't find zones data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot zones source ID not set")
+		}
+		return nil
+	}
+}
+
+func testAccCheckCloudflareZonesReturned(n string, a string, check func(int) bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		all := s.RootModule().Resources
+		rs, ok := all[n]
+		if !ok {
+			return fmt.Errorf("Can't find zones data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot zones source ID not set")
+		}
+
+		count, _ := strconv.Atoi(rs.Primary.Attributes[a])
+		if !check(count) {
+			return fmt.Errorf("Error evaluating %s.%s actual count: %d", n, a, count)
+		}
+		return nil
+	}
+}
+
+func testAccCloudflareZonesConfigMatchName() string {
+	return fmt.Sprintf(`
+data "cloudflare_zones" "examples_domains" {
+  filter {
+    zone   = "baa.*"
+    paused = "${cloudflare_zone.foo_net.paused}" // true
+  }
+}
+
+%s
+`, testZones)
+}
+
+func testAccCloudflareZonesConfigMatchPaused() string {
+	return fmt.Sprintf(`
+data "cloudflare_zones" "examples_domains" {
+  filter {
+    zone   = "baa.*"
+    paused = "${cloudflare_zone.baa_com.paused}" // false
+  }
+}
+
+%s
+`, testZones)
+}
+
+func testAccCloudflareZonesConfigMatchStatus() string {
+	return fmt.Sprintf(`
+data "cloudflare_zones" "examples_domains" {
+  filter {
+    status = "active"
+    paused = "${cloudflare_zone.baa_com.paused}" // false
+  }
+}
+
+%s
+`, testZones)
+}
+
+const testZones = `resource "cloudflare_zone" "baa_com" {
+  zone       = "baa.com"
+  paused     = false
+  jump_start = false
+}
+
+resource "cloudflare_zone" "baa_org" {
+  zone       = "baa.org"
+  paused     = true
+  jump_start = false
+}
+
+resource "cloudflare_zone" "baa_net" {
+  zone       = "baa.net"
+  paused     = true
+  jump_start = false
+}
+
+resource "cloudflare_zone" "foo_net" {
+  zone       = "foo.net"
+  paused     = true
+  jump_start = false
+  depends_on = ["cloudflare_zone.baa_net", "cloudflare_zone.baa_org", "cloudflare_zone.baa_com"]
+}`

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -99,7 +99,7 @@ func testAccCloudflareZonesConfigMatchName() string {
 	return fmt.Sprintf(`
 data "cloudflare_zones" "examples_domains" {
   filter {
-    zone   = "baa.*"
+    name   = "baa.*"
     paused = "${cloudflare_zone.foo_net.paused}" // true
   }
 }
@@ -112,7 +112,7 @@ func testAccCloudflareZonesConfigMatchPaused() string {
 	return fmt.Sprintf(`
 data "cloudflare_zones" "examples_domains" {
   filter {
-    zone   = "baa.*"
+    name   = "baa.*"
     paused = "${cloudflare_zone.baa_com.paused}" // false
   }
 }

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -84,6 +84,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"cloudflare_ip_ranges": dataSourceCloudflareIPRanges(),
+			"cloudflare_zones":     dataSourceCloudflareZones(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -16,7 +16,10 @@
             <li<%= sidebar_current("docs-cloudflare-datasource-ip_ranges") %>>
               <a href="/docs/providers/cloudflare/d/ip_ranges.html">cloudflare_ip_ranges</a>
             </li>
-          </ul>
+            <li<%= sidebar_current("docs-cloudflare-datasource-zones") %>>
+                <a href="/docs/providers/cloudflare/d/zones.html">cloudflare_zones</a>
+            </li>
+           </ul>
         </li>
 
         <li<%= sidebar_current("docs-cloudflare-resource") %>>

--- a/website/docs/d/zones.html.md
+++ b/website/docs/d/zones.html.md
@@ -1,0 +1,58 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_zones"
+sidebar_current: "docs-cloudflare-datasource-zones"
+description: |-
+  Get information on a Cloudflare Zones.
+---
+
+# cloudflare_zones
+
+Use this data source to look up [Zone][1] records.
+
+## Example Usage
+
+The example below matches all `active` zones that begin with `example.` and are not paused. The matched zones are then
+locked down using the `cloudflare_zone_lockdown` resource.
+
+```hcl
+data "cloudflare_zones" "test" {
+  filter {
+    zone   = "example.*"
+    status = "active"
+    paused = false
+  }
+}
+
+resource "cloudflare_zone_lockdown" "endpoint_lockdown" {
+  count       = "${length(data.cloudflare_zones.test.zones)}"
+  zone        = "${element(data.cloudflare_zones.test.zones, count.index)}"
+  paused      = "false"
+  description = "Restrict access to these endpoints to requests from a known IP address"
+  urls = [
+    "api.mysite.com/some/endpoint*",
+  ]
+  configurations = [
+    {
+      "target" = "ip"
+      "value" = "198.51.100.4"
+    },
+  ]
+}
+```
+
+## Argument Reference
+- `filter` - (Required) One or more values used to look up zone records. If more than one value is given all
+values must match in order to be included, see below for full list.
+
+**filter**
+
+- `zone` - (Optional) A regular expression matching the zone to lookup.
+- `status` - (Optional) Status of the zone to lookup. Valid values: active, pending, initializing, moved, deleted, deactivated and read only.
+- `paused` - (Optional) Paused status of the zone to lookup. Valid values are `true` or `false`.
+
+## Attributes Reference
+
+- `zones` - A list of zone names
+
+[1]: https://api.cloudflare.com/#zone-properties

--- a/website/docs/d/zones.html.md
+++ b/website/docs/d/zones.html.md
@@ -18,7 +18,7 @@ locked down using the `cloudflare_zone_lockdown` resource.
 ```hcl
 data "cloudflare_zones" "test" {
   filter {
-    zone   = "example.*"
+    name   = "example.*"
     status = "active"
     paused = false
   }
@@ -47,7 +47,7 @@ values must match in order to be included, see below for full list.
 
 **filter**
 
-- `zone` - (Optional) A regular expression matching the zone to lookup.
+- `name` - (Optional) A regular expression matching the zone to lookup.
 - `status` - (Optional) Status of the zone to lookup. Valid values: active, pending, initializing, moved, deleted, deactivated and read only.
 - `paused` - (Optional) Paused status of the zone to lookup. Valid values are `true` or `false`.
 


### PR DESCRIPTION
This PR adds support for a new data source `cloudflare_zones`. To look up zones based on a filter

# cloudflare_zones
 Use this data source to look up [Zone][1] records.

 ## Example Usage
 The example below matches all `active` zones that begin with `example.` and are not paused. The matched zones are then
locked down using the `cloudflare_zone_lockdown` resource.
 ```hcl
data "cloudflare_zones" "test" {
  filter {
    zone   = "example.*"
    status = "active"
    paused = false
  }
}

resource "cloudflare_zone_lockdown" "endpoint_lockdown" {
  count       = "${length(data.cloudflare_zones.test.zones)}"
  zone        = "${element(data.cloudflare_zones.test.zones, count.index)}"
  paused      = "false"
  description = "Restrict access to these endpoints to requests from a known IP address"
  urls = [
    "api.mysite.com/some/endpoint*",
  ]
  configurations = [
    {
      "target" = "ip"
      "value" = "198.51.100.4"
    },
  ]
}
```
 ## Argument Reference
- `filter` - (Required) filter - (Optional) One or more values filter off of. It more than one value is given all values
must match, see below for full list.
 **filter**
 - `zone` - (Optional) A regular expression matching the zone to lookup.
- `status` - (Optional) Status of the zone to lookup. Valid values: active, pending, initializing, moved, deleted, deactivated and read only.
- `paused` - (Optional) Paused status of the zone to lookup. Valid values are `true` or `false`.
 ## Attributes Reference
 - `zones` - A list of zone names
 [1]: https://api.cloudflare.com/#zone-properties

# Testing

- [x] Tested website manually

![image](https://user-images.githubusercontent.com/329397/48982496-415e4000-f0db-11e8-9b34-c539b357a0ca.png)

- [x] Tested website with `make website-test`

```
make website-test 
==> Testing cloudflare provider website in Docker...
Error response from daemon: No such container: tf-website-cloudflare-temp
make[1]: [website-provider-test] Error 1 (ignored)
272b7c8daa186403f547689a2640a84a81129db7c7751089cc4cb7cc9131a226
until curl -sS http://localhost:4567/ > /dev/null; do sleep 1; done
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
curl: (52) Empty reply from server
/Users/ewilde/dev/src/github.com/hashicorp/terraform-website/content/scripts/check-links.sh "http://127.0.0.1:4567/docs/providers/cloudflare/"
2018-11-25 17:57:02 URL:http://127.0.0.1:4567/docs/providers/cloudflare/ [30256/30256] -> "index.html.tmp.tmp" [1]
2018-11-25 17:57:02 URL:http://127.0.0.1:4567/robots.txt [44/44] -> "robots.txt.tmp" [1]
2018-11-25 17:57:02 URL:http://127.0.0.1:4567/docs/providers/cloudflare/index.html [30256/30256] -> "index.html.tmp.tmp" [1]
2018-11-25 17:57:02 URL:http://127.0.0.1:4567/docs/providers/cloudflare/d/ip_ranges.html [27911/27911] -> "ip_ranges.html.tmp.tmp" [1]
2018-11-25 17:57:02 URL:http://127.0.0.1:4567/docs/providers/cloudflare/d/zones.html [29438/29438] -> "zones.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_application.html [28448/28448] -> "access_application.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_policy.html [32207/32207] -> "access_policy.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/access_rule.html [32943/32943] -> "access_rule.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/account_member.html [28428/28428] -> "account_member.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/custom_pages.html [29474/29474] -> "custom_pages.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/filter.html [29622/29622] -> "filter.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/firewall_rule.html [30784/30784] -> "firewall_rule.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer.html [33725/33725] -> "load_balancer.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer_monitor.html [30883/30883] -> "load_balancer_monitor.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/load_balancer_pool.html [31769/31769] -> "load_balancer_pool.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/page_rule.html [34448/34448] -> "page_rule.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/rate_limit.html [35431/35431] -> "rate_limit.html.tmp.tmp" [1]
2018-11-25 17:57:03 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/record.html [30127/30127] -> "record.html.tmp.tmp" [1]
2018-11-25 17:57:04 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/waf_rule.html [28296/28296] -> "waf_rule.html.tmp.tmp" [1]
2018-11-25 17:57:04 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/worker_route.html [31039/31039] -> "worker_route.html.tmp.tmp" [1]
2018-11-25 17:57:04 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/worker_script.html [30028/30028] -> "worker_script.html.tmp.tmp" [1]
2018-11-25 17:57:04 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone.html [29371/29371] -> "zone.html.tmp.tmp" [1]
2018-11-25 17:57:04 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone_lockdown.html [30840/30840] -> "zone_lockdown.html.tmp.tmp" [1]
2018-11-25 17:57:04 URL:http://127.0.0.1:4567/docs/providers/cloudflare/r/zone_settings_override.html [37557/37557] -> "zone_settings_override.html.tmp.tmp" [1]
Found no broken links.

FINISHED --2018-11-25 17:57:04--
Total wall clock time: 1.8s
Downloaded: 24 files, 697K in 0.05s (13.2 MB/s)
tf-website-cloudflare-temp
```

- [x] Tested new data source with new integration tests
```
=== RUN   TestAccCloudflareZonesMatchName
--- PASS: TestAccCloudflareZonesMatchName (40.03s)
=== RUN   TestAccCloudflareZonesMatchPaused
--- PASS: TestAccCloudflareZonesMatchPaused (47.11s)
=== RUN   TestAccCloudflareZonesMatchStatus
--- PASS: TestAccCloudflareZonesMatchStatus (17.50s)
PASS

Process finished with exit code 0
```

Signed-off-by: Edward Wilde <ewilde@gmail.com>