### PR TITLE
Fixing actions block in example

### DIFF
--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -19,7 +19,7 @@ resource "cloudflare_page_rule" "foobar" {
   target = "sub.${var.cloudflare_zone}/page"
   priority = 1
 
-  actions = {
+  actions {
     ssl = "flexible"
     email_obfuscation = "on"
     minify {


### PR DESCRIPTION
Example Actions block had `=` that was not required