### PR TITLE
Add sweeper for `cloudflare_zones`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,6 +9,10 @@ default: build
 build: fmtcheck
 	go install -ldflags="-X github.com/terraform-providers/terraform-provider-cloudflare/version.ProviderVersion=$(VERSION)"
 
+sweep:
+	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
+	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)
+
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
@@ -57,4 +61,4 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
+.PHONY: build test sweep testacc vet fmt fmtcheck errcheck test-compile website website-test

--- a/cloudflare/cloudflare_sweeper_test.go
+++ b/cloudflare/cloudflare_sweeper_test.go
@@ -1,11 +1,25 @@
 package cloudflare
 
 import (
+	"os"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
+}
+
+// sharedClient returns a common Cloudflare client setup needed for the
+// sweeper functions.
+func sharedClient() (*cloudflare.API, error) {
+	client, err := cloudflare.New(os.Getenv("CLOUDFLARE_TOKEN"), os.Getenv("CLOUDFLARE_EMAIL"))
+
+	if err != nil {
+		return client, err
+	}
+
+	return client, nil
 }

--- a/cloudflare/cloudflare_sweeper_test.go
+++ b/cloudflare/cloudflare_sweeper_test.go
@@ -1,0 +1,11 @@
+package cloudflare
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -21,12 +21,12 @@ func init() {
 func testSweepCloudflareZones(r string) error {
 	client, clientErr := sharedClient()
 	if clientErr != nil {
-		log.Fatalf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
+		log.Printf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
 	}
 
 	zones, zoneErr := client.ListZones("baa.com", "baa.net", "baa.org", "foo.net")
 	if zoneErr != nil {
-		log.Fatalf("[ERROR] Failed to fetch Cloudflare zones: %s", zoneErr)
+		log.Printf("[ERROR] Failed to fetch Cloudflare zones: %s", zoneErr)
 	}
 
 	if len(zones) == 0 {

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -3,11 +3,9 @@ package cloudflare
 import (
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -21,8 +19,15 @@ func init() {
 }
 
 func testSweepCloudflareZones(r string) error {
-	client, _ := cloudflare.New(os.Getenv("CLOUDFLARE_TOKEN"), os.Getenv("CLOUDFLARE_EMAIL"))
-	zones, _ := client.ListZones("baa.com", "baa.net", "baa.org", "foo.net")
+	client, clientErr := sharedClient()
+	if clientErr != nil {
+		log.Fatalf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
+	}
+
+	zones, zoneErr := client.ListZones("baa.com", "baa.net", "baa.org", "foo.net")
+	if zoneErr != nil {
+		log.Fatalf("[ERROR] Failed to fetch Cloudflare zones: %s", zoneErr)
+	}
 
 	if len(zones) == 0 {
 		log.Print("[DEBUG] No Cloudflare Zones to sweep")


### PR DESCRIPTION
Creates a [Terraform sweeper](https://www.terraform.io/docs/extend/testing/acceptance-tests/sweepers.html) to clean up any dangling resources. Here,
for Cloudflare zones that are being used a test for management via the
API. I've restricted the lookup to the ephemeral zones we want to
remove instead of all of them as I suspect removing all would make the
other tests fail that depend on it always being there.

Closes #296