### PR TITLE
tests/cloudflare_record_test: Fix acceptance test values

### DIFF
--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -45,7 +45,7 @@ func TestAccCloudflareRecord_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "ttl", "3600"),
 					resource.TestCheckResourceAttr(
-						resourceName, "metadata.%", "2"),
+						resourceName, "metadata.%", "3"),
 					resource.TestCheckResourceAttr(
 						resourceName, "metadata.auto_added", "false"),
 				),


### PR DESCRIPTION
With the introduction of Argo Tunnel, the `metadata` key now has three
values returned whereas previously, it was only two resulting in the
following failure.

```
------- Stdout: -------
=== RUN   TestAccCloudflareRecord_Basic
=== PAUSE TestAccCloudflareRecord_Basic
=== CONT  TestAccCloudflareRecord_Basic
--- FAIL: TestAccCloudflareRecord_Basic (1.39s)
    testing.go:527: Step 0 error: Check failed: Check 11/12 error: cloudflare_record.foobar: Attribute 'metadata.%' expected "2", got "3"
FAIL
```

This rectifies the issue by matching the number of items it actually
returns.