### PR TITLE
Organization api is deprecated

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -75,10 +75,10 @@ func Provider() terraform.ResourceProvider {
 				Description: "If specified zone is owned by an organization, configure API client to always use that organization",
 			},
 
-			"org_id": &schema.Schema{
+			"account_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_ORG_ID", nil),
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_ACCOUNT_ID", nil),
 				Description: "Configure API client to always use that organization. If set this will override 'user_owner_from_zone'",
 			},
 		},
@@ -139,7 +139,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 
-	if orgId, ok := d.GetOk("org_id"); ok {
+	if orgId, ok := d.GetOk("account_id"); ok {
 		log.Printf("[INFO] Using specified organization id %s in Cloudflare provider", orgId.(string))
 		options = append(options, cloudflare.UsingOrganization(orgId.(string)))
 	} else if zoneName, ok := d.GetOk("use_org_from_zone"); ok {

--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -51,7 +51,7 @@ func testAccPreCheckAltDomain(t *testing.T) {
 }
 
 func testAccPreCheckOrg(t *testing.T) {
-	if v := os.Getenv("CLOUDFLARE_ORG_ID"); v == "" {
-		t.Fatal("CLOUDFLARE_ORG_ID must be set for this acceptance test")
+	if v := os.Getenv("CLOUDFLARE_ACCOUNT_ID"); v == "" {
+		t.Fatal("CLOUDFLARE_ACCOUNT_ID must be set for this acceptance test")
 	}
 }

--- a/cloudflare/resource_cloudflare_worker_route_test.go
+++ b/cloudflare/resource_cloudflare_worker_route_test.go
@@ -17,13 +17,13 @@ const (
 )
 
 func TestAccCloudflareWorkerRoute_SingleScriptNonEnt(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_ORG_ID if it is set in order
+	// Temporarily unset CLOUDFLARE_ACCOUNT_ID if it is set in order
 	// to test non-ENT behavior
-	if os.Getenv("CLOUDFLARE_ORG_ID") != "" {
+	if os.Getenv("CLOUDFLARE_ACCOUNT_ID") != "" {
 		defer func(orgId string) {
-			os.Setenv("CLOUDFLARE_ORG_ID", orgId)
-		}(os.Getenv("CLOUDFLARE_ORG_ID"))
-		os.Setenv("CLOUDFLARE_ORG_ID", "")
+			os.Setenv("CLOUDFLARE_ACCOUNT_ID", orgId)
+		}(os.Getenv("CLOUDFLARE_ACCOUNT_ID"))
+		os.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
 	}
 
 	testAccCloudflareWorkerRoute_SingleScript(t, nil)

--- a/cloudflare/resource_cloudflare_worker_script_test.go
+++ b/cloudflare/resource_cloudflare_worker_script_test.go
@@ -18,13 +18,13 @@ const (
 )
 
 func TestAccCloudflareWorkerScript_SingleScriptNonEnt(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_ORG_ID if it is set in order
+	// Temporarily unset CLOUDFLARE_ACCOUNT_ID if it is set in order
 	// to test non-ENT behavior
-	if os.Getenv("CLOUDFLARE_ORG_ID") != "" {
+	if os.Getenv("CLOUDFLARE_ACCOUNT_ID") != "" {
 		defer func(orgId string) {
-			os.Setenv("CLOUDFLARE_ORG_ID", orgId)
-		}(os.Getenv("CLOUDFLARE_ORG_ID"))
-		os.Setenv("CLOUDFLARE_ORG_ID", "")
+			os.Setenv("CLOUDFLARE_ACCOUNT_ID", orgId)
+		}(os.Getenv("CLOUDFLARE_ACCOUNT_ID"))
+		os.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
 	}
 
 	testAccCloudflareWorkerScript_SingleScript(t, nil)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
   specified with the `CLOUDFLARE_EMAIL` shell environment variable.
 * `token` - (Required) The Cloudflare API token. This can also be specified
   with the `CLOUDFLARE_TOKEN` shell environment variable.
-* `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4. 
+* `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4.
   This can also be specified with the `CLOUDFLARE_RPS` shell environment variable.
 * `retries` - (Optional) Maximum number of retries to perform when an API request fails. Default: 3.
   This can also be specified with the `CLOUDFLARE_RETRIES` shell environment variable.
@@ -51,10 +51,10 @@ The following arguments are supported:
   This can also be specified with the `CLOUDFLARE_MAX_BACKOFF` shell environment variable.
 * `api_client_logging` - (Optional) Whether to print logs from the API client (using the default log library logger). Default: false.
   This can also be specified with the `CLOUDFLARE_API_CLIENT_LOGGING` shell environment variable.
-* `org_id` - (Optional) Configure API client with this organisation ID, so calls use the organization API rather than the (default) user API.
+* `account_id` - (Optional) Configure API client with this organisation ID, so calls use the organization API rather than the (default) user API.
   This is required for other users in your organization to have access to the resources you manage.
-  This can also be specified with the `CLOUDFLARE_ORG_ID` shell environment variable.
-* `use_org_from_zone` - (Optional) Takes a zone name value. This is used to lookup the organization ID that owns this zone, 
-  which will be used to configure the API client. If `org_id` is also specified, this field will be ignored.
+  This can also be specified with the `CLOUDFLARE_ACCOUNT_ID` shell environment variable.
+* `use_org_from_zone` - (Optional) Takes a zone name value. This is used to lookup the organization ID that owns this zone,
+  which will be used to configure the API client. If `account_id` is also specified, this field will be ignored.
   This can also be specified with the `CLOUDFLARE_ORG_ZONE` shell environment variable.
 

--- a/website/docs/r/access_rule.html.markdown
+++ b/website/docs/r/access_rule.html.markdown
@@ -38,7 +38,7 @@ resource "cloudflare_access_rule" "antarctica" {
 # Resulting Terraform state will be a list of resources.
 provider "cloudflare" {
   # ... other provider configuration
-  org_id = "d41d8cd98f00b204e9800998ecf8427e"
+  account_id = "d41d8cd98f00b204e9800998ecf8427e"
 }
 variable "my_office" {
   type = "list"


### PR DESCRIPTION
Hello 👋 guys.

From cloudflare doc
```
This API is deprecated, please use equivalent /accounts API endpoints where possible. Account APIs provide a broader range of features, and are backwards-compatible to organization APIs.
```

https://api.cloudflare.com/#organizations-properties 

In the  cloudflare-go client they are using accounts endpoint https://github.com/cloudflare/cloudflare-go/blob/master/workers.go#L197 but still using OrganizationID instead accountID, I think is another PR there and here to be consistent.
Because in all doc they refer to this as `account_identifier` or `account_id`
```
PUT accounts/:account_identifier/workers/scripts/:script_name
```

To give you context, I'm doing this PR because I spent some time today looking for Organization ID and it isn't available anymore and is not obious that account id is the samething at least it wasn’t for me today 🤔

Problem of this PR is that it is a breaking change with the current interface and it is going to  affect users. I know some resource notify before they are going to be deprecated , don’t know if there is something similar to attributes, I will appreciate help here in order to keep the rosource working or backward compatible PR if you see this change worthy. 