### PR TITLE
Pass `RateLimitCorrelate` to `flattenRateLimitCorrelate`

### DIFF
--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -446,7 +446,7 @@ func resourceCloudflareRateLimitRead(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[WARN] Error setting action on rate limit %q: %s", d.Id(), err)
 	}
 
-	d.Set("correlate", flattenRateLimitCorrelate)
+	d.Set("correlate", flattenRateLimitCorrelate(rateLimit.Correlate))
 	d.Set("description", rateLimit.Description)
 	d.Set("disabled", rateLimit.Disabled)
 


### PR DESCRIPTION
During an import of `cloudflare_rate_limit` resources, the NAT
correlation value isn't getting set however subsequent runs are.

Looking into this issue, I can see that the `d.Set("correlate")` isn't
calling the `flattenRateLimitCorrelate` with the required argument of a
`RateLimitCorrelate` type. I cannot see how this ever worked (even on
subsequent runs) but passing in the argument has addressed the issue
with importing.

Fixes #199