### PR TITLE
Add enabled field to load_balancer (#208)

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -71,6 +71,12 @@ func resourceCloudflareLoadBalancer() *schema.Resource {
 				ConflictsWith: []string{"ttl"},
 			},
 
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"ttl": {
 				Type:          schema.TypeInt,
 				Optional:      true,
@@ -165,11 +171,13 @@ var localPoolElems = map[string]*schema.Resource{
 func resourceCloudflareLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
+	enabled := d.Get("enabled").(bool)
 	newLoadBalancer := cloudflare.LoadBalancer{
 		Name:           d.Get("name").(string),
 		FallbackPool:   d.Get("fallback_pool_id").(string),
 		DefaultPools:   expandInterfaceToStringList(d.Get("default_pool_ids")),
 		Proxied:        d.Get("proxied").(bool),
+		Enabled:        &enabled,
 		TTL:            d.Get("ttl").(int),
 		SteeringPolicy: d.Get("steering_policy").(string),
 		Persistence:    d.Get("session_affinity").(string),
@@ -229,12 +237,14 @@ func resourceCloudflareLoadBalancerUpdate(d *schema.ResourceData, meta interface
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
+	enabled := d.Get("enabled").(bool)
 	loadBalancer := cloudflare.LoadBalancer{
 		ID:             d.Id(),
 		Name:           d.Get("name").(string),
 		FallbackPool:   d.Get("fallback_pool_id").(string),
 		DefaultPools:   expandInterfaceToStringList(d.Get("default_pool_ids")),
 		Proxied:        d.Get("proxied").(bool),
+		Enabled:        &enabled,
 		TTL:            d.Get("ttl").(int),
 		SteeringPolicy: d.Get("steering_policy").(string),
 		Persistence:    d.Get("session_affinity").(string),
@@ -305,6 +315,7 @@ func resourceCloudflareLoadBalancerRead(d *schema.ResourceData, meta interface{}
 	d.Set("name", loadBalancer.Name)
 	d.Set("fallback_pool_id", loadBalancer.FallbackPool)
 	d.Set("proxied", loadBalancer.Proxied)
+	d.Set("enabled", *loadBalancer.Enabled)
 	d.Set("description", loadBalancer.Description)
 	d.Set("ttl", loadBalancer.TTL)
 	d.Set("steering_policy", loadBalancer.SteeringPolicy)

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `ttl` - (Optional) Time to live (TTL) of this load balancer's DNS `name`. Conflicts with `proxied` - this cannot be set for proxied load balancers. Default is `30`.
 * `steering_policy` - (Optional) Determine which method the load balancer uses to determine the fastest route to your origin. Valid values  are: "off", "geo", "dynamic_latency" or "". Default is "".
 * `proxied` - (Optional) Whether the hostname gets Cloudflare's origin protection. Defaults to `false`.
+* `enabled` - (Optional) Enable or disable the load balancer. Defaults to `true` (enabled).
 * `region_pools` - (Optional) A set containing mappings of region/country codes to a list of pool IDs (ordered by their failover priority) for the given region. Fields documented below.
 * `pop_pools` - (Optional) A set containing mappings of Cloudflare Point-of-Presence (PoP) identifiers to a list of pool IDs (ordered by their failover priority) for the PoP (datacenter). This feature is only available to enterprise customers. Fields documented below.
 * `session_affinity` - (Optional) Associates all requests coming from an end-user with a single origin. Cloudflare will set a cookie on the initial response to the client, such that consequent requests with the cookie in the request will go to the same origin, so long as it is available.


### PR DESCRIPTION
Adds support for enabled field in load-balancers (#208).
Load balancers that have been disabled via the dashboard (or other tooling) will want to change to enabled, you should add the field 'enabled: false' to them to match their current state.
Load balancers purely managed via terraform will be fine as there was no way to disable them before.