### PR TITLE
data_source_zone: Return ID and Name

### DIFF
--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -15,7 +15,6 @@ func dataSourceCloudflareZones() *schema.Resource {
 		Read: dataSourceCloudflareZonesRead,
 
 		Schema: map[string]*schema.Schema{
-
 			"filter": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -39,10 +38,20 @@ func dataSourceCloudflareZones() *schema.Resource {
 				},
 			},
 			"zones": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -61,7 +70,7 @@ func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error listing Zone: %s", err)
 	}
 
-	var zoneNames []string
+	zoneDetails := make([]interface{}, 0)
 	for _, v := range zones {
 
 		if filter.name != nil {
@@ -78,10 +87,13 @@ func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) err
 			continue
 		}
 
-		zoneNames = append(zoneNames, v.Name)
+		zoneDetails = append(zoneDetails, map[string]interface{}{
+			"id":   v.ID,
+			"name": v.Name,
+		})
 	}
 
-	err = d.Set("zones", zoneNames)
+	err = d.Set("zones", zoneDetails)
 	if err != nil {
 		return fmt.Errorf("Error setting zones: %s", err)
 	}

--- a/cloudflare/resource_cloudflare_spectrum_application_test.go
+++ b/cloudflare/resource_cloudflare_spectrum_application_test.go
@@ -31,7 +31,7 @@ func TestAccCloudflareSpectrumApplication_Basic(t *testing.T) {
 					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
 					resource.TestCheckResourceAttr(name, "protocol", "tcp/22"),
 					resource.TestCheckResourceAttr(name, "origin_direct.#", "1"),
-					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://192.0.2.1:23"),
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://1.2.3.4:23"),
 					resource.TestCheckResourceAttr(name, "origin_port", "22"),
 				),
 			},
@@ -82,7 +82,7 @@ func TestAccCloudflareSpectrumApplication_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
 					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
-					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://192.0.2.1:23"),
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://1.2.3.4:23"),
 				),
 			},
 			{
@@ -101,7 +101,7 @@ func TestAccCloudflareSpectrumApplication_Update(t *testing.T) {
 						}
 						return nil
 					},
-					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://192.0.2.2:23"),
+					resource.TestCheckResourceAttr(name, "origin_direct.0", "tcp://1.2.3.4:23"),
 				),
 			},
 		},
@@ -225,20 +225,22 @@ func testAccManuallyDeleteSpectrumApplication(name string, spectrumApp *cloudfla
 func testAccCheckCloudflareSpectrumApplicationConfigBasic(zoneName, ID string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_spectrum_application" "%[2]s" {
-  zone_id  = "${data.cloudflare_zone.test.id}"
+  zone_id  = "${lookup(data.cloudflare_zones.test.zones[0], "id")}"
   protocol = "tcp/22"
 
   dns = {
     "type" = "CNAME"
-    "name" = "ssh.${data.cloudflare_zone.test.zone}"
+    "name" = "ssh.${lookup(data.cloudflare_zones.test.zones[0], "name")}"
   }
 
-  origin_direct = ["tcp://192.0.2.1:23"]
+  origin_direct = ["tcp://1.2.3.4:23"]
   origin_port   = 22
 }
 
-data "cloudflare_zone" "test" {
-  zone = "%[1]s"
+data "cloudflare_zones" "test" {
+  filter {
+		name = "%[1]s.*"
+	}
 }
 `, zoneName, ID)
 }
@@ -246,22 +248,24 @@ data "cloudflare_zone" "test" {
 func testAccCheckCloudflareSpectrumApplicationConfigOriginDNS(zoneName, ID string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_spectrum_application" "%[2]s" {
-  zone_id  = "${data.cloudflare_zone.test.id}"
+  zone_id  = "${lookup(data.cloudflare_zones.test.zones[0], "id")}"
   protocol = "tcp/22"
 
   dns = {
     "type" = "CNAME"
-    "name" = "ssh.${data.cloudflare_zone.test.zone}"
+    "name" = "ssh.${lookup(data.cloudflare_zones.test.zones[0], "name")}"
   }
 
   origin_dns = {
-    name = "ssh.origin.${data.cloudflare_zone.test.zone}"
+    name = "ssh.origin.${lookup(data.cloudflare_zones.test.zones[0], "name")}"
   }
   origin_port   = 22
 }
 
-data "cloudflare_zone" "test" {
-  zone = "%[1]s"
+data "cloudflare_zones" "test" {
+  filter {
+		name = "%[1]s.*"
+	}
 }
 `, zoneName, ID)
 }
@@ -269,19 +273,21 @@ data "cloudflare_zone" "test" {
 func testAccCheckCloudflareSpectrumApplicationConfigBasicUpdated(zoneName, ID string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_spectrum_application" "%[2]s" {
-  zone_id  = "${data.cloudflare_zone.test.id}"
+  zone_id  = "${lookup(data.cloudflare_zones.test.zones[0], "id")}"
   protocol = "tcp/22"
 
   dns = {
 	"type" = "CNAME"
-	"name" = "ssh.${data.cloudflare_zone.test.zone}"
+	"name" = "ssh.${lookup(data.cloudflare_zones.test.zones[0], "name")}"
   }
 
-  origin_direct = ["tcp://192.0.2.2:23"]
+  origin_direct = ["tcp://1.2.3.4:23"]
   origin_port   = 22
 }
 
-data "cloudflare_zone" "test" {
-	zone = "%[1]s"
+data "cloudflare_zones" "test" {
+	filter {
+		name = "%[1]s.*"
+	}
 }`, zoneName, ID)
 }

--- a/website/docs/d/zones.html.md
+++ b/website/docs/d/zones.html.md
@@ -25,8 +25,7 @@ data "cloudflare_zones" "test" {
 }
 
 resource "cloudflare_zone_lockdown" "endpoint_lockdown" {
-  count       = "${length(data.cloudflare_zones.test.zones)}"
-  zone        = "${element(data.cloudflare_zones.test.zones, count.index)}"
+  zone        = "${lookup(data.cloudflare_zones.test.zones[0], "name")}"
   paused      = "false"
   description = "Restrict access to these endpoints to requests from a known IP address"
   urls = [
@@ -53,6 +52,11 @@ values must match in order to be included, see below for full list.
 
 ## Attributes Reference
 
-- `zones` - A list of zone names
+- `zones` - A map of zone details. Full list below:
+
+**zones**
+
+- `id` - The zone ID
+- `name` - Zone name
 
 [1]: https://api.cloudflare.com/#zone-properties


### PR DESCRIPTION
Updates the `cloudflare_zones` data source to return a map of the ID and·
name for the filtered results. This is to better help facilitate dynamic·
configurations where end users would like to pass in a zone filter and·
automate creation of resources.

There are a couple of potential downsides though:

- The first is that this introduces a somewhat breaking change as it
 doesn't perform as it once did. An entry will be added to the CHANGELOG
 but it could be easy to miss.
- The second is that the syntax to access a single result is pretty
 ugly. This will be nicer in 0.12 but for now it's 🤮 .

Included in this PR is fixing all the spectrum integration tests. They
have been failing since they were created due to relying on a data
source that never made it into the provider. It now uses the working
`cloudflare_zones` data source and has been confirmed working.

Closes #211