### PR TITLE
Bugfix: browser_cache_ttl is incorrectly sent as a string when unchanged

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -595,7 +595,7 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 	changed := d.HasChange(fmt.Sprintf("actions.0.%s", id))
 
 	if strValue, ok := value.(string); ok {
-		if id == "browser_cache_ttl" && changed {
+		if id == "browser_cache_ttl" {
 			intValue, err := strconv.Atoi(strValue)
 			if err == nil {
 				pageRuleAction.Value = intValue

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -297,6 +297,24 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders
 	})
 }
 
+func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLToSameValue(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	testAccRunResourceTestSteps(t, []resource.TestStep{
+		{
+			Config: buildPageRuleConfig("test", "browser_cache_ttl = 1"),
+		},
+		{
+			Config: buildPageRuleConfig("test", `browser_cache_ttl = 1
+browser_check = "on"`),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+				testAccCheckCloudflarePageRuleHasAction(&pageRule, "browser_cache_ttl", float64(1)),
+				resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.browser_cache_ttl", "1"),
+			),
+		},
+	})
+}
+
 func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders(t *testing.T) {
 	var pageRule cloudflare.PageRule
 	testAccRunResourceTestSteps(t, []resource.TestStep{


### PR DESCRIPTION
Fixes an issue added in https://github.com/terraform-providers/terraform-provider-cloudflare/pull/379 where changing an unrelated value will result in `browser_cache_ttl` being sent as a string rather than an integer. The error message returned from CloudFlare is "TTL values must be whole numbers only". Removing the `changed` from the conditional fixes that.