### PR TITLE
Add log action for firewall rules

### DIFF
--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -40,7 +40,7 @@ func resourceCloudflareFirewallRule() *schema.Resource {
 			"action": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"block", "challenge", "allow", "js_challenge"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"block", "challenge", "allow", "js_challenge", "log"}, false),
 			},
 			"priority": {
 				Type:         schema.TypeInt,

--- a/website/docs/r/firewall_rule.markdown
+++ b/website/docs/r/firewall_rule.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `zone` - (Optional) The DNS zone to which the Firewall Rule should be added. Will be resolved to `zone_id` upon creation.
 * `zone_id` - (Optional) The DNS zone to which the Filter should be added.
-* `action` - (Required) The action to apply to a matched request. Allowed values: "block", "challenge", "allow", "js_challenge".
+* `action` - (Required) The action to apply to a matched request. Allowed values: "block", "challenge", "allow", "js_challenge", "log".
 * `priority` - (Optional) The priority of the rule to allow control of processing order. A lower number indicates high priority. If not provided, any rules with a priority will be sequenced before those without.
 * `paused` - (Optional) Whether this filter based firewall rule is currently paused. Boolean value.
 * `description` - (Optional) A description of the rule to help identify it.

--- a/website/docs/r/firewall_rule.markdown
+++ b/website/docs/r/firewall_rule.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `zone` - (Optional) The DNS zone to which the Firewall Rule should be added. Will be resolved to `zone_id` upon creation.
 * `zone_id` - (Optional) The DNS zone to which the Filter should be added.
-* `action` - (Required) The action to apply to a matched request. Allowed values: "block", "challenge", "allow", "js_challenge", "log".
+* `action` - (Required) The action to apply to a matched request. Allowed values: "block", "challenge", "allow", "js_challenge". Enterprise plan also allows "log".
 * `priority` - (Optional) The priority of the rule to allow control of processing order. A lower number indicates high priority. If not provided, any rules with a priority will be sequenced before those without.
 * `paused` - (Optional) Whether this filter based firewall rule is currently paused. Boolean value.
 * `description` - (Optional) A description of the rule to help identify it.


### PR DESCRIPTION
CloudFlare has an `Enterprise plan` which allows firewall rules with an action of type `log`.

While this works exclusively for Enterprise users, it is something that should be available in the Terraform provider itself.