### PR TITLE
Deprecate `tls_1_2_only` for `cloudflare_zone_settings_override`

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -397,6 +397,7 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 		Optional:     true,
 		Computed:     true,
+		Deprecated:   "tls_1_2_only has been deprecated in favour of using `min_tls_version = \"1.2\"` instead.",
 	},
 
 	"tls_1_3": {

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -72,7 +72,6 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `server_side_exclude`
 * `sha1_support`
 * `sort_query_string_for_cache`
-* `tls_1_2_only`
 * `tls_client_auth`
 * `true_client_ip_header`
 * `waf`


### PR DESCRIPTION
Deprecates the use of `tls_1_2_only` as it has been superseded by
`min_tls_version`.