### PR TITLE
Fix: examples of cloudflare_zone_lockdown in documentation

### DIFF
--- a/website/docs/d/zones.html.md
+++ b/website/docs/d/zones.html.md
@@ -31,12 +31,10 @@ resource "cloudflare_zone_lockdown" "endpoint_lockdown" {
   urls = [
     "api.mysite.com/some/endpoint*",
   ]
-  configurations = [
-    {
-      "target" = "ip"
-      "value" = "198.51.100.4"
-    },
-  ]
+  configurations {
+    target = "ip"
+    value = "198.51.100.4"
+  }
 }
 ```
 

--- a/website/docs/r/zone_lockdown.html.markdown
+++ b/website/docs/r/zone_lockdown.html.markdown
@@ -21,12 +21,10 @@ resource "cloudflare_zone_lockdown" "endpoint_lockdown" {
   urls = [
     "api.mysite.com/some/endpoint*",
   ]
-  configurations = [
-    {
-      "target" = "ip"
-      "value" = "198.51.100.4"
-    },
-  ]
+  configurations {
+    target = "ip"
+    value = "198.51.100.4"
+  }
 }
 ```
 


### PR DESCRIPTION
Examples of cloudflare_zone_lockdown that provided in documentation doesn't work in terraform 0.12