### PR TITLE
page_rules: Make cache TTLs behave sensibly

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"strings"
 
@@ -206,15 +207,15 @@ func resourceCloudflarePageRule() *schema.Resource {
 						},
 
 						"browser_cache_ttl": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntAtMost(31536000),
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
 						},
 
 						"edge_cache_ttl": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntAtMost(31536000),
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
 						},
 
 						"cache_level": {
@@ -599,7 +600,11 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, changed b
 		if strValue == "" && !changed {
 			pageRuleAction.Value = nil
 		} else {
-			pageRuleAction.Value = strValue
+			if id == "browser_cache_ttl" || id == "edge_cache_ttl" {
+				pageRuleAction.Value, _ = strconv.Atoi(strValue)
+			} else {
+				pageRuleAction.Value = strValue
+			}
 		}
 	} else if unitValue, ok := value.(bool); ok {
 		if !unitValue {
@@ -614,13 +619,6 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, changed b
 			} else {
 				pageRuleAction.Value = true
 			}
-		}
-	} else if intValue, ok := value.(int); ok {
-		if (id == "edge_cache_ttl" && intValue == 0) || !changed {
-			// This happens when not set by the user
-			pageRuleAction.Value = nil
-		} else {
-			pageRuleAction.Value = intValue
 		}
 	} else if id == "forwarding_url" {
 		forwardActionSchema := value.([]interface{})


### PR DESCRIPTION
This changes the schema definition for `browser_cache_ttl` and
`edge_cache_ttl` from integers to strings (to be cast as integers
instead). This has come about because I've been battling getting
`browser_cache_ttl` to work consistently for the following scenarios:

- Creating a new action for a page rule where `browser_cache_ttl` is 0.
- Updating an action in a page rule where `browser_cache_ttl` is set to
  1 and I want to update it to 0.

The current logic where `browser_cache_ttl` and `edge_cache_ttl` are
grouped and treated similar made this quite difficult as only
`browser_cache_ttl` accepts 0 as a valid API value whereas 1 is the
minimum for `edge_cache_ttl`. To get around this, I've ditched the
checks that assumed 0 was a default value and instead explicitly set
the default for these keys as empty strings. This means they will end up
as `nil` and not get triggered for API updates but can still be set to
integers (cast as strings) for when you actually want those values.

One of the trade offs I've made here is removing the integer validation.
While the validation is great, I feel that this work around is better to
get the `{browser,edge}_cache_ttl` functionality working as expected is
more important. The validation will now just be enforced by the API
instead.