### PR TITLE
Fix type assertion for custom error pages

### DIFF
--- a/cloudflare/resource_cloudflare_custom_pages.go
+++ b/cloudflare/resource_cloudflare_custom_pages.go
@@ -118,7 +118,7 @@ func resourceCloudflareCustomPagesUpdate(d *schema.ResourceData, meta interface{
 
 	pageType := d.Get("type").(string)
 	customPageParameters := cloudflare.CustomPageParameters{
-		URL:   d.Get("url").(*string),
+		URL:   d.Get("url").(string),
 		State: "customized",
 	}
 	_, err := client.UpdateCustomPage(&pageOptions, pageType, customPageParameters)


### PR DESCRIPTION
The custom error page resource had an incorrect type assertion in it that causes updates to fail with an error similar to this:
```
019/01/16 14:29:32 [DEBUG] Resource state not found for "cloudflare_custom_pages.500_errors": cloudflare_custom_pages.500_errors


2019-01-16T14:29:32.550-0800 [DEBUG] plugin.terraform-provider-cloudflare_v1.11.0_x4: panic: interface conversion: interface {} is string, not *string
```

I changed the type assertion to a string rather than a pointer to a string (as the other similar assertions are).