### PR TITLE
Remove advanced_ddos from Zone Settings

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -77,13 +77,6 @@ func resourceCloudflareZoneSettingsOverride() *schema.Resource {
 }
 
 var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
-	"advanced_ddos": {
-		Type:         schema.TypeString,
-		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
-		Optional:     true,
-		Computed:     true, //Defaults to on for Business+ plans, off otherwise
-	},
-
 	"always_online": {
 		Type:         schema.TypeString,
 		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -48,7 +48,6 @@ The **settings** block supports settings that may be applied to the zone. These 
 
 These can be specified as "on" or "off" string. Similar to boolean values, but here the empty string also means to use the existing value. Attributes available:
 
-* `advanced_ddos`
 * `always_online`
 * `always_use_https`
 * `automatic_https_rewrites`


### PR DESCRIPTION
Per Issue #243:
- Removed option from zone settings
- Removed details from documentation.