### PR TITLE
test/cloudflare_record: Fix acceptance LOC tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* resource/cloudflare_record: Ensure `Create`/`Update`/`Read` functions all apply the record transformation and store the correct state values [GH-217]
 * resource/cloudflare_rate_limit: Read `correlate` back from API correctly [GH-204]
 * resource/cloudflare_load_balancer_monitor: Fix incorrect type cast for `port` [GH-213]
 * resource/cloudflare_load_balancer: Make `steering_policy` computed to avoid spurious diffs [GH-214]

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -382,6 +382,25 @@ func resourceCloudflareRecordRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
+	data, dataOk := d.GetOk("data")
+	log.Printf("[DEBUG] Data found in config: %#v", data)
+
+	readDataMap := make(map[string]interface{})
+
+	if dataOk {
+		for id, value := range data.(map[string]interface{}) {
+			newData, err := transformToCloudflareDNSData(record.Type, id, value)
+			if err != nil {
+				return err
+			} else if newData == nil {
+				continue
+			}
+			readDataMap[id] = newData
+		}
+
+		record.Data = readDataMap
+	}
+
 	d.SetId(record.ID)
 	d.Set("hostname", record.Name)
 	d.Set("type", record.Type)

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -132,7 +132,7 @@ func TestAccCloudflareRecord_LOC(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareRecordExists(resourceName, &record),
 					resource.TestCheckResourceAttr(
-						resourceName, "value", "37 46 46.000 N 122 23 35.000 W 0m 100m 0m 0m"),
+						resourceName, "value", "37 46 46.000 N 122 23 35.000 W 0.00m 100.00m 0.00m 0.00m"),
 					resource.TestCheckResourceAttr(
 						resourceName, "proxiable", "false"),
 					resource.TestCheckResourceAttr(
@@ -509,16 +509,16 @@ resource "cloudflare_record" "foobar" {
 	data {
 	  "lat_degrees" =  "37"
 	  "lat_minutes" = "46"
-	  "lat_seconds" = "46"
+	  "lat_seconds" = 46.000
 	  "lat_direction" = "N"
 	  "long_degrees" = "122"
 	  "long_minutes" = "23"
-	  "long_seconds" = "35"
+	  "long_seconds" = 35.000
 	  "long_direction" = "W"
-	  "altitude" = 0
-	  "size" = 100
-	  "precision_horz" = 0
-	  "precision_vert" = 0
+	  "altitude" = 0.00
+	  "size" = 100.00
+	  "precision_horz" = 0.00
+	  "precision_vert" = 0.00
 	}
 	type = "LOC"
 	ttl = 3600


### PR DESCRIPTION
This updates the `resourceCloudflareRecordRead` function to also run the
`data` attribute through the `transformToCloudflareDNSData` function
(like the `Create`/`Update` already do) in order to correctly parse the
floats that are returned as strings.

I've opened a discussion with the Cloudflare folks on fixing this
properly (not passing the floats as strings) in the response but I
suspect that won't be a quick fix and this will need to suffice while we
are working through that.

Fixes the following CI failure

```
------- Stdout: -------
=== RUN   TestAccCloudflareRecord_LOC
=== PAUSE TestAccCloudflareRecord_LOC
=== CONT  TestAccCloudflareRecord_LOC
--- FAIL: TestAccCloudflareRecord_LOC (2.98s)
    testing.go:527: Step 0 error: Check failed: Check 2/4 error: cloudflare_record.foobar: Attribute 'value' expected "37 46 46.000 N 122 23 35.000 W 0m 100m 0m 0m", got "37 46 46.000 N 122 23 35.000 W 0.00m 100.00m 0.00m 0.00m"
FAIL
```

FYI @radeksimko