### PR TITLE
Page rule `zone` attribute change to trigger new resource

### DIFF
--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -44,6 +44,12 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func testAccPreCheckAltDomain(t *testing.T) {
+	if v := os.Getenv("CLOUDFLARE_ALT_DOMAIN"); v == "" {
+		t.Fatal("CLOUDFLARE_ALT_DOMAIN must be set for this acceptance test")
+	}
+}
+
 func testAccPreCheckOrg(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_ORG_ID"); v == "" {
 		t.Fatal("CLOUDFLARE_ORG_ID must be set for this acceptance test")

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -26,6 +26,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 			"zone": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"zone_id": {

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -199,7 +199,10 @@ func TestAccCloudflarePageRule_UpdatingZoneForcesNewResource(t *testing.T) {
 	newZone := os.Getenv("CLOUDFLARE_ALT_DOMAIN")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAltDomain(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -193,6 +193,34 @@ func TestAccCloudflarePageRule_CreateAfterManualDestroy(t *testing.T) {
 	})
 }
 
+func TestAccCloudflarePageRule_UpdatingZoneForcesNewResource(t *testing.T) {
+	var before, after cloudflare.PageRule
+	oldZone := os.Getenv("CLOUDFLARE_DOMAIN")
+	newZone := os.Getenv("CLOUDFLARE_ALT_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflarePageRuleConfigBasic(oldZone, fmt.Sprintf("test-updating-zone-value.%s", oldZone)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &before),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "zone", oldZone),
+				),
+			},
+			{
+				Config: testAccCheckCloudflarePageRuleConfigBasic(newZone, fmt.Sprintf("test-updating-zone-value.%s", newZone)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &after),
+					testAccCheckCloudflarePageRuleRecreated(&before, &after),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "zone", newZone),
+				),
+			},
+		},
+	})
+}
+
 func TestTranformForwardingURL(t *testing.T) {
 	key, val, err := transformFromCloudflarePageRuleAction(&cloudflare.PageRuleAction{
 		ID: "forwarding_url",


### PR DESCRIPTION
#180 raised an issue whereby using a `cloudflare_page_rule` resource
with a single resource identifier but multiple variables to change the
`zone` attribute would attempt to update the page rule in place instead
of re-creating it (see the attached issue for full reproduction
steps). This isn't good as the `target` attribute needs to contain
references to the `zone` in order to be successfully updated.

To fix this, the schema details for `zone` has been updated to force a
new resource on change. On the surface this change is fine however I can
see a couple of scenarios where a `DiffSuppressFunc` that checks the
host against the stored state file host might be needed in order to not
create and delete unnecessarily and instead only create a new resource
if the hosts are different.

Fixes #180