### PR TITLE
Add H2 prioritisation and image resizing settings

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -435,9 +435,10 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 	},
 
 	"sha1_support": {
-		Type: schema.TypeString, ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
-		Optional: true,
-		Computed: true,
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+		Optional:     true,
+		Computed:     true,
 	},
 
 	"cname_flattening": {

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -466,6 +466,13 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 		Optional:     true,
 		Computed:     true,
 	},
+
+	"image_resizing": {
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+		Optional:     true,
+		Computed:     true,
+	},
 }
 
 func resourceCloudflareZoneSettingsOverrideCreate(d *schema.ResourceData, meta interface{}) error {

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -459,6 +459,13 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 		Optional: true,
 		Computed: true,
 	},
+
+	"h2_prioritization": {
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice([]string{"on", "off", "custom"}, false),
+		Optional:     true,
+		Computed:     true,
+	},
 }
 
 func resourceCloudflareZoneSettingsOverrideCreate(d *schema.ResourceData, meta interface{}) error {

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -82,6 +82,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 
 * `cache_level`. Allowed values: "aggressive", "basic", "simplified".
 * `cname_flattening`. Allowed values: "flatten_at_root", "flatten_all", "flatten_none".
+* `h2_prioritization`. Allowed values: "on", "off", "custom".
 * `min_tls_version`. Allowed values: "1.0", "1.1", "1.2", "1.3".
 * `polish`. Allowed values: "off", "lossless", "lossy".
 * `pseudo_ipv4`. Allowed values: "off", "add_header", "overwrite_header".

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -58,6 +58,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `email_obfuscation`
 * `hotlink_protection`
 * `http2`
+* `image_resizing`
 * `ip_geolocation`
 * `ipv6`
 * `mirage`


### PR DESCRIPTION
Updates the zone settings to support [http/2 prioritisation](https://blog.cloudflare.com/better-http-2-prioritization-for-a-faster-web/) and
[image resizing](https://blog.cloudflare.com/announcing-cloudflare-image-resizing-simplifying-optimal-image-delivery/)

Closes #376