### PR TITLE
Fix browser_cache_ttl page rule action bugs

### DIFF
--- a/cloudflare/import_cloudflare_page_rule_test.go
+++ b/cloudflare/import_cloudflare_page_rule_test.go
@@ -40,3 +40,49 @@ func TestAccCloudflarePageRule_Import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCloudflarePageRule_ImportWithBrowserCacheTTL30(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	name := "cloudflare_page_rule.test"
+	testAccRunResourceTestSteps(t, []resource.TestStep{
+		{
+			Config: buildPageRuleConfig("test", "browser_cache_ttl = 30"),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckCloudflarePageRuleExists(name, &pageRule),
+			),
+		},
+		{
+			ResourceName:        name,
+			ImportStateIdPrefix: fmt.Sprintf("%s/", zone),
+			ImportState:         true,
+			ImportStateVerify:   true,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckCloudflarePageRuleExists(name, &pageRule),
+			),
+		},
+	})
+}
+
+func TestAccCloudflarePageRule_ImportWithoutBrowserCacheTTL(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	name := "cloudflare_page_rule.test"
+	testAccRunResourceTestSteps(t, []resource.TestStep{
+		{
+			Config: buildPageRuleConfig("test", `browser_check = "on"`),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckCloudflarePageRuleExists(name, &pageRule),
+			),
+		},
+		{
+			ResourceName:        name,
+			ImportStateIdPrefix: fmt.Sprintf("%s/", zone),
+			ImportState:         true,
+			ImportStateVerify:   true,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckCloudflarePageRuleExists(name, &pageRule),
+			),
+		},
+	})
+}

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -3,7 +3,7 @@ package cloudflare
 import (
 	"fmt"
 	"log"
-
+	"strconv"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
@@ -206,9 +206,9 @@ func resourceCloudflarePageRule() *schema.Resource {
 						},
 
 						"browser_cache_ttl": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntAtMost(31536000),
+							Type:     schema.TypeString,
+							Optional: true,
+							//ValidateFunc: validation.IntAtMost(31536000),
 						},
 
 						"edge_cache_ttl": {
@@ -596,7 +596,12 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 	changed := d.HasChange(fmt.Sprintf("actions.0.%s", id))
 
 	if strValue, ok := value.(string); ok {
-		if strValue == "" && !changed {
+		if id == "browser_cache_ttl" && changed {
+			intValue, err := strconv.Atoi(strValue)
+			if err == nil {
+				pageRuleAction.Value = intValue
+			}
+		} else if strValue == "" && !changed {
 			pageRuleAction.Value = nil
 		} else {
 			pageRuleAction.Value = strValue
@@ -616,9 +621,7 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 			}
 		}
 	} else if intValue, ok := value.(int); ok {
-		if id == "browser_cache_ttl" && changed {
-			pageRuleAction.Value = intValue
-		} else if id == "edge_cache_ttl" && intValue > 0 && changed {
+		if id == "edge_cache_ttl" && intValue > 0 && changed {
 			pageRuleAction.Value = intValue
 		} else {
 			pageRuleAction.Value = nil

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -208,7 +208,6 @@ func resourceCloudflarePageRule() *schema.Resource {
 						"browser_cache_ttl": {
 							Type:     schema.TypeString,
 							Optional: true,
-							//ValidateFunc: validation.IntAtMost(31536000),
 						},
 
 						"edge_cache_ttl": {

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -540,12 +540,6 @@ var pageRuleAPINilFields = []string{
 	"disable_railgun",
 	"disable_security",
 }
-var pageRuleAPIFloatFields = []string{
-	"edge_cache_ttl",
-}
-var pageRuleAPIFloatAsStringFields = []string{
-	"browser_cache_ttl",
-}
 var pageRuleAPIStringFields = []string{
 	"bypass_cache_on_cookie",
 	"cache_key",
@@ -571,15 +565,15 @@ func transformFromCloudflarePageRuleAction(pageRuleAction *cloudflare.PageRuleAc
 		value = true
 		break
 
-	case contains(pageRuleAPIFloatFields, pageRuleAction.ID):
-		value = pageRuleAction.Value.(float64) // we use TypeInt but terraform seems to do the right thing converting from float
-		break
-
 	case contains(pageRuleAPIStringFields, pageRuleAction.ID):
 		value = pageRuleAction.Value.(string)
 		break
 
-	case contains(pageRuleAPIFloatAsStringFields, pageRuleAction.ID):
+	case pageRuleAction.ID == "edge_cache_ttl":
+		value = pageRuleAction.Value.(float64) // we use TypeInt but terraform seems to do the right thing converting from float
+		break
+
+	case pageRuleAction.ID == "browser_cache_ttl":
 		value = fmt.Sprintf("%.0f", pageRuleAction.Value.(float64))
 		break
 

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -541,8 +541,10 @@ var pageRuleAPINilFields = []string{
 	"disable_security",
 }
 var pageRuleAPIFloatFields = []string{
-	"browser_cache_ttl",
 	"edge_cache_ttl",
+}
+var pageRuleAPIFloatAsStringFields = []string{
+	"browser_cache_ttl",
 }
 var pageRuleAPIStringFields = []string{
 	"bypass_cache_on_cookie",
@@ -575,6 +577,10 @@ func transformFromCloudflarePageRuleAction(pageRuleAction *cloudflare.PageRuleAc
 
 	case contains(pageRuleAPIStringFields, pageRuleAction.ID):
 		value = pageRuleAction.Value.(string)
+		break
+
+	case contains(pageRuleAPIFloatAsStringFields, pageRuleAction.ID):
+		value = fmt.Sprintf("%.0f", pageRuleAction.Value.(float64))
 		break
 
 	case pageRuleAction.ID == "forwarding_url" || pageRuleAction.ID == "minify":

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -276,8 +276,8 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T)
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 1"),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+				testAccCheckCloudflarePageRuleHasAction(&pageRule, "browser_cache_ttl", float64(1)),
 				resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.browser_cache_ttl", "1"),
-				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(1)),
 			),
 		},
 	})
@@ -291,7 +291,7 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
 				resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.browser_cache_ttl", "0"),
-				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(0)),
+				testAccCheckCloudflarePageRuleHasAction(&pageRule, "browser_cache_ttl", float64(0)),
 			),
 		},
 	})
@@ -307,8 +307,8 @@ func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 0"),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+				testAccCheckCloudflarePageRuleHasAction(&pageRule, "browser_cache_ttl", float64(0)),
 				resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.browser_cache_ttl", "0"),
-				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(0)),
 			),
 		},
 	})
@@ -611,17 +611,8 @@ func testAccRunResourceTestSteps(t *testing.T, testSteps []resource.TestStep) {
 	})
 }
 
-func testAccCheckCloudflarePageRuleExistsWithAction(resourceName string, key string, value interface{}) resource.TestCheckFunc {
+func testAccCheckCloudflarePageRuleHasAction(pageRule *cloudflare.PageRule, key string, value interface{}) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		rs, ok := state.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		client := testAccProvider.Meta().(*cloudflare.API)
-		pageRule, err := client.PageRule(rs.Primary.Attributes["zone_id"], rs.Primary.ID)
-		if err != nil {
-			return fmt.Errorf("cloudflare page rule not found: %s", err)
-		}
 		for _, pageRuleAction := range pageRule.Actions {
 			if pageRuleAction.ID == key && pageRuleAction.Value == value {
 				return nil

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -270,30 +270,35 @@ func TestTranformForwardingURL(t *testing.T) {
 }
 
 func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T) {
+	var pageRule cloudflare.PageRule
 	testAccRunResourceTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 1"),
 			Check: resource.ComposeTestCheckFunc(
-				testAccCheckStatePageRuleExistsWithAction("test", "browser_cache_ttl", "1"),
-				testAccCheckCloudflarePageRuleExistsWithAction("test", "browser_cache_ttl", float64(1)),
+				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+				testAccCheckStatePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", "1"),
+				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(1)),
 			),
 		},
 	})
 }
 
 func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
+	var pageRule cloudflare.PageRule
 	testAccRunResourceTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 0"),
 			Check: resource.ComposeTestCheckFunc(
-				testAccCheckStatePageRuleExistsWithAction("test", "browser_cache_ttl", "0"),
-				testAccCheckCloudflarePageRuleExistsWithAction("test", "browser_cache_ttl", float64(0)),
+				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+				testAccCheckStatePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", "0"),
+				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(0)),
 			),
 		},
 	})
 }
 
 func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
+	var pageRule cloudflare.PageRule
 	testAccRunResourceTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 1"),
@@ -301,21 +306,26 @@ func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders
 		{
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 0"),
 			Check: resource.ComposeTestCheckFunc(
-				testAccCheckStatePageRuleExistsWithAction("test", "browser_cache_ttl", "0"),
-				testAccCheckCloudflarePageRuleExistsWithAction("test", "browser_cache_ttl", float64(0)),
+				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+				testAccCheckStatePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", "0"),
+				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(0)),
 			),
 		},
 	})
 }
 
 func TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
+	var pageRule cloudflare.PageRule
 	testAccRunResourceTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 0"),
 		},
 		{
 			Config: buildPageRuleConfig("test", `browser_check = "on"`),
-			Check:  testAccCheckStatePageRuleExistsWithAction("test", "browser_cache_ttl", ""),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+				testAccCheckStatePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", ""),
+			),
 		},
 	})
 }
@@ -603,14 +613,14 @@ func testAccRunResourceTestSteps(t *testing.T, testSteps []resource.TestStep) {
 
 func testAccCheckStatePageRuleExistsWithAction(resourceName string, key string, value string) resource.TestCheckFunc {
 	return resource.TestCheckResourceAttr(
-		fmt.Sprintf("cloudflare_page_rule.%s", resourceName),
+		resourceName,
 		fmt.Sprintf("actions.0.%s", key),
 		value)
 }
 
 func testAccCheckCloudflarePageRuleExistsWithAction(resourceName string, key string, value interface{}) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		rs, ok := state.RootModule().Resources[fmt.Sprintf("cloudflare_page_rule.%s", resourceName)]
+		rs, ok := state.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T) {
-	runTestSteps(t, []resource.TestStep{
+	testAccRunResourceTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRuleConfig(`browser_cache_ttl = 1`),
 			Check:  assertActionExists("browser_cache_ttl", "1", float64(1)),
@@ -22,7 +22,7 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T)
 }
 
 func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
-	runTestSteps(t, []resource.TestStep{
+	testAccRunResourceTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRuleConfig(`browser_cache_ttl = 0`),
 			Check:  assertActionExists("browser_cache_ttl", "0", float64(0)),
@@ -31,7 +31,7 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders
 }
 
 func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
-	runTestSteps(t, []resource.TestStep{
+	testAccRunResourceTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRuleConfig(`browser_cache_ttl = 1`),
 		},
@@ -43,7 +43,7 @@ func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders
 }
 
 func TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
-	runTestSteps(t, []resource.TestStep{
+	testAccRunResourceTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRuleConfig(`browser_cache_ttl = 0`),
 		},
@@ -71,7 +71,7 @@ func buildPageRuleConfig(actions string) string {
 		actions)
 }
 
-func runTestSteps(t *testing.T, testSteps []resource.TestStep) {
+func testAccRunResourceTestSteps(t *testing.T, testSteps []resource.TestStep) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -61,7 +61,7 @@ func buildPageRule(actions string) string {
 		resource "cloudflare_page_rule" "terraform-test" {
 			zone = "%s"
 			target = "%s"
-			actions = {
+			actions {
 				%s
 			}
         }`,

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -2,13 +2,14 @@ package cloudflare
 
 import (
 	"fmt"
-	"github.com/cloudflare/cloudflare-go"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"os"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestCreatesBrowserCacheTTLIntegerValues(t *testing.T) {

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestCreatesBrowserCacheTTLIntegerValues(t *testing.T) {
+func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T) {
 	runTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRule(`browser_cache_ttl = 1`),
@@ -21,7 +21,7 @@ func TestCreatesBrowserCacheTTLIntegerValues(t *testing.T) {
 	})
 }
 
-func TestCreatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
+func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	runTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRule(`browser_cache_ttl = 0`),
@@ -30,7 +30,7 @@ func TestCreatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	})
 }
 
-func TestUpdatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
+func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	runTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRule(`browser_cache_ttl = 1`),
@@ -42,7 +42,7 @@ func TestUpdatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	})
 }
 
-func TestDeletesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
+func TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	runTestSteps(t, []resource.TestStep{
 		{
 			Config: buildPageRule(`browser_cache_ttl = 0`),

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -276,7 +276,7 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T)
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 1"),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-				testAccCheckStatePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", "1"),
+				resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.browser_cache_ttl", "1"),
 				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(1)),
 			),
 		},
@@ -290,7 +290,7 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 0"),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-				testAccCheckStatePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", "0"),
+				resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.browser_cache_ttl", "0"),
 				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(0)),
 			),
 		},
@@ -307,7 +307,7 @@ func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders
 			Config: buildPageRuleConfig("test", "browser_cache_ttl = 0"),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-				testAccCheckStatePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", "0"),
+				resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.browser_cache_ttl", "0"),
 				testAccCheckCloudflarePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", float64(0)),
 			),
 		},
@@ -324,7 +324,7 @@ func TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders
 			Config: buildPageRuleConfig("test", `browser_check = "on"`),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-				testAccCheckStatePageRuleExistsWithAction("cloudflare_page_rule.test", "browser_cache_ttl", ""),
+				resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.browser_cache_ttl", ""),
 			),
 		},
 	})
@@ -609,13 +609,6 @@ func testAccRunResourceTestSteps(t *testing.T, testSteps []resource.TestStep) {
 		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps:        testSteps,
 	})
-}
-
-func testAccCheckStatePageRuleExistsWithAction(resourceName string, key string, value string) resource.TestCheckFunc {
-	return resource.TestCheckResourceAttr(
-		resourceName,
-		fmt.Sprintf("actions.0.%s", key),
-		value)
 }
 
 func testAccCheckCloudflarePageRuleExistsWithAction(resourceName string, key string, value interface{}) resource.TestCheckFunc {

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -541,6 +541,7 @@ resource "cloudflare_page_rule" "test" {
 	actions {
 		always_online = "on"
 		browser_check = "on"
+		browser_cache_ttl = 0
 		email_obfuscation = "on"
 		ip_geolocation = "on"
 		server_side_exclude = "on"

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T) {
 	runTestSteps(t, []resource.TestStep{
 		{
-			Config: buildPageRule(`browser_cache_ttl = 1`),
+			Config: buildPageRuleConfig(`browser_cache_ttl = 1`),
 			Check:  assertActionExists("browser_cache_ttl", "1", float64(1)),
 		},
 	})
@@ -24,7 +24,7 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T)
 func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	runTestSteps(t, []resource.TestStep{
 		{
-			Config: buildPageRule(`browser_cache_ttl = 0`),
+			Config: buildPageRuleConfig(`browser_cache_ttl = 0`),
 			Check:  assertActionExists("browser_cache_ttl", "0", float64(0)),
 		},
 	})
@@ -33,10 +33,10 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders
 func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	runTestSteps(t, []resource.TestStep{
 		{
-			Config: buildPageRule(`browser_cache_ttl = 1`),
+			Config: buildPageRuleConfig(`browser_cache_ttl = 1`),
 		},
 		{
-			Config: buildPageRule(`browser_cache_ttl = 0`),
+			Config: buildPageRuleConfig(`browser_cache_ttl = 0`),
 			Check:  assertActionExists("browser_cache_ttl", "0", float64(0)),
 		},
 	})
@@ -45,16 +45,16 @@ func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders
 func TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	runTestSteps(t, []resource.TestStep{
 		{
-			Config: buildPageRule(`browser_cache_ttl = 0`),
+			Config: buildPageRuleConfig(`browser_cache_ttl = 0`),
 		},
 		{
-			Config: buildPageRule(`browser_check = "on"`),
+			Config: buildPageRuleConfig(`browser_check = "on"`),
 			Check:  assertActionNotExists("browser_cache_ttl"),
 		},
 	})
 }
 
-func buildPageRule(actions string) string {
+func buildPageRuleConfig(actions string) string {
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	target := fmt.Sprintf("terraform-test.%s", zone)
 

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -83,26 +83,26 @@ func testAccRunResourceTestSteps(t *testing.T, testSteps []resource.TestStep) {
 func assertActionExists(key string, stateValue string, cloudflareValue interface{}) resource.TestCheckFunc {
 	resourceName := "cloudflare_page_rule.terraform-test"
 	return resource.ComposeTestCheckFunc(
-		assertStatePageRuleActionExists(resourceName, key, stateValue),
-		assertCloudflarePageRuleActionExists(resourceName, key, cloudflareValue),
+		testAccCheckStatePageRuleExistsWithAction(resourceName, key, stateValue),
+		testAccCheckCloudflarePageRuleExistsWithAction(resourceName, key, cloudflareValue),
 	)
 }
 
 func assertActionNotExists(key string) resource.TestCheckFunc {
 	resourceName := "cloudflare_page_rule.terraform-test"
 	return resource.ComposeTestCheckFunc(
-		assertStatePageRuleActionExists(resourceName, key, ""),
+		testAccCheckStatePageRuleExistsWithAction(resourceName, key, ""),
 	)
 }
 
-func assertStatePageRuleActionExists(resourceName string, key string, value string) resource.TestCheckFunc {
+func testAccCheckStatePageRuleExistsWithAction(resourceName string, key string, value string) resource.TestCheckFunc {
 	return resource.TestCheckResourceAttr(
 		resourceName,
 		fmt.Sprintf("actions.0.%s", key),
 		value)
 }
 
-func assertCloudflarePageRuleActionExists(resourceName string, key string, value interface{}) resource.TestCheckFunc {
+func testAccCheckCloudflarePageRuleExistsWithAction(resourceName string, key string, value interface{}) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		rs, _ := state.RootModule().Resources[resourceName]
 		client := testAccProvider.Meta().(*cloudflare.API)


### PR DESCRIPTION
Addresses 2 issues with `browser_cache_ttl` due to `0` being the default value and also a valid & desirable value to define it with.

- Deleting: After a `browser_cache_ttl` page rule action has been applied, it can't be deleted because its value is the default of `0` when it's removed, so it ends up in the update PUT request as being set to `0`.
- Setting to 0 initially: Defining `browser_cache_ttl = 0` initially doesn't work because it's not seen as a change (current workaround is to set to something else first, then 0).

Using an integer for this value in the schema makes that quite challenging. Another option might be to make `-1` a special and default value used to mean "not set". The approach in this PR is to use a string instead.

I'd like to take a closer look at some of the test cases before this merged (hence WIP in the title).