### PR TITLE
resource/cloudflare_zone_override: Remove `sha1_support`

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -435,13 +435,6 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 		Computed: true,
 	},
 
-	"sha1_support": {
-		Type:         schema.TypeString,
-		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
-		Optional:     true,
-		Computed:     true,
-	},
-
 	"cname_flattening": {
 		Type:         schema.TypeString,
 		ValidateFunc: validation.StringInSlice([]string{"flatten_at_root", "flatten_all", "flatten_none"}, false),

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -70,7 +70,6 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `response_buffering`
 * `rocket_loader`
 * `server_side_exclude`
-* `sha1_support`
 * `sort_query_string_for_cache`
 * `tls_client_auth`
 * `true_client_ip_header`


### PR DESCRIPTION
Cloudflare no longer offer SHA1 certificates once the existing ones
expire and this API endpoint has been removed which ends up erroring
when zone updates are applied.

Fixes the following error:

```
$ terraform apply
cloudflare_zone_settings_override.example_net: Refreshing state... (ID: 2bed060c895c6308651318210a2ef4a2)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ cloudflare_zone_settings_override.example_net
      settings.0.sha1_support:    "" => "on"

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudflare_zone_settings_override.example_net: Modifying... (ID: 2bed060c895c6308651318210a2ef4a2)
  settings.0.sha1_support:    "" => "on"

Error: Error applying plan:

1 error occurred:
    * cloudflare_zone_settings_override.example_net: 1 error occurred:
    * cloudflare_zone_settings_override.example_net: error from makeRequest: HTTP status 400: content "{\"success\":false,\"errors\":[{\"code\":1006,\"message\":\"Unrecognized zone setting name\"}],\"messages\":[],\"result\":null}"
```