### PR TITLE
provider: Rename "token" => "key"

### DIFF
--- a/cloudflare/cloudflare_sweeper_test.go
+++ b/cloudflare/cloudflare_sweeper_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 // sharedClient returns a common Cloudflare client setup needed for the
 // sweeper functions.
 func sharedClient() (*cloudflare.API, error) {
-	client, err := cloudflare.New(os.Getenv("CLOUDFLARE_TOKEN"), os.Getenv("CLOUDFLARE_EMAIL"))
+	client, err := cloudflare.New(os.Getenv("CLOUDFLARE_KEY"), os.Getenv("CLOUDFLARE_EMAIL"))
 
 	if err != nil {
 		return client, err

--- a/cloudflare/config.go
+++ b/cloudflare/config.go
@@ -9,13 +9,13 @@ import (
 
 type Config struct {
 	Email   string
-	Token   string
+	Key     string
 	Options []cloudflare.Option
 }
 
 // Client() returns a new client for accessing cloudflare.
 func (c *Config) Client() (*cloudflare.API, error) {
-	client, err := cloudflare.New(c.Token, c.Email, c.Options...)
+	client, err := cloudflare.New(c.Key, c.Email, c.Options...)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating new Cloudflare client: %s", err)
 	}

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -26,11 +26,11 @@ func Provider() terraform.ResourceProvider {
 				Description: "A registered Cloudflare email address.",
 			},
 
-			"token": &schema.Schema{
+			"key": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_TOKEN", nil),
-				Description: "The token key for API operations.",
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_KEY", nil),
+				Description: "The API key for operations.",
 			},
 
 			"rps": &schema.Schema{
@@ -132,7 +132,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	config := Config{
 		Email:   d.Get("email").(string),
-		Token:   d.Get("token").(string),
+		Key:     d.Get("key").(string),
 		Options: options,
 	}
 
@@ -186,7 +186,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	config = Config{
 		Email:   d.Get("email").(string),
-		Token:   d.Get("token").(string),
+		Key:     d.Get("key").(string),
 		Options: options,
 	}
 

--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -36,8 +36,8 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("CLOUDFLARE_EMAIL must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("CLOUDFLARE_TOKEN"); v == "" {
-		t.Fatal("CLOUDFLARE_TOKEN must be set for acceptance tests")
+	if v := os.Getenv("CLOUDFLARE_KEY"); v == "" {
+		t.Fatal("CLOUDFLARE_KEY must be set for acceptance tests")
 	}
 
 	if v := os.Getenv("CLOUDFLARE_DOMAIN"); v == "" {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -19,7 +19,7 @@ Use the navigation to the left to read about the available resources.
 # Configure the Cloudflare provider
 provider "cloudflare" {
   email = "${var.cloudflare_email}"
-  token = "${var.cloudflare_token}"
+  key   = "${var.cloudflare_key}"
 }
 
 # Create a record
@@ -39,9 +39,9 @@ The following arguments are supported:
 
 * `email` - (Required) The email associated with the account. This can also be
   specified with the `CLOUDFLARE_EMAIL` shell environment variable.
-* `token` - (Required) The Cloudflare API token. This can also be specified
-  with the `CLOUDFLARE_TOKEN` shell environment variable.
-* `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4. 
+* `key` - (Required) The Cloudflare API key. This can also be specified
+  with the `CLOUDFLARE_KEY` shell environment variable.
+* `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4.
   This can also be specified with the `CLOUDFLARE_RPS` shell environment variable.
 * `retries` - (Optional) Maximum number of retries to perform when an API request fails. Default: 3.
   This can also be specified with the `CLOUDFLARE_RETRIES` shell environment variable.
@@ -54,7 +54,6 @@ The following arguments are supported:
 * `org_id` - (Optional) Configure API client with this organisation ID, so calls use the organization API rather than the (default) user API.
   This is required for other users in your organization to have access to the resources you manage.
   This can also be specified with the `CLOUDFLARE_ORG_ID` shell environment variable.
-* `use_org_from_zone` - (Optional) Takes a zone name value. This is used to lookup the organization ID that owns this zone, 
+* `use_org_from_zone` - (Optional) Takes a zone name value. This is used to lookup the organization ID that owns this zone,
   which will be used to configure the API client. If `org_id` is also specified, this field will be ignored.
   This can also be specified with the `CLOUDFLARE_ORG_ZONE` shell environment variable.
-


### PR DESCRIPTION
API "token" is currently used for HTTP authentication requests where the
`X-Auth-Key` needs to be set. Until recently, it was fine to use the
wrong term for this authentication method (as there was only the one)
however there is a new feature upcoming from Cloudflare which is
actually called API tokens and it requires a different authentication
procedure.

This means we need to rename the existing variables and references to
allow us to build in the new functionality when it is announced.

I've updated all the references to use the term "key" as that is what
the documentation and values are and I think it's a better reflection of
what method is in use than what we have in place at the moment.