### PR TITLE
Ensure `zone` and `zone_id` are always set

### DIFF
--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -94,11 +94,7 @@ func resourceCloudflareAccessRuleCreate(d *schema.ResourceData, meta interface{}
 			r, err = client.CreateUserAccessRule(newRule)
 		}
 	} else {
-		var zoneID string
-
-		if zoneID != "" {
-			zoneID = zoneID
-		} else {
+		if zoneID == "" {
 			zoneID, err = client.ZoneIDByName(zone)
 			if err != nil {
 				return fmt.Errorf("Error finding zone %q: %s", zone, err)

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -25,6 +25,7 @@ func resourceCloudflareAccessRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"zone_id": {
 				Type:     schema.TypeString,
@@ -67,7 +68,7 @@ func resourceCloudflareAccessRule() *schema.Resource {
 func resourceCloudflareAccessRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	zone := d.Get("zone").(string)
-	zone_id := d.Get("zone_id").(string)
+	zoneID := d.Get("zone_id").(string)
 
 	newRule := cloudflare.AccessRule{
 		Notes: d.Get("notes").(string),
@@ -86,7 +87,7 @@ func resourceCloudflareAccessRuleCreate(d *schema.ResourceData, meta interface{}
 	var r *cloudflare.AccessRuleResponse
 	var err error
 
-	if zone == "" && zone_id == "" {
+	if zone == "" && zoneID == "" {
 		if client.OrganizationID != "" {
 			r, err = client.CreateOrganizationAccessRule(client.OrganizationID, newRule)
 		} else {
@@ -95,8 +96,8 @@ func resourceCloudflareAccessRuleCreate(d *schema.ResourceData, meta interface{}
 	} else {
 		var zoneID string
 
-		if zone_id != "" {
-			zoneID = zone_id
+		if zoneID != "" {
+			zoneID = zoneID
 		} else {
 			zoneID, err = client.ZoneIDByName(zone)
 			if err != nil {


### PR DESCRIPTION
During an import of the `cloudflare_access_rule` resource, the `zone_id` is
defined within the composite ID. This value is then populated and synced
within `resourceCloudflareAccessRuleRead` to match the expected schema
resource. However, we don't currently set zone (the zone name) anywhere.
This becomes problematic on subsequent terraform operations as the Read
attempts to sync the schema with the access rule and ends up attempting to
recreate the resource due to detecting a change.

This is a similar issue to #161 and is addressed in a similar manner.

Fixes #166