### PR TITLE
Update test names to trigger acceptance tests

### DIFF
--- a/cloudflare/resource_cloudflare_filter_test.go
+++ b/cloudflare/resource_cloudflare_filter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestFilterSimple(t *testing.T) {
+func TestAccFilterSimple(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_filter." + rnd
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -56,7 +56,7 @@ EOF
 }
 `
 
-func TestFilterWhitespace(t *testing.T) {
+func TestAccFilterWhitespace(t *testing.T) {
 	rnd := generateRandomResourceName()
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 

--- a/cloudflare/resource_cloudflare_firewall_rule_test.go
+++ b/cloudflare/resource_cloudflare_firewall_rule_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestFirewallRuleSimple(t *testing.T) {
+func TestAccFirewallRuleSimple(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_firewall_rule." + rnd
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")

--- a/cloudflare/resource_cloudflare_zone_lockdown_test.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestCloudflareZoneLockdown(t *testing.T) {
+func TestAccCloudflareZoneLockdown(t *testing.T) {
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := generateRandomResourceName()
 	name := "cloudflare_zone_lockdown." + rnd
@@ -33,7 +33,7 @@ func TestCloudflareZoneLockdown(t *testing.T) {
 	})
 }
 
-func TestCloudflareZoneLockdown_Import(t *testing.T) {
+func TestAccCloudflareZoneLockdown_Import(t *testing.T) {
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := generateRandomResourceName()
 	name := "cloudflare_zone_lockdown." + rnd
@@ -63,11 +63,9 @@ func testCloudflareZoneLockdownConfig(resourceID, zone, paused, description, url
 					paused = "%[3]s"
 					description = "%[4]s"
 					urls = ["%[5]s"]
-					configurations = [
-						{
-							target = "%[6]s"
-							value = "%[7]s"
-						}
-					]
+					configurations {
+						target = "%[6]s"
+						value = "%[7]s"
+					}
 				}`, resourceID, zone, paused, description, url, target, value)
 }

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestZone(t *testing.T) {
+func TestAccCloudflareZone(t *testing.T) {
 	name := "cloudflare_zone.test"
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
The test names didn't start with `TestAcc` so the integration suite
wasn't running them despite being integration tests.