### PR TITLE
Add `allow_insecure` and `follow_redirects` to load balancer monitor

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -111,6 +111,12 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+
+			"follow_redirects": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"created_on": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -153,6 +159,11 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 	if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
 		loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
 	}
+
+	if followRedirects, ok := d.GetOk("follow_redirects"); ok {
+		loadBalancerMonitor.FollowRedirects = followRedirects.(bool)
+	}
+
 	log.Printf("[DEBUG] Creating Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	r, err := client.CreateLoadBalancerMonitor(loadBalancerMonitor)
@@ -201,6 +212,11 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, met
 	if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
 		loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
 	}
+
+	if followRedirects, ok := d.GetOk("follow_redirects"); ok {
+		loadBalancerMonitor.FollowRedirects = followRedirects.(bool)
+	}
+
 	log.Printf("[DEBUG] Update Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	_, err := client.ModifyLoadBalancerMonitor(loadBalancerMonitor)
@@ -250,6 +266,7 @@ func resourceCloudflareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta 
 	d.Set("description", loadBalancerMonitor.Description)
 	d.Set("port", loadBalancerMonitor.Port)
 	d.Set("allow_insecure", loadBalancerMonitor.AllowInsecure)
+	d.Set("follow_redirects", loadBalancerMonitor.FollowRedirects)
 	d.Set("created_on", loadBalancerMonitor.CreatedOn.Format(time.RFC3339Nano))
 	d.Set("modified_on", loadBalancerMonitor.ModifiedOn.Format(time.RFC3339Nano))
 

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -107,6 +107,10 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 				Optional: true,
 			},
 
+			"allow_insecure": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"created_on": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -146,6 +150,9 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 		loadBalancerMonitor.Port = port.(uint16)
 	}
 
+	if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
+		loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
+	}
 	log.Printf("[DEBUG] Creating Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	r, err := client.CreateLoadBalancerMonitor(loadBalancerMonitor)
@@ -191,6 +198,9 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, met
 		loadBalancerMonitor.Port = port.(uint16)
 	}
 
+	if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
+		loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
+	}
 	log.Printf("[DEBUG] Update Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	_, err := client.ModifyLoadBalancerMonitor(loadBalancerMonitor)
@@ -239,6 +249,7 @@ func resourceCloudflareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta 
 	d.Set("type", loadBalancerMonitor.Type)
 	d.Set("description", loadBalancerMonitor.Description)
 	d.Set("port", loadBalancerMonitor.Port)
+	d.Set("allow_insecure", loadBalancerMonitor.AllowInsecure)
 	d.Set("created_on", loadBalancerMonitor.CreatedOn.Format(time.RFC3339Nano))
 	d.Set("modified_on", loadBalancerMonitor.ModifiedOn.Format(time.RFC3339Nano))
 

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -27,6 +27,7 @@ resource "cloudflare_load_balancer_monitor" "test" {
     values = ["example.com"]
   }
   allow_insecure = false
+  follow_redirects = true
 }
 ```
 
@@ -45,6 +46,7 @@ The following arguments are supported:
 * `type` - (Optional) The protocol to use for the healthcheck. Currently supported protocols are 'HTTP' and 'HTTPS'. Default: "http".
 * `description` - (Optional) Free text description.
 * `allow_insecure` - (Optional) Do not validate the certificate when monitor use HTTPS.
+* `follow_redirects` - (Optional) Follow redirects if returned by the origin.
 
 **header** requires the following:
 

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -26,6 +26,7 @@ resource "cloudflare_load_balancer_monitor" "test" {
     header = "Host"
     values = ["example.com"]
   }
+  allow_insecure = false
 }
 ```
 
@@ -43,6 +44,7 @@ The following arguments are supported:
 * `header` - (Optional) The HTTP request headers to send in the health check. It is recommended you set a Host header by default. The User-Agent header cannot be overridden. Fields documented below.
 * `type` - (Optional) The protocol to use for the healthcheck. Currently supported protocols are 'HTTP' and 'HTTPS'. Default: "http".
 * `description` - (Optional) Free text description.
+* `allow_insecure` - (Optional) Do not validate the certificate when monitor use HTTPS.
 
 **header** requires the following:
 


### PR DESCRIPTION
This updates the `cloudflare_load_balancer_monitor` to accept two new
attributes:

- `allow_insecure`: Determine if the origin HTTPS certificate should be
  validated.
- `follow_redirects`: Should the monitor allow following a redirect if
  the origin presents it.

Fixes #113