### PR TITLE
tests/cloudflare_access_rule: Fix acceptance test

### DIFF
--- a/cloudflare/resource_cloudflare_access_rule_test.go
+++ b/cloudflare/resource_cloudflare_access_rule_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccessRuleASN(t *testing.T) {
+func TestAccAccessRuleASN(t *testing.T) {
 	name := "cloudflare_access_rule.test"
 
 	resource.Test(t, resource.TestCase{

--- a/cloudflare/resource_cloudflare_access_rule_test.go
+++ b/cloudflare/resource_cloudflare_access_rule_test.go
@@ -15,7 +15,7 @@ func TestAccessRuleASN(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccessRuleAccountConfig(name, "challenge", "this is notes", "asn", "AS112"),
+				Config: testAccessRuleAccountConfig("challenge", "this is notes", "asn", "AS112"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "notes", "this is notes"),
 					resource.TestCheckResourceAttr(name, "mode", "challenge"),
@@ -27,14 +27,14 @@ func TestAccessRuleASN(t *testing.T) {
 	})
 }
 
-func testAccessRuleAccountConfig(resourceID, mode, notes, target, value string) string {
+func testAccessRuleAccountConfig(mode, notes, target, value string) string {
 	return fmt.Sprintf(`
-				resource "cloudflare_access_rule" "%[1]s" {
-					notes = "%[3]s"
-					mode = "%[2]s"
-					configuration {
-					  target = "%[4]s"
-					  value = "%[5]s"
-					}
-				}`, resourceID, mode, notes, target, value)
+resource "cloudflare_access_rule" "test" {
+  notes = "%[2]s"
+  mode = "%[1]s"
+  configuration {
+    target = "%[3]s"
+    value = "%[4]s"
+  }
+}`, mode, notes, target, value)
 }


### PR DESCRIPTION
This fixes the following failing acceptance test:

```
=== RUN   TestAccessRuleASN
--- FAIL: TestAccessRuleASN (0.00s)
    testing.go:527: Step 0 error: config is invalid: Error parsing address 'cloudflare_access_rule.cloudflare_access_rule.test': Unexpected value for InstanceType field: "test"
FAIL
```