### PR TITLE
page_rules: Swap to completely replacing rules

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -350,7 +350,7 @@ func resourceCloudflarePageRuleCreate(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Actions found in config: %#v", actions)
 	for _, action := range actions {
 		for id, value := range action.(map[string]interface{}) {
-			newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value, false)
+			newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value)
 			if err != nil {
 				return err
 			} else if newPageRuleAction.Value == nil || newPageRuleAction.Value == "" {
@@ -463,25 +463,24 @@ func resourceCloudflarePageRuleUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	old, new := d.GetChange("actions")
+	if v, ok := d.GetOk("actions"); ok {
+		actions := v.([]interface{})
+		newPageRuleActions := make([]cloudflare.PageRuleAction, 0, len(actions))
 
-	oldActions := old.([]interface{})[0].(map[string]interface{})
-	newActions := new.([]interface{})[0].(map[string]interface{})
-
-	newPageRuleActions := make([]cloudflare.PageRuleAction, 0, len(newActions))
-
-	for id, value := range newActions {
-		hasChanged := id != "forwarding_url" && id != "minify" && oldActions[id] != value
-		newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value, hasChanged)
-		if err != nil {
-			return err
-		} else if newPageRuleAction.Value == nil {
-			continue
+		for _, action := range actions {
+			for id, value := range action.(map[string]interface{}) {
+				newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value)
+				if err != nil {
+					return err
+				} else if newPageRuleAction.Value == nil {
+					continue
+				}
+				newPageRuleActions = append(newPageRuleActions, newPageRuleAction)
+			}
 		}
-		newPageRuleActions = append(newPageRuleActions, newPageRuleAction)
-	}
 
-	updatePageRule.Actions = newPageRuleActions
+		updatePageRule.Actions = newPageRuleActions
+	}
 
 	if priority, ok := d.GetOk("priority"); ok {
 		updatePageRule.Priority = priority.(int)
@@ -493,9 +492,7 @@ func resourceCloudflarePageRuleUpdate(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[DEBUG] Cloudflare Page Rule update configuration: %#v", updatePageRule)
 
-	// contrary to docs, change page rule actually does a full replace
-	// this part of the api needs some work, so it may change in future
-	if err := client.ChangePageRule(zoneID, d.Id(), updatePageRule); err != nil {
+	if err := client.UpdatePageRule(zoneID, d.Id(), updatePageRule); err != nil {
 		return fmt.Errorf("Failed to update Cloudflare Page Rule: %s", err)
 	}
 
@@ -591,7 +588,7 @@ func transformFromCloudflarePageRuleAction(pageRuleAction *cloudflare.PageRuleAc
 	return
 }
 
-func transformToCloudflarePageRuleAction(id string, value interface{}, changed bool) (pageRuleAction cloudflare.PageRuleAction, err error) {
+func transformToCloudflarePageRuleAction(id string, value interface{}) (pageRuleAction cloudflare.PageRuleAction, err error) {
 
 	pageRuleAction.ID = id
 


### PR DESCRIPTION
For a long time, this provider relied on sending page rules using
cloudflare-go's `ChangePageRule` which was documentated to allow inline
updates using a PATCH request. Until recently, this wasn't the case and
it actually mimicked the PUT alternative (`UpdatePageRule`) where it
attempted to replace the entire rule. This was [fixed](https://github.com/terraform-providers/terraform-provider-cloudflare/pull/176#issuecomment-452906541) and while you
could now send inline updates to actions, there wasn't a way to remove
them once they were there. To address this, I've swapped back to
`UpdatePageRule` (the PUT request) which will resolve the aforementioned
issue with removing rules but it does re-introduce the caveat of not
being able to manage actions that require a Solutions Engineer. This
means, you can't manage them using this endpoint as you won't have
permission to apply them. This extends to page rule changes like
re-ordering or updating other actions which are in the same rule. If you
hit this use case, you should move the cache key into Cloudflare
Workers.

This commit backs out most of the changes from c1799f4 as they are no
longer required for differentiating the actions to send but it does
introduce some changes to the way we determine whether or not we send
`browser_cache_ttl` and `edge_cache_ttl` based on some issues
encountered with their default values. It now performs a `HasChange` on 
their values to help determine whether or not they should be a part of 
the payload.

Closes #198 
Closes #265
