### PR TITLE
provider: Enable request/response logging

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -125,7 +125,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	c := cleanhttp.DefaultClient()
-	c.Transport = logging.NewTransport("CloudFlare", c.Transport)
+	c.Transport = logging.NewTransport("Cloudflare", c.Transport)
 	options = append(options, cloudflare.HTTPClient(c))
 
 	config := Config{


### PR DESCRIPTION
This makes debugging for developers & users of this provider easier by exposing all requests & responses in the log (when >`DEBUG` severity is set).

I didn't have chance to explore the `api_client_logging` option on the provider, but it became a common convention in other major providers to just respect logging level of Terraform (typically controlled via `TF_LOG`) and leverage the global logging settings, which also allows us to respect `TF_LOG_PATH` and send all these useful logs somewhere safe, instead of flooding stderr.

Keeping providers aligned may help users going forward and reduce confusion as we can document debugging/troubleshooting guides in one place for all providers and just point people there.

Whether you decide to keep that option in the provider block or deprecate it is ultimately up to you though. I don't want you to feel like I'm pressing you into deprecating it. 😉 

Example:

```
2019/02/22 17:24:29 [DEBUG] CloudFlare API Request Details:
---[ REQUEST ]---------------------------------------
GET /client/v4/zones/25afd8e9b39af234c001b657a2eb2c5c/pagerules/81932b0afeb25157322318a4398a1d91 HTTP/1.1
Host: api.cloudflare.com
User-Agent: Terraform/0.11.8 terraform-provider-cloudflare/dev
Content-Type: application/json
X-Auth-Email: <redacted>
X-Auth-Key: <redacted>
Accept-Encoding: gzip


-----------------------------------------------------
2019/02/22 17:24:29 [DEBUG] CloudFlare API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 200 OK
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Cf-Ray: 4ad325865d64c99f-SEA
Content-Type: application/json
Date: Fri, 22 Feb 2019 17:24:29 GMT
Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Expires: Sun, 25 Jan 1981 05:00:00 GMT
Pragma: no-cache
Served-In-Seconds: 0.076
Server: cloudflare
Set-Cookie: __cfduid=dd589b51e35be510cb67896a359ac31f21550856269; expires=Sat, 22-Feb-20 17:24:29 GMT; path=/; domain=.cloudflare.com; HttpOnly
Set-Cookie: __cf_bm=eaa413494bbc211b6e125bec5eef183a064db294-1550856269-1800-AdKEAnqZ7d6UhqYeMM0SFMqvu+72epIWfqlSPkhTtECmqiANMO/hDxe9Ez58RP/wD6tXNYuyhQwC4/x2WN7CmJc=; path=/; expires=Fri, 22-Feb-19 17:54:29 GMT; domain=.cloudflare.com; HttpOnly
Strict-Transport-Security: max-age=15780000; includeSubDomains
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Ssl-Protocol: TLSv1.2

{
 "result": {
  "id": "81932b0afeb25157322318a4398a1d91",
  "targets": [
   {
    "target": "url",
    "constraint": {
     "operator": "matches",
     "value": "test-basic.hashicorptest.com\/"
    }
   }
  ],
  "actions": [
   {
    "id": "ssl",
    "value": "flexible"
   },
   {
    "id": "always_online",
    "value": "on"
   },
   {
    "id": "disable_apps"
   }
  ],
  "priority": 1,
  "status": "active",
  "created_on": "2018-03-13T04:18:44.000000Z",
  "modified_on": "2019-02-22T17:24:29.000000Z"
 },
 "success": true,
 "errors": [],
 "messages": []
}
-----------------------------------------------------
```