### PR TITLE
resource/cloudflare_zone: Update test domain

### DIFF
--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -65,7 +65,6 @@ func TestAccCloudflareZonePartialSetup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "zone", "foo.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
-					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),
 					resource.TestCheckResourceAttr(name, "type", "partial"),
 				),

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccCloudflareZone(t *testing.T) {
-	name := "cloudflare_zone.tf-acc-test"
+func TestAccCloudflareZoneBasic(t *testing.T) {
+	name := "cloudflare_zone.tf-acc-basic-zone"
 	resourceName := strings.Split(name, ".")[1]
 
 	resource.Test(t, resource.TestCase{
@@ -26,6 +26,18 @@ func TestAccCloudflareZone(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "type", "full"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccCloudflareZoneWithPlan(t *testing.T) {
+	name := "cloudflare_zone.tf-acc-with-plan-zone"
+	resourceName := strings.Split(name, ".")[1]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
 				Config: testZoneConfigWithPlan(resourceName, "example.cfapi.net", "true", "false", "free"),
 				Check: resource.ComposeTestCheckFunc(
@@ -36,6 +48,18 @@ func TestAccCloudflareZone(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "type", "full"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccCloudflareZonePartialSetup(t *testing.T) {
+	name := "cloudflare_zone.tf-acc-partial-setup-zone"
+	resourceName := strings.Split(name, ".")[1]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
 				Config: testZoneConfigWithPartialSetup(resourceName, "example.cfapi.net", "true", "false", "free"),
 				Check: resource.ComposeTestCheckFunc(
@@ -46,6 +70,18 @@ func TestAccCloudflareZone(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "type", "partial"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccCloudflareZoneFullSetup(t *testing.T) {
+	name := "cloudflare_zone.tf-acc-full-setup-zone"
+	resourceName := strings.Split(name, ".")[1]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
 				Config: testZoneConfigWithExplicitFullSetup(resourceName, "example.cfapi.net", "true", "false", "free"),
 				Check: resource.ComposeTestCheckFunc(

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -61,9 +61,9 @@ func TestAccCloudflareZonePartialSetup(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testZoneConfigWithPartialSetup(resourceName, "example.cfapi.net", "true", "false", "free"),
+				Config: testZoneConfigWithPartialSetup(resourceName, "foo.net", "true", "false", "free"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "example.cfapi.net"),
+					resource.TestCheckResourceAttr(name, "zone", "foo.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -2,22 +2,24 @@ package cloudflare
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccCloudflareZone(t *testing.T) {
-	name := "cloudflare_zone.test"
+	name := "cloudflare_zone.tf-acc-test"
+	resourceName := strings.Split(name, ".")[1]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testZoneConfig("test", "example.org", "true", "false"),
+				Config: testZoneConfig(resourceName, "example.cfapi.net", "true", "false"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "example.org"),
+					resource.TestCheckResourceAttr(name, "zone", "example.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),
@@ -25,9 +27,9 @@ func TestAccCloudflareZone(t *testing.T) {
 				),
 			},
 			{
-				Config: testZoneConfigWithPlan("test", "example.org", "true", "false", "free"),
+				Config: testZoneConfigWithPlan(resourceName, "example.cfapi.net", "true", "false", "free"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "example.org"),
+					resource.TestCheckResourceAttr(name, "zone", "example.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),
@@ -35,9 +37,9 @@ func TestAccCloudflareZone(t *testing.T) {
 				),
 			},
 			{
-				Config: testZoneConfigWithPartialSetup("test", "example.org", "true", "false", "free"),
+				Config: testZoneConfigWithPartialSetup(resourceName, "example.cfapi.net", "true", "false", "free"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "example.org"),
+					resource.TestCheckResourceAttr(name, "zone", "example.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),
@@ -45,9 +47,9 @@ func TestAccCloudflareZone(t *testing.T) {
 				),
 			},
 			{
-				Config: testZoneConfigWithExplicitFullSetup("test", "example.org", "true", "false", "free"),
+				Config: testZoneConfigWithExplicitFullSetup(resourceName, "example.cfapi.net", "true", "false", "free"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "example.org"),
+					resource.TestCheckResourceAttr(name, "zone", "example.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(name, "plan", planIDFree),


### PR DESCRIPTION
CI has recently started failing the `TestAccCloudflareZone` test as the
`example.org` domain is using old Cloudflare nameservers and the work to
address this is on a backlog to be fixed. Instead of using an example
domain, we can swap to using an ephemeral subdomain and perform the
assertions against that.