### PR TITLE
Add `opportunistic_onion` zone setting support

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -260,6 +260,13 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 		Computed:     true,
 	},
 
+	"opportunistic_onion": {
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+		Optional:     true,
+		Computed:     true,
+	},
+
 	"polish": {
 		Type:         schema.TypeString,
 		Optional:     true,

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -63,6 +63,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `ipv6`
 * `mirage`
 * `opportunistic_encryption`
+* `opportunistic_onion`
 * `origin_error_page_pass_thru`
 * `prefetch_preload`
 * `privacy_pass`


### PR DESCRIPTION
Updates the `zone_settings_override` resource to have support for
`opportunistic_onion`.

API links:

- https://api.cloudflare.com/#zone-settings-get-opportunistic-onion-setting
- https://api.cloudflare.com/#zone-settings-change-opportunistic-onion-setting