### PR TITLE
SDK-10 Implement support for LogpushJob

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -99,6 +99,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_load_balancer_monitor":  resourceCloudflareLoadBalancerMonitor(),
 			"cloudflare_load_balancer_pool":     resourceCloudflareLoadBalancerPool(),
 			"cloudflare_load_balancer":          resourceCloudflareLoadBalancer(),
+			"cloudflare_logpush_job":            resourceCloudflareLogpushJob(),
 			"cloudflare_page_rule":              resourceCloudflarePageRule(),
 			"cloudflare_rate_limit":             resourceCloudflareRateLimit(),
 			"cloudflare_record":                 resourceCloudflareRecord(),

--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -55,3 +55,9 @@ func testAccPreCheckOrg(t *testing.T) {
 		t.Fatal("CLOUDFLARE_ORG_ID must be set for this acceptance test")
 	}
 }
+
+func testAccPreCheckLogpushToken(t *testing.T) {
+	if v := os.Getenv("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN"); v == "" {
+		t.Fatal("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN must be set for this acceptance test")
+	}
+}

--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -60,4 +60,7 @@ func testAccPreCheckLogpushToken(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN"); v == "" {
 		t.Fatal("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN must be set for this acceptance test")
 	}
+	if v := os.Getenv("CLOUDFLARE_ZONE_ID"); v == "" {
+		t.Fatal("CLOUDFLARE_ZONE_ID must be set for this acceptance test")
+	}
 }

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -1,0 +1,176 @@
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceCloudflareLogpushJob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareLogpushJobCreate,
+		Read:   resourceCloudflareLogpushJobRead,
+		Update: resourceCloudflareLogpushJobUpdate,
+		Delete: resourceCloudflareLogpushJobDelete,
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"zone": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"logpull_options": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"destination_conf": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ownership_challenge": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func getJobFromResource(d *schema.ResourceData) cloudflare.LogpushJob {
+	id, err := strconv.Atoi(d.Id())
+
+	if err != nil {
+		fmt.Errorf("Could not extract Logpush job from resource - invalid identifier: %+v", id)
+	}
+
+	job := cloudflare.LogpushJob{
+		ID:                 id,
+		Enabled:            d.Get("enabled").(bool),
+		Name:               d.Get("name").(string),
+		LogpullOptions:     d.Get("logpull_options").(string),
+		DestinationConf:    d.Get("destination_conf").(string),
+		OwnershipChallenge: d.Get("ownership_challenge").(string),
+	}
+	return job
+}
+
+func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	jobId, err := strconv.Atoi(d.Id())
+
+	zoneName := d.Get("zone").(string)
+	zoneId, err := client.ZoneIDByName(zoneName)
+	if err != nil {
+		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
+	}
+
+	job, err := client.LogpushJob(zoneId, jobId)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
+		return fmt.Errorf("error finding logpush job %q: %s", jobId, err)
+	}
+
+	if job.ID == 0 {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", job.Name)
+	d.Set("enabled", job.Enabled)
+	d.Set("logpull_options", job.LogpullOptions)
+	d.Set("destination_conf", job.DestinationConf)
+	d.Set("ownership_challenge", d.Get("ownership_challenge"))
+
+	return nil
+}
+
+func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	job := getJobFromResource(d)
+
+	if d.Get("ownership_challenge") == "" {
+		return fmt.Errorf("You must include an ownership_challenge token when creating a logpush job")
+	}
+
+	zoneName := d.Get("zone").(string)
+	zoneId, err := client.ZoneIDByName(zoneName)
+	if err != nil {
+		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
+	}
+	d.Set("zone_id", zoneId)
+
+	log.Printf("[INFO] Creating Cloudflare Logpush Job from struct: %+v", job)
+
+	j, err := client.CreateLogpushJob(zoneId, job)
+
+	if err != nil {
+		return fmt.Errorf("error creating logpush job")
+	}
+
+	if j.ID == 0 {
+		return fmt.Errorf("failed to find ID in Create response; resource was empty")
+	}
+
+	d.SetId(strconv.Itoa(j.ID))
+
+	log.Printf("[INFO] Cloudflare Logpush Job ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceCloudflareLogpushJobUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	job := getJobFromResource(d)
+
+	zoneName := d.Get("zone").(string)
+	zoneId, err := client.ZoneIDByName(zoneName)
+	if err != nil {
+		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
+	}
+	d.Set("zone_id", zoneId)
+
+	log.Printf("[INFO] Updating Cloudflare Logpush Job from struct: %+v", job)
+
+	updateErr := client.UpdateLogpushJob(zoneId, job.ID, job)
+
+	if updateErr != nil {
+		return fmt.Errorf("error updating logpush job: %+v", job.ID)
+	}
+
+	return nil
+}
+
+func resourceCloudflareLogpushJobDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	job := getJobFromResource(d)
+
+	zoneName := d.Get("zone").(string)
+	zoneId, err := client.ZoneIDByName(zoneName)
+	if err != nil {
+		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
+	}
+	d.Set("zone_id", zoneId)
+
+	log.Printf("[INFO] Deleting Cloudflare Logpush job from zone :%+v with id: %+v", zoneId, job.ID)
+
+	deleteErr := client.DeleteLogpushJob(zoneId, job.ID)
+	if deleteErr != nil {
+		return fmt.Errorf("error deleting logpush job: %+v", job.ID)
+	}
+
+	return nil
+}

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -79,6 +79,7 @@ func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) 
 
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
+			log.Printf("[INFO] Could not find LogpushJob with id: %q", jobId)
 			return nil
 		}
 		return fmt.Errorf("error finding logpush job %q: %s", jobId, err)
@@ -113,7 +114,7 @@ func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}
 	}
 	d.Set("zone_id", zoneId)
 
-	log.Printf("[INFO] Creating Cloudflare Logpush Job from struct: %+v", job)
+	log.Printf("[DEBUG] Creating Cloudflare Logpush Job from struct: %+v", job)
 
 	j, err := client.CreateLogpushJob(zoneId, job)
 
@@ -127,7 +128,7 @@ func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}
 
 	d.SetId(strconv.Itoa(j.ID))
 
-	log.Printf("[INFO] Cloudflare Logpush Job ID: %s", d.Id())
+	log.Printf("[INFO] Created Cloudflare Logpush Job ID: %s", d.Id())
 
 	return nil
 }
@@ -165,7 +166,7 @@ func resourceCloudflareLogpushJobDelete(d *schema.ResourceData, meta interface{}
 	}
 	d.Set("zone_id", zoneId)
 
-	log.Printf("[INFO] Deleting Cloudflare Logpush job from zone :%+v with id: %+v", zoneId, job.ID)
+	log.Printf("[DEBUG] Deleting Cloudflare Logpush job from zone :%+v with id: %+v", zoneId, job.ID)
 
 	deleteErr := client.DeleteLogpushJob(zoneId, job.ID)
 	if deleteErr != nil {

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -93,7 +93,7 @@ func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("enabled", job.Enabled)
 	d.Set("logpull_options", job.LogpullOptions)
 	d.Set("destination_conf", job.DestinationConf)
-	d.Set("ownership_challenge", d.Get("ownership_challenge"))
+	d.Set("ownership_challenge", job.OwnershipChallenge)
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -103,10 +103,6 @@ func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}
 	client := meta.(*cloudflare.API)
 	job := getJobFromResource(d)
 
-	if d.Get("ownership_challenge") == "" {
-		return fmt.Errorf("You must include an ownership_challenge token when creating a logpush job")
-	}
-
 	zoneName := d.Get("zone").(string)
 	zoneId, err := client.ZoneIDByName(zoneName)
 	if err != nil {

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -41,7 +41,7 @@ func resourceCloudflareLogpushJob() *schema.Resource {
 			},
 			"ownership_challenge": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 			},
 		},
 	}

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -88,7 +88,7 @@ func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("enabled", job.Enabled)
 	d.Set("logpull_options", job.LogpullOptions)
 	d.Set("destination_conf", job.DestinationConf)
-	d.Set("ownership_challenge", job.OwnershipChallenge)
+	d.Set("ownership_challenge", d.Get("ownership_challenge"))
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -19,7 +19,7 @@ func resourceCloudflareLogpushJob() *schema.Resource {
 
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
-			"zone": {
+			"zone_id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -69,13 +69,7 @@ func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*cloudflare.API)
 	jobId, err := strconv.Atoi(d.Id())
 
-	zoneName := d.Get("zone").(string)
-	zoneId, err := client.ZoneIDByName(zoneName)
-	if err != nil {
-		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
-	}
-
-	job, err := client.LogpushJob(zoneId, jobId)
+	job, err := client.LogpushJob(d.Get("zone_id").(string), jobId)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -103,16 +97,9 @@ func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}
 	client := meta.(*cloudflare.API)
 	job := getJobFromResource(d)
 
-	zoneName := d.Get("zone").(string)
-	zoneId, err := client.ZoneIDByName(zoneName)
-	if err != nil {
-		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
-	}
-	d.Set("zone_id", zoneId)
-
 	log.Printf("[DEBUG] Creating Cloudflare Logpush Job from struct: %+v", job)
 
-	j, err := client.CreateLogpushJob(zoneId, job)
+	j, err := client.CreateLogpushJob(d.Get("zone_id").(string), job)
 
 	if err != nil {
 		return fmt.Errorf("error creating logpush job")
@@ -133,16 +120,9 @@ func resourceCloudflareLogpushJobUpdate(d *schema.ResourceData, meta interface{}
 	client := meta.(*cloudflare.API)
 	job := getJobFromResource(d)
 
-	zoneName := d.Get("zone").(string)
-	zoneId, err := client.ZoneIDByName(zoneName)
-	if err != nil {
-		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
-	}
-	d.Set("zone_id", zoneId)
-
 	log.Printf("[INFO] Updating Cloudflare Logpush Job from struct: %+v", job)
 
-	updateErr := client.UpdateLogpushJob(zoneId, job.ID, job)
+	updateErr := client.UpdateLogpushJob(d.Get("zone_id").(string), job.ID, job)
 
 	if updateErr != nil {
 		return fmt.Errorf("error updating logpush job: %+v", job.ID)
@@ -155,16 +135,9 @@ func resourceCloudflareLogpushJobDelete(d *schema.ResourceData, meta interface{}
 	client := meta.(*cloudflare.API)
 	job := getJobFromResource(d)
 
-	zoneName := d.Get("zone").(string)
-	zoneId, err := client.ZoneIDByName(zoneName)
-	if err != nil {
-		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
-	}
-	d.Set("zone_id", zoneId)
+	log.Printf("[DEBUG] Deleting Cloudflare Logpush job from zone :%+v with id: %+v", d.Get("zone_id"), job.ID)
 
-	log.Printf("[DEBUG] Deleting Cloudflare Logpush job from zone :%+v with id: %+v", zoneId, job.ID)
-
-	deleteErr := client.DeleteLogpushJob(zoneId, job.ID)
+	deleteErr := client.DeleteLogpushJob(d.Get("zone_id").(string), job.ID)
 	if deleteErr != nil {
 		return fmt.Errorf("error deleting logpush job: %+v", job.ID)
 	}

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -113,11 +113,13 @@ func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[INFO] Created Cloudflare Logpush Job ID: %s", d.Id())
 
-	return nil
+	return resourceCloudflareLogpushJobRead(d, meta)
+
 }
 
 func resourceCloudflareLogpushJobUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
+
 	job := getJobFromResource(d)
 
 	log.Printf("[INFO] Updating Cloudflare Logpush Job from struct: %+v", job)
@@ -128,7 +130,7 @@ func resourceCloudflareLogpushJobUpdate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("error updating logpush job: %+v", job.ID)
 	}
 
-	return nil
+	return resourceCloudflareLogpushJobRead(d, meta)
 }
 
 func resourceCloudflareLogpushJobDelete(d *schema.ResourceData, meta interface{}) error {
@@ -142,5 +144,6 @@ func resourceCloudflareLogpushJobDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("error deleting logpush job: %+v", job.ID)
 	}
 
-	return nil
+	return resourceCloudflareLogpushJobRead(d, meta)
+
 }

--- a/cloudflare/resource_cloudflare_logpush_job_test.go
+++ b/cloudflare/resource_cloudflare_logpush_job_test.go
@@ -1,0 +1,73 @@
+package cloudflare
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"os"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudflareLogpushJob_Basic(t *testing.T) {
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := acctest.RandString(10)
+	name := "cloudflare_logpush_job." + rnd
+	ownershipToken := os.Getenv("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareLogpushJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareLogpushJobConfig(zone, rnd, ownershipToken),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "test-logpush-job"),
+					resource.TestCheckResourceAttr(name, "enabled", "true"),
+					resource.TestCheckResourceAttr(name, "logpull_options", "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339"),
+					resource.TestCheckResourceAttr(name, "destination_conf", "s3://logpush-test-bucket?region=us-west-1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareLogpushJobDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_logpush_job" {
+			continue
+		}
+
+		primaryID, err := strconv.Atoi(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("Could not retrieve LogpushJob ID")
+		}
+
+		_, fetchErr := client.LogpushJob(rs.Primary.Attributes["zone_id"], primaryID)
+		if fetchErr == nil {
+			return fmt.Errorf("Logpush job still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudflareLogpushJobConfig(zoneName, ID, ownershipToken string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_logpush_job" "%[2]s" {
+  name = "test-logpush-job"
+  enabled = "true" 
+  zone = "%[1]s"
+  destination_conf = "s3://logpush-test-bucket?region=us-west-1"
+  logpull_options = "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339"
+  ownership_challenge = "%[3]s"
+}`, zoneName, ID, ownershipToken)
+}

--- a/cloudflare/resource_cloudflare_logpush_job_test.go
+++ b/cloudflare/resource_cloudflare_logpush_job_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestAccCloudflareLogpushJob_Basic(t *testing.T) {
-	zone := os.Getenv("CLOUDFLARE_DOMAIN")
-	rnd := acctest.RandString(10)
+	jobID := acctest.RandString(10)
 	name := "cloudflare_logpush_job." + rnd
+	zoneID = os.Getenv("CLOUDFLARE_ZONE_ID")
 	ownershipToken := os.Getenv("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN")
 
 	resource.Test(t, resource.TestCase{
@@ -28,7 +28,7 @@ func TestAccCloudflareLogpushJob_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckCloudflareLogpushJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflareLogpushJobConfig(zone, rnd, ownershipToken),
+				Config: testAccCheckCloudflareLogpushJobConfig(jobID, zoneID, ownershipToken),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", "test-logpush-job"),
 					resource.TestCheckResourceAttr(name, "enabled", "true"),
@@ -63,14 +63,14 @@ func testAccCheckCloudflareLogpushJobDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudflareLogpushJobConfig(zoneName, ID, ownershipToken string) string {
+func testAccCheckCloudflareLogpushJobConfig(jobID, zoneID, ownershipToken string) string {
 	return fmt.Sprintf(`
-resource "cloudflare_logpush_job" "%[2]s" {
+resource "cloudflare_logpush_job" "%[1]s" {
   name = "test-logpush-job"
   enabled = "true" 
-  zone = "%[1]s"
+  zone_id = "%[2]s"
   destination_conf = "s3://logpush-test-bucket?region=us-west-1"
   logpull_options = "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339"
   ownership_challenge = "%[3]s"
-}`, zoneName, ID, ownershipToken)
+}`, jobID, zoneID, ownershipToken)
 }

--- a/cloudflare/resource_cloudflare_logpush_job_test.go
+++ b/cloudflare/resource_cloudflare_logpush_job_test.go
@@ -20,7 +20,10 @@ func TestAccCloudflareLogpushJob_Basic(t *testing.T) {
 	ownershipToken := os.Getenv("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckLogpushToken(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudflareLogpushJobDestroy,
 		Steps: []resource.TestStep{

--- a/cloudflare/resource_cloudflare_logpush_job_test.go
+++ b/cloudflare/resource_cloudflare_logpush_job_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestAccCloudflareLogpushJob_Basic(t *testing.T) {
 	jobID := acctest.RandString(10)
-	name := "cloudflare_logpush_job." + rnd
-	zoneID = os.Getenv("CLOUDFLARE_ZONE_ID")
+	name := "cloudflare_logpush_job." + jobID
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	ownershipToken := os.Getenv("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN")
 
 	resource.Test(t, resource.TestCase{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.19.11 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/cloudflare/cloudflare-go v0.8.6-0.20190328165822-4034ff974d99
+	github.com/cloudflare/cloudflare-go v0.8.6-0.20190409214620-92c75602c045
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/go-getter v1.2.0 // indirect
 	github.com/hashicorp/go-hclog v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJ
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.8.6-0.20190328165822-4034ff974d99 h1:2axtLqDDameHDzDfIDo1R+nZHmNoxItkzTkQJhACK8k=
 github.com/cloudflare/cloudflare-go v0.8.6-0.20190328165822-4034ff974d99/go.mod h1:wqCYq1S9oX9sYJ5O8rF6z8qocTG+vA35evLmFE2Qi60=
+github.com/cloudflare/cloudflare-go v0.8.6-0.20190409214620-92c75602c045 h1:CVIPe6Ft0OJZOE2CHaKs2XeJ80ik/bxFMOCbLjb9Ekg=
+github.com/cloudflare/cloudflare-go v0.8.6-0.20190409214620-92c75602c045/go.mod h1:wqCYq1S9oX9sYJ5O8rF6z8qocTG+vA35evLmFE2Qi60=
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
 github.com/coreos/bbolt v1.3.1-coreos.1/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.2.0-rc.1.0.20170908195435-80aa810309d4+incompatible h1:VLCxgrfBsnJtqTy0WFP0GsjjwWZQiuQiNgiWnY6g6Gc=

--- a/vendor/github.com/cloudflare/cloudflare-go/logpush.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/logpush.go
@@ -10,14 +10,15 @@ import (
 
 // LogpushJob describes a Logpush job.
 type LogpushJob struct {
-	ID              int        `json:"id,omitempty"`
-	Enabled         bool       `json:"enabled"`
-	Name            string     `json:"name"`
-	LogpullOptions  string     `json:"logpull_options"`
-	DestinationConf string     `json:"destination_conf"`
-	LastComplete    *time.Time `json:"last_complete,omitempty"`
-	LastError       *time.Time `json:"last_error,omitempty"`
-	ErrorMessage    string     `json:"error_message,omitempty"`
+	ID                 int        `json:"id,omitempty"`
+	Enabled            bool       `json:"enabled"`
+	Name               string     `json:"name"`
+	LogpullOptions     string     `json:"logpull_options"`
+	DestinationConf    string     `json:"destination_conf"`
+	OwnershipChallenge string     `json:"ownership_challenge,omitempty"`
+	LastComplete       *time.Time `json:"last_complete,omitempty"`
+	LastError          *time.Time `json:"last_error,omitempty"`
+	ErrorMessage       string     `json:"error_message,omitempty"`
 }
 
 // LogpushJobsResponse is the API response, containing an array of Logpush Jobs.
@@ -135,7 +136,7 @@ func (api *API) LogpushJob(zoneID string, jobID int) (LogpushJob, error) {
 // API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
 func (api *API) UpdateLogpushJob(zoneID string, jobID int, job LogpushJob) error {
 	uri := "/zones/" + zoneID + "/logpush/jobs/" + strconv.Itoa(jobID)
-	res, err := api.makeRequest("PUT", uri, nil)
+	res, err := api.makeRequest("PUT", uri, job)
 	if err != nil {
 		return errors.Wrap(err, errMakeRequestError)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
-# github.com/cloudflare/cloudflare-go v0.8.6-0.20190328165822-4034ff974d99
+# github.com/cloudflare/cloudflare-go v0.8.6-0.20190409214620-92c75602c045
 github.com/cloudflare/cloudflare-go
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -55,6 +55,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-load-balancer-pool") %>>
               <a href="/docs/providers/cloudflare/r/load_balancer_pool.html">cloudflare_load_balancer_pool</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-logpush-job") %>>
+              <a href="/docs/providers/cloudflare/r/logpush_job.html">cloudflare_logpush_job</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-page-rule") %>>
                 <a href="/docs/providers/cloudflare/r/page_rule.html">cloudflare_page_rule</a>
             </li>

--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_logpush_job"
+sidebar_current: "docs-cloudflare-logpush-job"
+description: |-
+  Provides a resource which manages Cloudflare logpush jobs.
+---
+
+# cloudflare_logpush_job
+
+Provides a resource which manages Cloudflare logpush jobs.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_logpush_job" "example_job" {
+  enabled = true
+  name = "My logpush job"
+  logpull_options = "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339"
+  destination_conf = "s3://my-bucket-path?region=us-west-2"
+  ownership_challenge = "00000000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `desitination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included.
+* `ownership_challenge` - (Required) Ownership challenge token to prove destination ownership. See [https://developers.cloudflare.com/logs/tutorials/tutorial-logpush-curl/](https://developers.cloudflare.com/logs/tutorials/tutorial-logpush-curl/)
+
+## Import
+
+Account members can be imported using a composite ID formed of account ID and account member ID, e.g.
+
+```
+$ terraform import cloudflare_logpush_job.example_job d41d8cd98f00b204e9800998ecf8427e/b58c6f14d292556214bd64909bcdb118
+```
+
+where:
+
+* `d41d8cd98f00b204e9800998ecf8427e` - account ID as returned by the [API](https://api.cloudflare.com/#accounts-account-details)
+* `b58c6f14d292556214bd64909bcdb118` - logpush job ID as returned by the [API](https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs)

--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 ## Import
 
-Account members can be imported using a composite ID formed of account ID and account member ID, e.g.
+Logpush jobs can be imported using a composite ID formed of zone ID and logpush ID, e.g.
 
 ```
 $ terraform import cloudflare_logpush_job.example_job d41d8cd98f00b204e9800998ecf8427e/b58c6f14d292556214bd64909bcdb118


### PR DESCRIPTION
This adds a new resource ```cloudflare_logpush_job``` which represents a long running task that delivers your Cloudflare logs to a configured storage bucket at a regular interval.

See [the docs](https://developers.cloudflare.com/logs/about/) for more info on the Logpush feature.

**N.B.** we've decided not to represent Logpush ownership verification challenges in Terraform, at least for now. See [the Logpush API docs](https://developers.cloudflare.com/logs/tutorials/tutorial-logpush-curl/) for more info on how to create and complete an ownership challenge. 

As such, this PR adds support for performing CRUD operations on Logpush jobs via Terraform.

```
$ go test -v -run TestAccCloudflareLogpushJob_Basic ./... 
=== RUN   TestAccCloudflareLogpushJob_Basic
--- PASS: TestAccCloudflareLogpushJob_Basic (6.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-cloudflare/cloudflare 6.806s
```