### PR TITLE
resource/cloudflare_zone: Add unicode support

### DIFF
--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -58,7 +58,7 @@ func TestAccCloudflareZone(t *testing.T) {
 	})
 }
 
-func TestZoneWithUnicodeIsStoredAsUnicode(t *testing.T) {
+func TestAccZoneWithUnicodeIsStoredAsUnicode(t *testing.T) {
 	name := "cloudflare_zone.tf-acc-unicode-test-1"
 
 	resource.Test(t, resource.TestCase{
@@ -79,7 +79,7 @@ func TestZoneWithUnicodeIsStoredAsUnicode(t *testing.T) {
 	})
 }
 
-func TestZoneWithoutUnicodeIsStoredAsUnicode(t *testing.T) {
+func TestAccZoneWithoutUnicodeIsStoredAsUnicode(t *testing.T) {
 	name := "cloudflare_zone.tf-acc-unicode-test-2"
 
 	resource.Test(t, resource.TestCase{
@@ -100,7 +100,7 @@ func TestZoneWithoutUnicodeIsStoredAsUnicode(t *testing.T) {
 	})
 }
 
-func TestZonePerformsUnicodeComparison(t *testing.T) {
+func TestAccZonePerformsUnicodeComparison(t *testing.T) {
 	name := "cloudflare_zone.tf-acc-unicode-test-3"
 
 	resource.Test(t, resource.TestCase{

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -66,9 +66,9 @@ func TestAccZoneWithUnicodeIsStoredAsUnicode(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testZoneConfig("tf-acc-unicode-test-1", "zajęzyk.pl", "true", "false"),
+				Config: testZoneConfig("tf-acc-unicode-test-1", "żółw.cfapi.net", "true", "false"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "zajęzyk.pl"),
+					resource.TestCheckResourceAttr(name, "zone", "żółw.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),
@@ -87,9 +87,9 @@ func TestAccZoneWithoutUnicodeIsStoredAsUnicode(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testZoneConfig("tf-acc-unicode-test-2", "xn--zajzyk-y4a.pl", "true", "false"),
+				Config: testZoneConfig("tf-acc-unicode-test-2", "xn--w-uga1v8h.cfapi.net", "true", "false"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "zajęzyk.pl"),
+					resource.TestCheckResourceAttr(name, "zone", "żółw.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),
@@ -108,9 +108,9 @@ func TestAccZonePerformsUnicodeComparison(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testZoneConfig("tf-acc-unicode-test-3", "zajęzyk.pl", "true", "false"),
+				Config: testZoneConfig("tf-acc-unicode-test-3", "żółw.cfapi.net", "true", "false"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "zajęzyk.pl"),
+					resource.TestCheckResourceAttr(name, "zone", "żółw.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),
@@ -118,10 +118,10 @@ func TestAccZonePerformsUnicodeComparison(t *testing.T) {
 				),
 			},
 			{
-				Config:   testZoneConfig("tf-acc-unicode-test-3", "xn--zajzyk-y4a.pl", "true", "false"),
+				Config:   testZoneConfig("tf-acc-unicode-test-3", "xn--w-uga1v8h.cfapi.net", "true", "false"),
 				PlanOnly: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "zajęzyk.pl"),
+					resource.TestCheckResourceAttr(name, "zone", "żółw.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),
@@ -204,7 +204,7 @@ func TestPlanIDFallsBackToEmptyIfUnknown(t *testing.T) {
 func testZoneConfigWithPartialSetup(resourceID, zoneName, paused, jumpStart, plan string) string {
 	return fmt.Sprintf(`
 				resource "cloudflare_zone" "%[1]s" {
-                    zone = "%[2]s"
+					zone = "%[2]s"
 					paused = %[3]s
 					jump_start = %[4]s
 					plan = "%[5]s"
@@ -215,7 +215,7 @@ func testZoneConfigWithPartialSetup(resourceID, zoneName, paused, jumpStart, pla
 func testZoneConfigWithExplicitFullSetup(resourceID, zoneName, paused, jumpStart, plan string) string {
 	return fmt.Sprintf(`
 				resource "cloudflare_zone" "%[1]s" {
-                    zone = "%[2]s"
+					zone = "%[2]s"
 					paused = %[3]s
 					jump_start = %[4]s
 					plan = "%[5]s"

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -58,10 +58,84 @@ func TestAccCloudflareZone(t *testing.T) {
 	})
 }
 
+func TestZoneWithUnicodeIsStoredAsUnicode(t *testing.T) {
+	name := "cloudflare_zone.tf-acc-unicode-test-1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testZoneConfig("tf-acc-unicode-test-1", "zajęzyk.pl", "true", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone", "zajęzyk.pl"),
+					resource.TestCheckResourceAttr(name, "paused", "true"),
+					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
+					resource.TestCheckResourceAttr(name, "plan", planIDFree),
+					resource.TestCheckResourceAttr(name, "type", "full"),
+				),
+			},
+		},
+	})
+}
+
+func TestZoneWithoutUnicodeIsStoredAsUnicode(t *testing.T) {
+	name := "cloudflare_zone.tf-acc-unicode-test-2"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testZoneConfig("tf-acc-unicode-test-2", "xn--zajzyk-y4a.pl", "true", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone", "zajęzyk.pl"),
+					resource.TestCheckResourceAttr(name, "paused", "true"),
+					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
+					resource.TestCheckResourceAttr(name, "plan", planIDFree),
+					resource.TestCheckResourceAttr(name, "type", "full"),
+				),
+			},
+		},
+	})
+}
+
+func TestZonePerformsUnicodeComparison(t *testing.T) {
+	name := "cloudflare_zone.tf-acc-unicode-test-3"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testZoneConfig("tf-acc-unicode-test-3", "zajęzyk.pl", "true", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone", "zajęzyk.pl"),
+					resource.TestCheckResourceAttr(name, "paused", "true"),
+					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
+					resource.TestCheckResourceAttr(name, "plan", planIDFree),
+					resource.TestCheckResourceAttr(name, "type", "full"),
+				),
+			},
+			{
+				Config:   testZoneConfig("tf-acc-unicode-test-3", "xn--zajzyk-y4a.pl", "true", "false"),
+				PlanOnly: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone", "zajęzyk.pl"),
+					resource.TestCheckResourceAttr(name, "paused", "true"),
+					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
+					resource.TestCheckResourceAttr(name, "plan", planIDFree),
+					resource.TestCheckResourceAttr(name, "type", "full"),
+				),
+			},
+		},
+	})
+}
+
 func testZoneConfig(resourceID, zoneName, paused, jumpStart string) string {
 	return fmt.Sprintf(`
 				resource "cloudflare_zone" "%[1]s" {
-                    zone = "%[2]s"
+					zone = "%[2]s"
 					paused = %[3]s
 					jump_start = %[4]s
 				}`, resourceID, zoneName, paused, jumpStart)
@@ -70,7 +144,7 @@ func testZoneConfig(resourceID, zoneName, paused, jumpStart string) string {
 func testZoneConfigWithPlan(resourceID, zoneName, paused, jumpStart, plan string) string {
 	return fmt.Sprintf(`
 				resource "cloudflare_zone" "%[1]s" {
-                    zone = "%[2]s"
+					zone = "%[2]s"
 					paused = %[3]s
 					jump_start = %[4]s
 					plan = "%[5]s"

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/hashicorp/terraform v0.12.4
 	github.com/pkg/errors v0.8.1
 	google.golang.org/genproto v0.0.0-20190716165318-c506a9f90610 // indirect
+	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 )

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab h1:9RfW3ktsOZxgo9YNbBAjq1FWzc/igwEcUzZz8IXgSbk=
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
+golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ golang.org/x/crypto/cast5
 golang.org/x/crypto/openpgp/elgamal
 golang.org/x/crypto/ed25519/internal/edwards25519
 golang.org/x/crypto/internal/subtle
-# golang.org/x/net v0.0.0-20190502183928-7f726cade0ab
+# golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 golang.org/x/net/context
 golang.org/x/net/trace
 golang.org/x/net/internal/timeseries


### PR DESCRIPTION
Introduce unicode support for using zone names and ensure that the
schema comparison is performed after first converting both values to
unicode. This change ensures that the punycode and unicode values are
both stored as the unicode version to match what the Cloudflare API
returns.

### To do

- [x] Setup/purchase unicode domain for tests

Closes #399 