### PR TITLE
test/data_source_zones: Fix flakey tests due to domain count

### DIFF
--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -35,7 +35,7 @@ func TestAccCloudflareZonesMatchPaused(t *testing.T) {
 				Config: testAccCloudflareZonesConfigMatchPaused(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareZonesDataSourceID("data.cloudflare_zones.examples_domains"),
-					resource.TestCheckResourceAttr("data.cloudflare_zones.examples_domains", "zones.#", "1"),
+					resource.TestCheckResourceAttrSet("data.cloudflare_zones.examples_domains", "zones.#"),
 				),
 			},
 		},
@@ -52,7 +52,7 @@ func TestAccCloudflareZonesMatchStatus(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareZonesDataSourceID("data.cloudflare_zones.examples_domains"),
 					testAccCheckCloudflareZonesReturned("data.cloudflare_zones.examples_domains", "zones.#", func(i int) bool {
-						return i >= 1 && i <= 2
+						return i > 0
 					}),
 				),
 			},


### PR DESCRIPTION
Updates two zone data source tests to account for situations where the
tests aren't being run against a clean or empty Cloudflare account which
results in flakey CI runs.

In both cases, the count was off by at least one due to the account
already have domains setup in them.