### PR TITLE
Allow `zone_id` to set `zone` and vice versa

### DIFF
--- a/cloudflare/resource_cloudflare_firewall_rule_test.go
+++ b/cloudflare/resource_cloudflare_firewall_rule_test.go
@@ -30,6 +30,8 @@ func TestFirewallRuleSimple(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "action", "allow"),
 					resource.TestCheckResourceAttr(name, "priority", "1"),
+					resource.TestCheckResourceAttr(name, "zone", zone),
+					resource.TestCheckResourceAttrSet(name, "zone_id"),
 				),
 			},
 		},


### PR DESCRIPTION
During an import of the `cloudflare_firewall_rule` resource, the `zone_id` is
defined within the composite ID. This value is then populated and synced
within `resourceCloudflareFirewallRuleRead` to match the expected schema
resource. However, we don't currently set zone (the zone name)
anywhere. This becomes problematic on subsequent terraform operations as
the Read attempts to sync the schema with the firewall rule and ends up
attempting to recreate the resource due to detecting a change.

This is a similar issue to #161 and is addressed in a similar manner.

Fixes #165