### PR TITLE
Unlock unicode domain support in 'cloudflare_zone'

### DIFF
--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -42,8 +42,7 @@ func resourceCloudflareZone() *schema.Resource {
 			"zone": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([a-zA-Z0-9][\\-a-zA-Z0-9]*\\.)+[\\-a-zA-Z0-9]{2,20}$"), ""),
+				ForceNew:     true
 			},
 			"jump_start": {
 				Type:     schema.TypeBool,

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -42,7 +42,7 @@ func resourceCloudflareZone() *schema.Resource {
 			"zone": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true
+				ForceNew:     true,
 			},
 			"jump_start": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
Since RFC 3492 due punycode the range of allowable values for the field has significantly expanded. The correct zone is, for example, "[zajęzyk.pl](http://zajęzyk.pl/)" ([xn--zajzyk-y4a.pl](http://xn--zajzyk-y4a.pl)).

The CloudFlare API returns domain addresses without Punycode encoding, i.e. with a huge number of characters, much larger than allowed in this regular expression.