### PR TITLE
cloudflare_page_rule: Allow `browser_cache_ttl` of 0

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -326,7 +326,7 @@ func resourceCloudflarePageRuleCreate(d *schema.ResourceData, meta interface{}) 
 			newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value, false)
 			if err != nil {
 				return err
-			} else if newPageRuleAction.Value == nil {
+			} else if newPageRuleAction.Value == nil || newPageRuleAction.Value == "" {
 				continue
 			}
 			newPageRuleActions = append(newPageRuleActions, newPageRuleAction)
@@ -588,7 +588,7 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, changed b
 			}
 		}
 	} else if intValue, ok := value.(int); ok {
-		if intValue == 0 && !changed {
+		if (id == "edge_cache_ttl" && intValue == 0) || !changed {
 			// This happens when not set by the user
 			pageRuleAction.Value = nil
 		} else {


### PR DESCRIPTION
In c1799f4, @patryk made some improvements on how the `Update` handles
working out which rules need to be changed. With the introduction of
that change, the `transformToCloudflarePageRuleAction` now accepts a
third argument of whether the action has changed. For the majority of
rules, this isn't problematic however it has caused issues with
`browser_cache_ttl` as a value of 0 tells Cloudflare to respect the
origin cache control headers however, here it would end up setting the
page rule action value to `nil` (as it hadn't changed and was equal to
0).

To start with, I was going to remove the `intValue == 0` portion of the
check and just rely on whether the rule had been changed but this didn't
work due to the way disabling `edge_cache_ttl` works (it is set to 0
for removal). Instead, I moved the check into the conditional for the
`pageRuleAPIFloatFields` `elseif` which will allow the functionality for
both to work actions to work as desired.

Fixes https://github.com/terraform-providers/terraform-provider-cloudflare/issues/107#issuecomment-482353024