### PR TITLE
page_rules: Fix logic error for `transformToCloudflarePageRuleAction`

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -616,7 +616,7 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, changed b
 			}
 		}
 	} else if intValue, ok := value.(int); ok {
-		if (id == "edge_cache_ttl" && intValue == 0) || !changed {
+		if (id == "edge_cache_ttl" && intValue == 0) && !changed {
 			// This happens when not set by the user
 			pageRuleAction.Value = nil
 		} else {


### PR DESCRIPTION
In order to be able to use `browser_cache_ttl` of 0 in page rules (to
respect the origin cache control value) I updated the required logic in
#291. Unfortunately, this only partially fixed the issue. Updating an
existing resource worked fine however creating a new resource fell into
the old behaviour due to using `||` where it should have been a `&&` to
ensure both conditions were met.