### PR TITLE
Update website/docs/r/logpush_job.html.markdown

### DIFF
--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -15,7 +15,8 @@ Provides a resource which manages Cloudflare logpush jobs.
 ```hcl
 resource "cloudflare_logpush_job" "example_job" {
   enabled = true
-  name = "My logpush job"
+  zone_id = "d41d8cd98f00b204e9800998ecf8427e"
+  name = "My-logpush-job"
   logpull_options = "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339"
   destination_conf = "s3://my-bucket-path?region=us-west-2"
   ownership_challenge = "00000000000000000"
@@ -26,18 +27,13 @@ resource "cloudflare_logpush_job" "example_job" {
 
 The following arguments are supported:
 
-* `desitination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included.
-* `ownership_challenge` - (Required) Ownership challenge token to prove destination ownership. See [https://developers.cloudflare.com/logs/tutorials/tutorial-logpush-curl/](https://developers.cloudflare.com/logs/tutorials/tutorial-logpush-curl/)
 
-## Import
+* `name` - (Required) The name of the logpush job to create. Must match the regular expression `^[a-zA-Z0-9\-\.]*$`
+* `zone_id` - (Required) The zone ID where the logpush job should be created.
+* `destination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#destination)
+* `ownership_challenge` - (Required) Ownership challenge token to prove destination ownership. See [https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage)
 
-Logpush jobs can be imported using a composite ID formed of zone ID and logpush job ID, e.g.
+- - -
 
-```
-$ terraform import cloudflare_logpush_job.example_job d41d8cd98f00b204e9800998ecf8427e/1
-```
-
-where:
-
-* `d41d8cd98f00b204e9800998ecf8427e` - zone ID as returned by the API
-* `1` - logpush job ID as returned by the [API](https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs)
+* `logpull_options` - (Optional) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpull options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options)
+* `enable` - (Optional) Whether to enable to job to create or not.

--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -28,12 +28,12 @@ resource "cloudflare_logpush_job" "example_job" {
 The following arguments are supported:
 
 
-* `name` - (Required) The name of the logpush job to create. Must match the regular expression `^[a-zA-Z0-9\-\.]*$`
+* `name` - (Required) The name of the logpush job to create. Must match the regular expression `^[a-zA-Z0-9\-\.]*$`.
 * `zone_id` - (Required) The zone ID where the logpush job should be created.
-* `destination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#destination)
-* `ownership_challenge` - (Required) Ownership challenge token to prove destination ownership. See [https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage)
+* `destination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#destination).
+* `ownership_challenge` - (Required) Ownership challenge token to prove destination ownership. See [Developer documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage).
 
 - - -
 
-* `logpull_options` - (Optional) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpull options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options)
+* `logpull_options` - (Optional) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpull options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).
 * `enable` - (Optional) Whether to enable to job to create or not.


### PR DESCRIPTION
- Fixing confusing name field in the example as it must not contain spaces
- Adding missing required field and their description.
- Removing import section as it is not supported for this resource. Error message when trying to run an import : 
```
cloudflare_logpush_job.example_job: Importing from ID "a9c1ccd9b3d737cc0a83e54226b6e96d/6080"...

Error: cloudflare_logpush_job.example_job (import id: a9c1ccd9b3d537cc0a63e54226b6e96d/6070): import cloudflare_logpush_job.example_job (id: a9c1ccd9b3d537cc0a63e54226b6e96d/6080): resource cloudflare_logpush_job doesn't support import
```