### PR TITLE
Add challenge and js_challenge rate-limit modes

### DIFF
--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -375,10 +375,8 @@ func expandRateLimitAction(d *schema.ResourceData) (action cloudflare.RateLimitA
 		if mode == "simulate" || mode == "ban" {
 			return action, fmt.Errorf("rate limit timeout must be set if the 'mode' is simulate or ban")
 		}
-	} else {
-		if mode == "challenge" || mode == "js_challenge" {
-			return action, fmt.Errorf("rate limit timeout must not be set if the 'mode' is challenge or js_challenge")
-		}
+	} else if mode == "challenge" || mode == "js_challenge" {
+		return action, fmt.Errorf("rate limit timeout must not be set if the 'mode' is challenge or js_challenge")
 	}
 
 	action.Mode = mode

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -364,7 +364,6 @@ func expandRateLimitTrafficMatcher(d *schema.ResourceData) (matcher cloudflare.R
 }
 
 func expandRateLimitAction(d *schema.ResourceData) (action cloudflare.RateLimitAction, err error) {
-	log.Printf("[INFO] Expanding Rate Limit action")
 	// dont need to guard for array length because MinItems is set **and** action is required
 	tfAction := d.Get("action").([]interface{})[0].(map[string]interface{})
 

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -567,13 +567,3 @@ func resourceCloudflareRateLimitImport(d *schema.ResourceData, meta interface{})
 
 	return []*schema.ResourceData{d}, nil
 }
-
-// StringInSlice returns a SchemaValidateFunc which tests if the provided value
-// is of type string and matches the value of an element in the valid slice
-// will test with in lower case if ignoreCase is true
-func ValidateAction() schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (s []string, es []error) {
-		es = append(es, fmt.Errorf("failure validating action"))
-		return
-	}
-}

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -56,12 +56,12 @@ func resourceCloudflareRateLimit() *schema.Resource {
 						"mode": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"simulate", "ban"}, true),
+							ValidateFunc: validation.StringInSlice([]string{"simulate", "ban", "challenge", "js_challenge"}, true),
 						},
 
 						"timeout": {
 							Type:         schema.TypeInt,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 86400),
 						},
 
@@ -331,6 +331,7 @@ func expandRateLimitTrafficMatcher(d *schema.ResourceData) (matcher cloudflare.R
 			}
 			responseMatcher.Statuses = statuses
 		}
+
 		if originIface, ok := matchResp["origin_traffic"]; ok {
 			originTraffic := originIface.(bool)
 			responseMatcher.OriginTraffic = &originTraffic

--- a/cloudflare/resource_cloudflare_rate_limit_test.go
+++ b/cloudflare/resource_cloudflare_rate_limit_test.go
@@ -326,7 +326,7 @@ func testAccCheckCloudflareRateLimitConfigBasic(zone, id string) string {
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
   threshold = 1000
-  period = 1
+  period = 10
   action {
     mode = "simulate"
     timeout = 86400
@@ -339,7 +339,7 @@ func testAccCheckCloudflareRateLimitConfigMatchingUrl(zone, id string) string {
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
   threshold = 1000
-  period = 1
+  period = 10
   match {
     request {
       url_pattern = "%[2]s/tfacc-url-%[1]s"
@@ -357,7 +357,7 @@ func testAccCheckCloudflareRateLimitConfigFullySpecified(zone, id string) string
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
   threshold = 2000
-  period = 2
+  period = 10
   match {
     request {
       url_pattern = "%[2]s/tfacc-full-%[1]s"
@@ -391,7 +391,7 @@ func testAccCheckCloudflareRateLimitChallengeConfigBasic(zone, id string) string
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
   threshold = 1000
-  period = 1
+  period = 10
   action {
     mode = "challenge"
   }
@@ -403,7 +403,7 @@ func testAccCheckCloudflareRateLimitConfigWithoutTimeout(zone, id string) string
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
   threshold = 1000
-  period = 1
+  period = 10
   action {
     mode = "simulate"
   }
@@ -415,10 +415,10 @@ func testAccCheckCloudflareRateLimitChallengeConfigWithTimeout(zone, id string) 
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
   threshold = 1000
-  period = 1
+  period = 10
   action {
     mode = "challenge"
-    timeoute = 60
+    timeout = 60
   }
 }`, id, zone)
 }

--- a/cloudflare/resource_cloudflare_rate_limit_test.go
+++ b/cloudflare/resource_cloudflare_rate_limit_test.go
@@ -410,7 +410,6 @@ resource "cloudflare_rate_limit" "%[1]s" {
 }`, id, zone)
 }
 
-
 func testAccCheckCloudflareRateLimitChallengeConfigWithTimeout(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {

--- a/website/docs/r/rate_limit.html.markdown
+++ b/website/docs/r/rate_limit.html.markdown
@@ -78,7 +78,7 @@ The **match.response** block supports:
 The **action** block supports:
 
 * `mode` - (Required) The type of action to perform. Allowable values are 'simulate' and 'ban'.
-* `timeout` - (Required) The time in seconds as an integer to perform the mitigation action. Must be the same or greater than the period (min: 1, max: 86400).
+* `timeout` - (Optional) The time in seconds as an integer to perform the mitigation action. This field is required if the `mode` is either `simulate` or `ban`. Must be the same or greater than the period (min: 1, max: 86400).
 * `response` - (Optional) Custom content-type and body to return, this overrides the custom error for the zone. This field is not required. Omission will result in default HTML error page. Definition below.
 
 The **action.response** block supports:


### PR DESCRIPTION
Minor update to add `challenge` and `js_challenge` support to `cloudflare_rate_limit` resource.

This has been manually tested and I can confirm it will create a rate limit with a `challenge` or `js_challenge` action as expected.

This PR related to [issue 171](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/171)