### PR TITLE
Add support for Workers KV

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -108,6 +108,8 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_waf_rule":               resourceCloudflareWAFRule(),
 			"cloudflare_worker_route":           resourceCloudflareWorkerRoute(),
 			"cloudflare_worker_script":          resourceCloudflareWorkerScript(),
+			"cloudflare_worker_kv_namespace":    resourceCloudflareWorkerKVNamespace(),
+			"cloudflare_worker_kv_pair":         resourceCloudflareWorkerKVPair(),
 			"cloudflare_zone_lockdown":          resourceCloudflareZoneLockdown(),
 			"cloudflare_zone_settings_override": resourceCloudflareZoneSettingsOverride(),
 			"cloudflare_zone":                   resourceCloudflareZone(),

--- a/cloudflare/resource_cloudflare_worker_kv_namespace.go
+++ b/cloudflare/resource_cloudflare_worker_kv_namespace.go
@@ -1,0 +1,155 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudflareWorkerKVNamespace() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareWorkerKVNamespaceCreate,
+		Read:   resourceCloudflareWorkerKVNamespaceRead,
+		Update: resourceCloudflareWorkerKVNamespaceUpdate,
+		Delete: resourceCloudflareWorkerKVNamespaceDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareWorkerKVNamespaceImport,
+		},
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"title": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func kvNamespaceRequestFromResource(d *schema.ResourceData) *cloudflare.WorkersKVNamespaceRequest {
+	return &cloudflare.WorkersKVNamespaceRequest{
+		Title: d.Get("title").(string),
+	}
+}
+
+func kvNamespaceFromResource(d *schema.ResourceData) cloudflare.WorkersKVNamespace {
+	namespace := cloudflare.WorkersKVNamespace{
+		ID:    d.Id(),
+		Title: d.Get("title").(string),
+	}
+	return namespace
+}
+
+func resourceCloudflareWorkerKVNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
+	req := kvNamespaceRequestFromResource(d)
+
+	log.Printf("[INFO] Creating Cloudflare Workers KV Namespace from struct: %+v", req)
+
+	client, err := clientWithOrg(meta)
+	var resp cloudflare.WorkersKVNamespaceResponse
+	if client != nil {
+		resp, err = client.CreateWorkersKVNamespace(context.Background(), req)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "error creating workers kv namespace")
+	}
+
+	id := resp.Result.ID
+
+	if id == "" {
+		return fmt.Errorf("failed to find id in Create response; resource was empty")
+	}
+
+	d.SetId(id)
+
+	log.Printf("[INFO] Cloudflare Workers KV Namespace ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceCloudflareWorkerKVNamespaceRead(d *schema.ResourceData, meta interface{}) error {
+	namespace, err := resourceCloudflareWorkerKVNamespaceReadById(d.Id(), meta)
+	if err != nil {
+		return errors.Wrap(err, "error Reading workers kv namespaces")
+	}
+
+	if namespace.ID == "" {
+		d.SetId("")
+	} else {
+		d.Set("title", namespace.Title)
+	}
+
+	return nil
+}
+
+func resourceCloudflareWorkerKVNamespaceReadById(namespaceId string, meta interface{}) (*cloudflare.WorkersKVNamespace, error) {
+	client, err := clientWithOrg(meta)
+
+	var resp cloudflare.ListWorkersKVNamespacesResponse
+	if client != nil {
+		resp, err = client.ListWorkersKVNamespaces(context.Background())
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ns := range resp.Result {
+		if ns.ID == namespaceId {
+			return &ns, nil
+		}
+	}
+
+	return nil, fmt.Errorf("not found")
+}
+
+func resourceCloudflareWorkerKVNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	namespace := kvNamespaceFromResource(d)
+	req := kvNamespaceRequestFromResource(d)
+
+	log.Printf("[INFO] Updating Cloudflare Workers KV Namespace from struct: %+v", namespace)
+
+	client, err := clientWithOrg(meta)
+	if client != nil {
+		_, err = client.UpdateWorkersKVNamespace(context.Background(), namespace.ID, req)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "error updating workers kv namespace")
+	}
+
+	return nil
+}
+
+func resourceCloudflareWorkerKVNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
+	namespace := kvNamespaceFromResource(d)
+
+	log.Printf("[INFO] Deleting Cloudflare Workers KV Namespace with id: %+v", namespace.ID)
+
+	client, err := clientWithOrg(meta)
+	if client != nil {
+		_, err = client.DeleteWorkersKVNamespace(context.Background(), namespace.ID)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "error deleting workers kv namespace")
+	}
+
+	return nil
+}
+
+func resourceCloudflareWorkerKVNamespaceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	namespace, err := resourceCloudflareWorkerKVNamespaceReadById(d.Id(), meta)
+	if err != nil {
+		return nil, errors.Wrap(err, "error Importing workers kv namespace")
+	}
+
+	d.Set("title", namespace.Title)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/cloudflare/resource_cloudflare_worker_kv_pair.go
+++ b/cloudflare/resource_cloudflare_worker_kv_pair.go
@@ -1,0 +1,126 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/pkg/errors"
+)
+
+// TODO: add expiring key support when cloudflare-go updates.
+func resourceCloudflareWorkerKVPair() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareWorkerKVPairUpdate,
+		Read:   resourceCloudflareWorkerKVPairRead,
+		Update: resourceCloudflareWorkerKVPairUpdate,
+		Delete: resourceCloudflareWorkerKVPairDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareWorkerKVPairImport,
+		},
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceCloudflareWorkerKVPairGet(namespace string, key string, meta interface{}) ([]byte, error) {
+	client, err := clientWithOrg(meta)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.ReadWorkersKV(context.Background(), namespace, key)
+}
+
+func resourceCloudflareWorkerKVPairRead(d *schema.ResourceData, meta interface{}) error {
+	namespace := d.Get("namespace").(string)
+	key := d.Get("key").(string)
+
+	val, err := resourceCloudflareWorkerKVPairGet(namespace, key, meta)
+	if err != nil {
+		return errors.Wrap(err, "error Reading workers kv pair")
+	}
+
+	// Since the resource schema does not support byte arrays,
+	// encode the value as a string.
+	d.Set("value", string(val))
+
+	return nil
+}
+
+func resourceCloudflareWorkerKVPairUpdate(d *schema.ResourceData, meta interface{}) error {
+	namespace := d.Get("namespace").(string)
+	key := d.Get("key").(string)
+	value := []byte(d.Get("value").(string))
+
+	log.Printf("[INFO] Updating Cloudflare Workers KV Pair of %+v/%+v = %+v", namespace, key, value)
+
+	client, err := clientWithOrg(meta)
+	if client != nil {
+		_, err = client.WriteWorkersKV(context.Background(), namespace, key, value)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(namespace + "/" + key)
+
+	return nil
+}
+
+func resourceCloudflareWorkerKVPairDelete(d *schema.ResourceData, meta interface{}) error {
+	namespace := d.Get("namespace").(string)
+	key := d.Get("key").(string)
+
+	log.Printf("[INFO] Deleting Cloudflare Workers KV Pair with key: %+v", key)
+
+	client, err := clientWithOrg(meta)
+	if client != nil {
+		_, err = client.DeleteWorkersKV(context.Background(), namespace, key)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "error Deleting workers kv pair")
+	}
+
+	return nil
+}
+
+func resourceCloudflareWorkerKVPairImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// split the id so we can lookup
+	attr := strings.SplitN(d.Id(), "/", 2)
+	var namespace string
+	var key string
+	if len(attr) == 2 {
+		namespace = attr[0]
+		key = attr[1]
+	} else {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"namespaceId/key\"", d.Id())
+	}
+
+	d.Set("namespace", namespace)
+	d.Set("key", key)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -4,8 +4,25 @@ import (
 	"crypto/md5"
 	"fmt"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform/helper/schema"
 )
+
+func client(meta interface{}) *cloudflare.API {
+	return meta.(*cloudflare.API)
+}
+
+// TODO: will need to be refactored when Orginization API is deprecated.
+// https://github.com/terraform-providers/terraform-provider-cloudflare/issues/227
+func clientWithOrg(meta interface{}) (*cloudflare.API, error) {
+	client := client(meta)
+
+	if client.OrganizationID == "" {
+		return nil, fmt.Errorf("provider needs 'org_id' for this action")
+	}
+
+	return client, nil
+}
 
 func expandInterfaceToStringList(list interface{}) []string {
 	ifaceList := list.([]interface{})

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -82,6 +82,12 @@
             <li<%= sidebar_current("docs-cloudflare-resource-worker-script") %>>
               <a href="/docs/providers/cloudflare/r/worker_script.html">cloudflare_worker_script</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-worker-kv-namespace") %>>
+              <a href="/docs/providers/cloudflare/r/worker_kv_namespace.html">cloudflare_worker_kv_namespace</a>
+            </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-worker-kv-pair") %>>
+              <a href="/docs/providers/cloudflare/r/worker_kv_pair.html">cloudflare_worker_kv_pair</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-zone") %>>
               <a href="/docs/providers/cloudflare/r/zone.html">cloudflare_zone</a>
             </li>

--- a/website/docs/r/worker_kv_namespace.html.markdown
+++ b/website/docs/r/worker_kv_namespace.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_worker_kv_namespace"
+sidebar_current: "docs-cloudflare-resource-worker-kv-namespace"
+description: |-
+  Provides a Cloudflare worker kv namespace resource.
+---
+
+# cloudflare_worker_kv_namespace
+
+Provides a Cloudflare worker kv namespace resource. A namespace will also require a `cloudflare_worker_script`.
+
+## Example Usage
+
+```hcl
+# Creates a new workers kv namespace titled 'My Namespace'
+resource "cloudflare_worker_kv_namespace" "my_namespace" {
+  title = "My Namespace"
+
+  # it's recommended to set `depends_on` to point to the cloudflare_worker_script
+  # resource in order to make sure that the script is uploaded before the route
+  # is created
+  depends_on = ["cloudflare_worker_script.my_script"]
+}
+
+resource "cloudflare_worker_script" "my_script" {
+  # see "cloudflare_worker_script" documentation ...
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `title` - (Required) The human-readable title of the namespace.
+
+## Import
+
+Records can be imported using the ID of the namespace, e.g.
+
+```
+$ terraform import cloudflare_worker_kv_namespace.default 0f2ac74b498b48028cb68387c421e279
+```
+
+where:
+
+* `0f2ac74b498b48028cb68387c421e279` - route ID as returned by [API](https://api.cloudflare.com/#workers-kv-namespace-create-a-namespace)
+
+

--- a/website/docs/r/worker_kv_pair.html.markdown
+++ b/website/docs/r/worker_kv_pair.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_worker_kv_pair"
+sidebar_current: "docs-cloudflare-resource-worker-kv-pair"
+description: |-
+  Provides a Cloudflare worker kv pair resource.
+---
+
+# cloudflare_worker_kv_pair
+
+Provides a Cloudflare worker kv pair resource. A pair will require both a `cloudflare_worker_kv_namespace` and a `cloudflare_worker_script`.
+
+## Example Usage
+
+```hcl
+# Create a new key-value pair from a local file
+resource "cloudflare_worker_kv_pair" "my_pair" {
+  namespace = "${cloudflare_worker_kv_namespace.my_namespace.id}"
+  key = "my-key"
+  value = "${my-file.txt}"
+
+  # it's recommended to set `depends_on` to make sure that the
+  # kv namespace and script have both been created
+  depends_on = ["cloudflare_worker_kv_namespace.my_namespace"]
+}
+
+resource "cloudflare_worker_kv_namespace" "my_namespace" {
+  # see "cloudflare_worker_kv_namespace" documentation ...
+  depends_on = ["cloudflare_worker_kv_namespace.my_script"]
+}
+
+resource "cloudflare_worker_script" "my_script" {
+  # see "cloudflare_worker_script" documentation ...
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Required) The ID of the worker kv namespace.
+* `key` - (Required) The key name of the pair.
+* `value` - (Required) The value of the pair.
+
+## Import
+
+Records can be imported using the ID of the pair, e.g.
+
+```
+$ terraform import cloudflare_worker_kv_pair.default 0f2ac74b498b48028cb68387c421e279/my-key
+```
+
+where:
+
+* `0f2ac74b498b48028cb68387c421e279` - namespace ID as returned by [API](https://api.cloudflare.com/#workers-kv-namespace-create-a-namespace)
+* `my-key` - key name of the pair
+
+


### PR DESCRIPTION
Addresses the resource request from #277. I'm _relatively_ new to Go, so feel free to nit pick! Since KV is eventually consistent, acceptance tests could prove to be more of a hassle than it's worth, thoughts?

* Adds `cloudflare_worker_kv_namespace` and `cloudflare_worker_kv_pair` resources 
* Convince methods for casting the client were added to `utils.go`<br>(may need future refactoring with account overhaul)
* Updates website documentation