### PR TITLE
Swap casing for `testAcc*`

### DIFF
--- a/cloudflare/data_source_ip_ranges_test.go
+++ b/cloudflare/data_source_ip_ranges_test.go
@@ -27,7 +27,7 @@ func TestAccCloudflareIPRanges(t *testing.T) {
 	})
 }
 
-func testAccCloudflareIPRanges(n string) resource.TestCheckFunc {
+func TestAccCloudflareIPRanges(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		r := s.RootModule().Resources[n]
 		a := r.Primary.Attributes

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -96,7 +96,7 @@ func TestAccCloudflareZonesMatchStatus(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareZonesDataSourceID(n string) resource.TestCheckFunc {
+func TestAccCheckCloudflareZonesDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		all := s.RootModule().Resources
 		rs, ok := all[n]
@@ -111,7 +111,7 @@ func testAccCheckCloudflareZonesDataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckCloudflareZonesReturned(n string, a string, check func(int) bool) resource.TestCheckFunc {
+func TestAccCheckCloudflareZonesReturned(n string, a string, check func(int) bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		all := s.RootModule().Resources
 		rs, ok := all[n]
@@ -131,7 +131,7 @@ func testAccCheckCloudflareZonesReturned(n string, a string, check func(int) boo
 	}
 }
 
-func testAccCloudflareZonesConfigMatchName() string {
+func TestAccCloudflareZonesConfigMatchName() string {
 	return fmt.Sprintf(`
 data "cloudflare_zones" "examples_domains" {
   filter {
@@ -144,7 +144,7 @@ data "cloudflare_zones" "examples_domains" {
 `, testZones)
 }
 
-func testAccCloudflareZonesConfigMatchPaused() string {
+func TestAccCloudflareZonesConfigMatchPaused() string {
 	return fmt.Sprintf(`
 data "cloudflare_zones" "examples_domains" {
   filter {
@@ -157,7 +157,7 @@ data "cloudflare_zones" "examples_domains" {
 `, testZones)
 }
 
-func testAccCloudflareZonesConfigMatchStatus() string {
+func TestAccCloudflareZonesConfigMatchStatus() string {
 	return fmt.Sprintf(`
 data "cloudflare_zones" "examples_domains" {
   filter {

--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -31,7 +31,7 @@ func TestProvider_impl(t *testing.T) {
 
 type preCheckFunc = func(*testing.T)
 
-func testAccPreCheck(t *testing.T) {
+func TestAccPreCheck(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_EMAIL"); v == "" {
 		t.Fatal("CLOUDFLARE_EMAIL must be set for acceptance tests")
 	}
@@ -49,19 +49,19 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccPreCheckAltDomain(t *testing.T) {
+func TestAccPreCheckAltDomain(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_ALT_DOMAIN"); v == "" {
 		t.Fatal("CLOUDFLARE_ALT_DOMAIN must be set for this acceptance test")
 	}
 }
 
-func testAccPreCheckOrg(t *testing.T) {
+func TestAccPreCheckOrg(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_ORG_ID"); v == "" {
 		t.Fatal("CLOUDFLARE_ORG_ID must be set for this acceptance test")
 	}
 }
 
-func testAccPreCheckLogpushToken(t *testing.T) {
+func TestAccPreCheckLogpushToken(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN"); v == "" {
 		t.Fatal("CLOUDFLARE_LOGPUSH_OWNERSHIP_TOKEN must be set for this acceptance test")
 	}

--- a/cloudflare/resource_cloudflare_access_rule_test.go
+++ b/cloudflare/resource_cloudflare_access_rule_test.go
@@ -27,7 +27,7 @@ func TestAccAccessRuleASN(t *testing.T) {
 	})
 }
 
-func testAccessRuleAccountConfig(mode, notes, target, value string) string {
+func TestAccessRuleAccountConfig(mode, notes, target, value string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_access_rule" "test" {
   notes = "%[2]s"

--- a/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
@@ -138,7 +138,7 @@ func TestAccCloudflareLoadBalancerMonitor_CreateAfterManualDestroy(t *testing.T)
 	})
 }
 
-func testAccCheckCloudflareLoadBalancerMonitorDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareLoadBalancerMonitorDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -155,7 +155,7 @@ func testAccCheckCloudflareLoadBalancerMonitorDestroy(s *terraform.State) error 
 	return nil
 }
 
-func testAccCheckCloudflareLoadBalancerMonitorExists(n string, load *cloudflare.LoadBalancerMonitor) resource.TestCheckFunc {
+func TestAccCheckCloudflareLoadBalancerMonitorExists(n string, load *cloudflare.LoadBalancerMonitor) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -178,7 +178,7 @@ func testAccCheckCloudflareLoadBalancerMonitorExists(n string, load *cloudflare.
 	}
 }
 
-func testAccCheckCloudflareLoadBalancerMonitorDates(n string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, testStartTime time.Time) resource.TestCheckFunc {
+func TestAccCheckCloudflareLoadBalancerMonitorDates(n string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, _ := s.RootModule().Resources[n]
@@ -206,7 +206,7 @@ func testAccCheckCloudflareLoadBalancerMonitorDates(n string, loadBalancerMonito
 	}
 }
 
-func testAccManuallyDeleteLoadBalancerMonitor(name string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, initialId *string) resource.TestCheckFunc {
+func TestAccManuallyDeleteLoadBalancerMonitor(name string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, initialId *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
 		*initialId = loadBalancerMonitor.ID
@@ -218,7 +218,7 @@ func testAccManuallyDeleteLoadBalancerMonitor(name string, loadBalancerMonitor *
 	}
 }
 
-func testAccCheckCloudflareLoadBalancerMonitorConfigBasic() string {
+func TestAccCheckCloudflareLoadBalancerMonitorConfigBasic() string {
 	return `
 resource "cloudflare_load_balancer_monitor" "test" {
   expected_body = "alive"
@@ -227,7 +227,7 @@ resource "cloudflare_load_balancer_monitor" "test" {
 }`
 }
 
-func testAccCheckCloudflareLoadBalancerMonitorConfigFullySpecified() string {
+func TestAccCheckCloudflareLoadBalancerMonitorConfigFullySpecified() string {
 	return `
 resource "cloudflare_load_balancer_monitor" "test" {
   expected_body = "dead"

--- a/cloudflare/resource_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool_test.go
@@ -102,7 +102,7 @@ func TestAccCloudflareLoadBalancerPool_CreateAfterManualDestroy(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareLoadBalancerPoolDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareLoadBalancerPoolDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -119,7 +119,7 @@ func testAccCheckCloudflareLoadBalancerPoolDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudflareLoadBalancerPoolExists(n string, loadBalancerPool *cloudflare.LoadBalancerPool) resource.TestCheckFunc {
+func TestAccCheckCloudflareLoadBalancerPoolExists(n string, loadBalancerPool *cloudflare.LoadBalancerPool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -142,7 +142,7 @@ func testAccCheckCloudflareLoadBalancerPoolExists(n string, loadBalancerPool *cl
 	}
 }
 
-func testAccCheckCloudflareLoadBalancerPoolDates(n string, loadBalancerPool *cloudflare.LoadBalancerPool, testStartTime time.Time) resource.TestCheckFunc {
+func TestAccCheckCloudflareLoadBalancerPoolDates(n string, loadBalancerPool *cloudflare.LoadBalancerPool, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, _ := s.RootModule().Resources[n]
@@ -170,7 +170,7 @@ func testAccCheckCloudflareLoadBalancerPoolDates(n string, loadBalancerPool *clo
 	}
 }
 
-func testAccManuallyDeleteLoadBalancerPool(name string, loadBalancerPool *cloudflare.LoadBalancerPool, initialId *string) resource.TestCheckFunc {
+func TestAccManuallyDeleteLoadBalancerPool(name string, loadBalancerPool *cloudflare.LoadBalancerPool, initialId *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
 		*initialId = loadBalancerPool.ID
@@ -183,7 +183,7 @@ func testAccManuallyDeleteLoadBalancerPool(name string, loadBalancerPool *cloudf
 }
 
 // using IPs from 192.0.2.0/24 as per RFC5737
-func testAccCheckCloudflareLoadBalancerPoolConfigBasic(id string) string {
+func TestAccCheckCloudflareLoadBalancerPoolConfigBasic(id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_load_balancer_pool" "%[1]s" {
   name = "my-tf-pool-basic-%[1]s"
@@ -195,7 +195,7 @@ resource "cloudflare_load_balancer_pool" "%[1]s" {
 }`, id)
 }
 
-func testAccCheckCloudflareLoadBalancerPoolConfigFullySpecified(id string) string {
+func TestAccCheckCloudflareLoadBalancerPoolConfigFullySpecified(id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_load_balancer_pool" "%[1]s" {
   name = "my-tf-pool-basic-%[1]s"

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -213,7 +213,7 @@ func TestAccCloudflareLoadBalancer_CreateAfterManualDestroy(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareLoadBalancerDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareLoadBalancerDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -230,7 +230,7 @@ func testAccCheckCloudflareLoadBalancerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudflareLoadBalancerExists(n string, loadBalancer *cloudflare.LoadBalancer) resource.TestCheckFunc {
+func TestAccCheckCloudflareLoadBalancerExists(n string, loadBalancer *cloudflare.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -253,7 +253,7 @@ func testAccCheckCloudflareLoadBalancerExists(n string, loadBalancer *cloudflare
 	}
 }
 
-func testAccCheckCloudflareLoadBalancerIDIsValid(n, expectedZone string) resource.TestCheckFunc {
+func TestAccCheckCloudflareLoadBalancerIDIsValid(n, expectedZone string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -279,7 +279,7 @@ func testAccCheckCloudflareLoadBalancerIDIsValid(n, expectedZone string) resourc
 	}
 }
 
-func testAccCheckCloudflareLoadBalancerDates(n string, loadBalancer *cloudflare.LoadBalancer, testStartTime time.Time) resource.TestCheckFunc {
+func TestAccCheckCloudflareLoadBalancerDates(n string, loadBalancer *cloudflare.LoadBalancer, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, _ := s.RootModule().Resources[n]
@@ -307,7 +307,7 @@ func testAccCheckCloudflareLoadBalancerDates(n string, loadBalancer *cloudflare.
 	}
 }
 
-func testAccManuallyDeleteLoadBalancer(name string, loadBalancer *cloudflare.LoadBalancer, initialId *string) resource.TestCheckFunc {
+func TestAccManuallyDeleteLoadBalancer(name string, loadBalancer *cloudflare.LoadBalancer, initialId *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[name]
 		client := testAccProvider.Meta().(*cloudflare.API)
@@ -320,7 +320,7 @@ func testAccManuallyDeleteLoadBalancer(name string, loadBalancer *cloudflare.Loa
 	}
 }
 
-func testAccCheckCloudflareLoadBalancerConfigBasic(zone, id string) string {
+func TestAccCheckCloudflareLoadBalancerConfigBasic(zone, id string) string {
 	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
 resource "cloudflare_load_balancer" "%[2]s" {
   zone = "%[1]s"
@@ -331,7 +331,7 @@ resource "cloudflare_load_balancer" "%[2]s" {
 }`, zone, id)
 }
 
-func testAccCheckCloudflareLoadBalancerConfigSessionAffinity(zone, id string) string {
+func TestAccCheckCloudflareLoadBalancerConfigSessionAffinity(zone, id string) string {
 	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
 resource "cloudflare_load_balancer" "%[2]s" {
   zone = "%[1]s"
@@ -342,7 +342,7 @@ resource "cloudflare_load_balancer" "%[2]s" {
 }`, zone, id)
 }
 
-func testAccCheckCloudflareLoadBalancerConfigGeoBalanced(zone, id string) string {
+func TestAccCheckCloudflareLoadBalancerConfigGeoBalanced(zone, id string) string {
 	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
 resource "cloudflare_load_balancer" "%[2]s" {
   zone = "%[1]s"
@@ -363,7 +363,7 @@ resource "cloudflare_load_balancer" "%[2]s" {
 }`, zone, id)
 }
 
-func testAccCheckCloudflareLoadBalancerConfigDuplicatePool(zone, id string) string {
+func TestAccCheckCloudflareLoadBalancerConfigDuplicatePool(zone, id string) string {
 	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
 resource "cloudflare_load_balancer" "%[2]s" {
   zone = "%[1]s"

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -270,7 +270,7 @@ func TestTranformForwardingURL(t *testing.T) {
 	}
 }
 
-func testAccCheckCloudflarePageRuleRecreated(before, after *cloudflare.PageRule) resource.TestCheckFunc {
+func TestAccCheckCloudflarePageRuleRecreated(before, after *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if before.ID == after.ID {
 			return fmt.Errorf("Expected change of PageRule Ids, but both were %v", before.ID)
@@ -279,7 +279,7 @@ func testAccCheckCloudflarePageRuleRecreated(before, after *cloudflare.PageRule)
 	}
 }
 
-func testAccCheckCloudflarePageRuleIDUnchanged(before, after *cloudflare.PageRule) resource.TestCheckFunc {
+func TestAccCheckCloudflarePageRuleIDUnchanged(before, after *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if before.ID != after.ID {
 			return fmt.Errorf("ID should not change suring in place update, but got change %s -> %s", before.ID, after.ID)
@@ -288,7 +288,7 @@ func testAccCheckCloudflarePageRuleIDUnchanged(before, after *cloudflare.PageRul
 	}
 }
 
-func testAccCheckCloudflarePageRuleDestroy(s *terraform.State) error {
+func TestAccCheckCloudflarePageRuleDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -305,7 +305,7 @@ func testAccCheckCloudflarePageRuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudflarePageRuleAttributesBasic(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
+func TestAccCheckCloudflarePageRuleAttributesBasic(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		// check the api only has attributes we set non-empty values for
@@ -338,7 +338,7 @@ func testAccCheckCloudflarePageRuleAttributesBasic(pageRule *cloudflare.PageRule
 	}
 }
 
-func testAccCheckCloudflarePageRuleAttributesUpdated(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
+func TestAccCheckCloudflarePageRuleAttributesUpdated(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		actionMap := pageRuleActionsToMap(pageRule.Actions)
@@ -388,7 +388,7 @@ func testAccCheckCloudflarePageRuleAttributesUpdated(pageRule *cloudflare.PageRu
 	}
 }
 
-func testAccCheckCloudflarePageRuleExists(n string, pageRule *cloudflare.PageRule) resource.TestCheckFunc {
+func TestAccCheckCloudflarePageRuleExists(n string, pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -415,7 +415,7 @@ func testAccCheckCloudflarePageRuleExists(n string, pageRule *cloudflare.PageRul
 	}
 }
 
-func testAccManuallyDeletePageRule(name string, initialID *string) resource.TestCheckFunc {
+func TestAccManuallyDeletePageRule(name string, initialID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -432,7 +432,7 @@ func testAccManuallyDeletePageRule(name string, initialID *string) resource.Test
 	}
 }
 
-func testAccCheckCloudflarePageRuleConfigMinify(zone, target string) string {
+func TestAccCheckCloudflarePageRuleConfigMinify(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -447,7 +447,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudflarePageRuleConfigBasic(zone, target string) string {
+func TestAccCheckCloudflarePageRuleConfigBasic(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -459,7 +459,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudflarePageRuleConfigNewValue(zone, target string) string {
+func TestAccCheckCloudflarePageRuleConfigNewValue(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -473,7 +473,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudflarePageRuleConfigFullySpecified(zone, target string) string {
+func TestAccCheckCloudflarePageRuleConfigFullySpecified(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -494,7 +494,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudflarePageRuleConfigForwardingOnly(zone, target string) string {
+func TestAccCheckCloudflarePageRuleConfigForwardingOnly(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"
@@ -509,7 +509,7 @@ resource "cloudflare_page_rule" "test" {
 }`, zone, target)
 }
 
-func testAccCheckCloudflarePageRuleConfigForwardingAndOthers(zone, target string) string {
+func TestAccCheckCloudflarePageRuleConfigForwardingAndOthers(zone, target string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_page_rule" "test" {
 	zone = "%s"

--- a/cloudflare/resource_cloudflare_rate_limit_test.go
+++ b/cloudflare/resource_cloudflare_rate_limit_test.go
@@ -237,7 +237,7 @@ func TestAccCloudflareRateLimit_ChallengeWithTimeout(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareRateLimitDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareRateLimitDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -254,7 +254,7 @@ func testAccCheckCloudflareRateLimitDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudflareRateLimitExists(n string, rateLimit *cloudflare.RateLimit) resource.TestCheckFunc {
+func TestAccCheckCloudflareRateLimitExists(n string, rateLimit *cloudflare.RateLimit) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -281,7 +281,7 @@ func testAccCheckCloudflareRateLimitExists(n string, rateLimit *cloudflare.RateL
 	}
 }
 
-func testAccCheckCloudflareRateLimitIDIsValid(n, expectedZone string) resource.TestCheckFunc {
+func TestAccCheckCloudflareRateLimitIDIsValid(n, expectedZone string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -308,7 +308,7 @@ func testAccCheckCloudflareRateLimitIDIsValid(n, expectedZone string) resource.T
 	}
 }
 
-func testAccManuallyDeleteRateLimit(name string, rateLimit *cloudflare.RateLimit, initialRateLimitId *string) resource.TestCheckFunc {
+func TestAccManuallyDeleteRateLimit(name string, rateLimit *cloudflare.RateLimit, initialRateLimitId *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
 		*initialRateLimitId = rateLimit.ID
@@ -320,7 +320,7 @@ func testAccManuallyDeleteRateLimit(name string, rateLimit *cloudflare.RateLimit
 	}
 }
 
-func testAccCheckCloudflareRateLimitConfigBasic(zone, id string) string {
+func TestAccCheckCloudflareRateLimitConfigBasic(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
@@ -333,7 +333,7 @@ resource "cloudflare_rate_limit" "%[1]s" {
 }`, id, zone)
 }
 
-func testAccCheckCloudflareRateLimitConfigMatchingUrl(zone, id string) string {
+func TestAccCheckCloudflareRateLimitConfigMatchingUrl(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
@@ -351,7 +351,7 @@ resource "cloudflare_rate_limit" "%[1]s" {
 }`, id, zone)
 }
 
-func testAccCheckCloudflareRateLimitConfigFullySpecified(zone, id string) string {
+func TestAccCheckCloudflareRateLimitConfigFullySpecified(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
@@ -385,7 +385,7 @@ resource "cloudflare_rate_limit" "%[1]s" {
 }`, id, zone)
 }
 
-func testAccCheckCloudflareRateLimitChallengeConfigBasic(zone, id string) string {
+func TestAccCheckCloudflareRateLimitChallengeConfigBasic(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
@@ -397,7 +397,7 @@ resource "cloudflare_rate_limit" "%[1]s" {
 }`, id, zone)
 }
 
-func testAccCheckCloudflareRateLimitConfigWithoutTimeout(zone, id string) string {
+func TestAccCheckCloudflareRateLimitConfigWithoutTimeout(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"
@@ -409,7 +409,7 @@ resource "cloudflare_rate_limit" "%[1]s" {
 }`, id, zone)
 }
 
-func testAccCheckCloudflareRateLimitChallengeConfigWithTimeout(zone, id string) string {
+func TestAccCheckCloudflareRateLimitChallengeConfigWithTimeout(zone, id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_rate_limit" "%[1]s" {
   zone = "%[2]s"

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -364,7 +364,7 @@ func TestAccCloudflareRecord_TtlValidationUpdate(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareRecordRecreated(before, after *cloudflare.DNSRecord) resource.TestCheckFunc {
+func TestAccCheckCloudflareRecordRecreated(before, after *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if before.ID == after.ID {
 			return fmt.Errorf("Expected change of Record Ids, but both were %v", before.ID)
@@ -373,7 +373,7 @@ func testAccCheckCloudflareRecordRecreated(before, after *cloudflare.DNSRecord) 
 	}
 }
 
-func testAccCheckCloudflareRecordDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -390,7 +390,7 @@ func testAccCheckCloudflareRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccManuallyDeleteRecord(record *cloudflare.DNSRecord) resource.TestCheckFunc {
+func TestAccManuallyDeleteRecord(record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
 		err := client.DeleteDNSRecord(record.ZoneID, record.ID)
@@ -401,7 +401,7 @@ func testAccManuallyDeleteRecord(record *cloudflare.DNSRecord) resource.TestChec
 	}
 }
 
-func testAccCheckCloudflareRecordAttributes(record *cloudflare.DNSRecord) resource.TestCheckFunc {
+func TestAccCheckCloudflareRecordAttributes(record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if record.Content != "192.168.0.10" {
@@ -412,7 +412,7 @@ func testAccCheckCloudflareRecordAttributes(record *cloudflare.DNSRecord) resour
 	}
 }
 
-func testAccCheckCloudflareRecordAttributesUpdated(record *cloudflare.DNSRecord) resource.TestCheckFunc {
+func TestAccCheckCloudflareRecordAttributesUpdated(record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if record.Content != "192.168.0.11" {
@@ -423,7 +423,7 @@ func testAccCheckCloudflareRecordAttributesUpdated(record *cloudflare.DNSRecord)
 	}
 }
 
-func testAccCheckCloudflareRecordDates(n string, record *cloudflare.DNSRecord, testStartTime time.Time) resource.TestCheckFunc {
+func TestAccCheckCloudflareRecordDates(n string, record *cloudflare.DNSRecord, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, _ := s.RootModule().Resources[n]
@@ -451,7 +451,7 @@ func testAccCheckCloudflareRecordDates(n string, record *cloudflare.DNSRecord, t
 	}
 }
 
-func testAccCheckCloudflareRecordExists(n string, record *cloudflare.DNSRecord) resource.TestCheckFunc {
+func TestAccCheckCloudflareRecordExists(n string, record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -478,7 +478,7 @@ func testAccCheckCloudflareRecordExists(n string, record *cloudflare.DNSRecord) 
 	}
 }
 
-func testAccCheckCloudflareRecordConfigBasic(zone, name string) string {
+func TestAccCheckCloudflareRecordConfigBasic(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%s"
@@ -490,7 +490,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudflareRecordConfigApex(zone string) string {
+func TestAccCheckCloudflareRecordConfigApex(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%s"
@@ -501,7 +501,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone)
 }
 
-func testAccCheckCloudflareRecordConfigLOC(zone string) string {
+func TestAccCheckCloudflareRecordConfigLOC(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
   domain = "%[1]s"
@@ -525,7 +525,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone)
 }
 
-func testAccCheckCloudflareRecordConfigSRV(zone string) string {
+func TestAccCheckCloudflareRecordConfigSRV(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
   domain = "%[1]s"
@@ -544,7 +544,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone)
 }
 
-func testAccCheckCloudflareRecordConfigProxied(zone, name string) string {
+func TestAccCheckCloudflareRecordConfigProxied(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%[1]s"
@@ -556,7 +556,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudflareRecordConfigNewValue(zone, name string) string {
+func TestAccCheckCloudflareRecordConfigNewValue(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%s"
@@ -568,7 +568,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudflareRecordConfigChangeType(zone, name string) string {
+func TestAccCheckCloudflareRecordConfigChangeType(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%[1]s"
@@ -580,7 +580,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudflareRecordConfigChangeHostname(zone, name string) string {
+func TestAccCheckCloudflareRecordConfigChangeHostname(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%s"
@@ -592,7 +592,7 @@ resource "cloudflare_record" "foobar" {
 }`, zone, name)
 }
 
-func testAccCheckCloudflareRecordConfigTtlValidation(zone, name string) string {
+func TestAccCheckCloudflareRecordConfigTtlValidation(zone, name string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_record" "foobar" {
 	domain = "%[1]s"

--- a/cloudflare/resource_cloudflare_spectrum_application_test.go
+++ b/cloudflare/resource_cloudflare_spectrum_application_test.go
@@ -146,7 +146,7 @@ func TestAccCloudflareSpectrumApplication_CreateAfterManualDestroy(t *testing.T)
 	})
 }
 
-func testAccCheckCloudflareSpectrumApplicationDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareSpectrumApplicationDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -163,7 +163,7 @@ func testAccCheckCloudflareSpectrumApplicationDestroy(s *terraform.State) error 
 	return nil
 }
 
-func testAccCheckCloudflareSpectrumApplicationExists(n string, spectrumApp *cloudflare.SpectrumApplication) resource.TestCheckFunc {
+func TestAccCheckCloudflareSpectrumApplicationExists(n string, spectrumApp *cloudflare.SpectrumApplication) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -186,7 +186,7 @@ func testAccCheckCloudflareSpectrumApplicationExists(n string, spectrumApp *clou
 	}
 }
 
-func testAccCheckCloudflareSpectrumApplicationIDIsValid(n string) resource.TestCheckFunc {
+func TestAccCheckCloudflareSpectrumApplicationIDIsValid(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -208,7 +208,7 @@ func testAccCheckCloudflareSpectrumApplicationIDIsValid(n string) resource.TestC
 	}
 }
 
-func testAccManuallyDeleteSpectrumApplication(name string, spectrumApp *cloudflare.SpectrumApplication, initialId *string) resource.TestCheckFunc {
+func TestAccManuallyDeleteSpectrumApplication(name string, spectrumApp *cloudflare.SpectrumApplication, initialId *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[name]
 		client := testAccProvider.Meta().(*cloudflare.API)
@@ -221,7 +221,7 @@ func testAccManuallyDeleteSpectrumApplication(name string, spectrumApp *cloudfla
 	}
 }
 
-func testAccCheckCloudflareSpectrumApplicationConfigBasic(zoneName, ID string) string {
+func TestAccCheckCloudflareSpectrumApplicationConfigBasic(zoneName, ID string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_spectrum_application" "%[2]s" {
   zone_id  = "${lookup(data.cloudflare_zones.test.zones[0], "id")}"
@@ -244,7 +244,7 @@ data "cloudflare_zones" "test" {
 `, zoneName, ID)
 }
 
-func testAccCheckCloudflareSpectrumApplicationConfigOriginDNS(zoneName, ID string) string {
+func TestAccCheckCloudflareSpectrumApplicationConfigOriginDNS(zoneName, ID string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_spectrum_application" "%[2]s" {
   zone_id  = "${lookup(data.cloudflare_zones.test.zones[0], "id")}"
@@ -269,7 +269,7 @@ data "cloudflare_zones" "test" {
 `, zoneName, ID)
 }
 
-func testAccCheckCloudflareSpectrumApplicationConfigBasicUpdated(zoneName, ID string) string {
+func TestAccCheckCloudflareSpectrumApplicationConfigBasicUpdated(zoneName, ID string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_spectrum_application" "%[2]s" {
   zone_id  = "${lookup(data.cloudflare_zones.test.zones[0], "id")}"

--- a/cloudflare/resource_cloudflare_waf_rule_test.go
+++ b/cloudflare/resource_cloudflare_waf_rule_test.go
@@ -46,7 +46,7 @@ func TestAccCloudflareWAFRule_CreateThenUpdate(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareWAFRuleDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareWAFRuleDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*cloudflare.API)
 
 	for _, rs := range s.RootModule().Resources {
@@ -67,7 +67,7 @@ func testAccCheckCloudflareWAFRuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudflareWAFRuleConfig(zone, ruleID, mode, name string) string {
+func TestAccCheckCloudflareWAFRuleConfig(zone, ruleID, mode, name string) string {
 	return fmt.Sprintf(`
 				resource "cloudflare_waf_rule" "%[4]s" {
 					rule_id = %[2]s

--- a/cloudflare/resource_cloudflare_worker_route_test.go
+++ b/cloudflare/resource_cloudflare_worker_route_test.go
@@ -34,7 +34,7 @@ func TestAccCloudflareWorkerRoute_SingleScriptEnt(t *testing.T) {
 	testAccCloudflareWorkerRoute_SingleScript(t, testAccPreCheckOrg)
 }
 
-func testAccCloudflareWorkerRoute_SingleScript(t *testing.T, preCheck preCheckFunc) {
+func TestAccCloudflareWorkerRoute_SingleScript(t *testing.T, preCheck preCheckFunc) {
 	var route cloudflare.WorkerRoute
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	routeRnd := generateRandomResourceName()
@@ -82,7 +82,7 @@ func testAccCloudflareWorkerRoute_SingleScript(t *testing.T, preCheck preCheckFu
 	})
 }
 
-func testAccCheckCloudflareWorkerRouteConfigSingleScriptInitial(zone, routeRnd, scriptRnd, pattern string) string {
+func TestAccCheckCloudflareWorkerRouteConfigSingleScriptInitial(zone, routeRnd, scriptRnd, pattern string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_route" "%[2]s" {
   zone = "%[1]s"
@@ -97,7 +97,7 @@ resource "cloudflare_worker_script" "%[3]s" {
 }`, zone, routeRnd, scriptRnd, pattern, defaultScriptContent)
 }
 
-func testAccCheckCloudflareWorkerRouteConfigSingleScriptUpdate(zone, routeRnd, scriptRnd, pattern string) string {
+func TestAccCheckCloudflareWorkerRouteConfigSingleScriptUpdate(zone, routeRnd, scriptRnd, pattern string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_route" "%[2]s" {
   zone = "%[1]s"
@@ -159,7 +159,7 @@ func TestAccCloudflareWorkerRoute_MultiScriptEnt(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareWorkerRouteConfigMultiScriptInitial(zone, routeRnd, scriptRnd, pattern string) string {
+func TestAccCheckCloudflareWorkerRouteConfigMultiScriptInitial(zone, routeRnd, scriptRnd, pattern string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_route" "%[2]s" {
   zone = "%[1]s"
@@ -173,7 +173,7 @@ resource "cloudflare_worker_script" "%[3]s" {
 }`, zone, routeRnd, scriptRnd, pattern, defaultScriptContent)
 }
 
-func testAccCheckCloudflareWorkerRouteConfigMultiScriptUpdate(zone, routeRnd, scriptRnd, pattern string) string {
+func TestAccCheckCloudflareWorkerRouteConfigMultiScriptUpdate(zone, routeRnd, scriptRnd, pattern string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_route" "%[2]s" {
   zone = "%[1]s"
@@ -218,7 +218,7 @@ func TestAccCloudflareWorkerRoute_MultiScriptDisabledRoute(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareWorkerRouteConfigMultiScriptDisabledRoute(zone, routeRnd, pattern string) string {
+func TestAccCheckCloudflareWorkerRouteConfigMultiScriptDisabledRoute(zone, routeRnd, pattern string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_route" "%[2]s" {
   zone = "%[1]s"
@@ -251,7 +251,7 @@ func getRouteFromApi(zoneId, routeId string) (cloudflare.WorkerRoute, error) {
 	return route, nil
 }
 
-func testAccCheckCloudflareWorkerRouteExists(n string, route *cloudflare.WorkerRoute) resource.TestCheckFunc {
+func TestAccCheckCloudflareWorkerRouteExists(n string, route *cloudflare.WorkerRoute) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -278,7 +278,7 @@ func testAccCheckCloudflareWorkerRouteExists(n string, route *cloudflare.WorkerR
 	}
 }
 
-func testAccCheckCloudflareWorkerRouteDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareWorkerRouteDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudflare_worker_route" {
 			continue

--- a/cloudflare/resource_cloudflare_worker_script_test.go
+++ b/cloudflare/resource_cloudflare_worker_script_test.go
@@ -35,7 +35,7 @@ func TestAccCloudflareWorkerScript_SingleScriptEnt(t *testing.T) {
 	testAccCloudflareWorkerScript_SingleScript(t, testAccPreCheckOrg)
 }
 
-func testAccCloudflareWorkerScript_SingleScript(t *testing.T, preCheck preCheckFunc) {
+func TestAccCloudflareWorkerScript_SingleScript(t *testing.T, preCheck preCheckFunc) {
 	var script cloudflare.WorkerScript
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := generateRandomResourceName()
@@ -75,7 +75,7 @@ func testAccCloudflareWorkerScript_SingleScript(t *testing.T, preCheck preCheckF
 	})
 }
 
-func testAccCheckCloudflareWorkerScriptConfigSingleScriptInitial(zone, rnd string) string {
+func TestAccCheckCloudflareWorkerScriptConfigSingleScriptInitial(zone, rnd string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_script" "%[2]s" {
   zone = "%[1]s"
@@ -83,7 +83,7 @@ resource "cloudflare_worker_script" "%[2]s" {
 }`, zone, rnd, scriptContent1)
 }
 
-func testAccCheckCloudflareWorkerScriptConfigSingleScriptUpdate(zone, rnd string) string {
+func TestAccCheckCloudflareWorkerScriptConfigSingleScriptUpdate(zone, rnd string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_script" "%[2]s" {
   zone = "%[1]s"
@@ -130,7 +130,7 @@ func TestAccCloudflareWorkerScript_MultiScriptEnt(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareWorkerScriptConfigMultiScriptInitial(rnd string) string {
+func TestAccCheckCloudflareWorkerScriptConfigMultiScriptInitial(rnd string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_script" "%[1]s" {
   name = "%[1]s"
@@ -138,7 +138,7 @@ resource "cloudflare_worker_script" "%[1]s" {
 }`, rnd, scriptContent1)
 }
 
-func testAccCheckCloudflareWorkerScriptConfigMultiScriptUpdate(rnd string) string {
+func TestAccCheckCloudflareWorkerScriptConfigMultiScriptUpdate(rnd string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_worker_script" "%[1]s" {
   name = "%[1]s"
@@ -161,7 +161,7 @@ func getRequestParamsFromResource(rs *terraform.ResourceState) cloudflare.Worker
 	return params
 }
 
-func testAccCheckCloudflareWorkerScriptExists(n string, script *cloudflare.WorkerScript) resource.TestCheckFunc {
+func TestAccCheckCloudflareWorkerScriptExists(n string, script *cloudflare.WorkerScript) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -188,7 +188,7 @@ func testAccCheckCloudflareWorkerScriptExists(n string, script *cloudflare.Worke
 	}
 }
 
-func testAccCheckCloudflareWorkerScriptDestroy(s *terraform.State) error {
+func TestAccCheckCloudflareWorkerScriptDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudflare_worker_script" {
 			continue

--- a/cloudflare/resource_cloudflare_zone_settings_override_test.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override_test.go
@@ -95,7 +95,7 @@ func TestAccCloudflareZoneSettingsOverride_RemoveAttributes(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareZoneSettingsEmpty(n string) resource.TestCheckFunc {
+func TestAccCheckCloudflareZoneSettingsEmpty(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -121,7 +121,7 @@ func testAccCheckCloudflareZoneSettingsEmpty(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckCloudflareZoneSettings(n string) resource.TestCheckFunc {
+func TestAccCheckCloudflareZoneSettings(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -160,7 +160,7 @@ func testAccCheckCloudflareZoneSettings(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccGetInitialZoneSettings(t *testing.T, zoneName string, settings map[string]interface{}) resource.TestCheckFunc {
+func TestAccGetInitialZoneSettings(t *testing.T, zoneName string, settings map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
 
@@ -184,7 +184,7 @@ func testAccGetInitialZoneSettings(t *testing.T, zoneName string, settings map[s
 	}
 }
 
-func testAccCheckInitialZoneSettings(zoneName string, initialSettings map[string]interface{}) resource.TestCheckFunc {
+func TestAccCheckInitialZoneSettings(zoneName string, initialSettings map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
 
@@ -210,14 +210,14 @@ func testAccCheckInitialZoneSettings(zoneName string, initialSettings map[string
 	}
 }
 
-func testAccCheckCloudflareZoneSettingsOverrideConfigEmpty(zone string) string {
+func TestAccCheckCloudflareZoneSettingsOverrideConfigEmpty(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_zone_settings_override" "test" {
 	name = "%s"
 }`, zone)
 }
 
-func testAccCheckCloudflareZoneSettingsOverrideConfigNormal(zone string) string {
+func TestAccCheckCloudflareZoneSettingsOverrideConfigNormal(zone string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_zone_settings_override" "test" {
 	name = "%s"


### PR DESCRIPTION
Looking at the CI configuration, I've noticed we're only running 70 test
cases however there are far more listed. Taking a look at the
configuration, only test cases named `TestAcc` get picked up. To address
this, I've updated the casing used which will make these run.