### PR TITLE
example of include = generates an error

### DIFF
--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -23,7 +23,7 @@ resource "cloudflare_access_policy" "test_policy" {
   precedence     = "1"
   decision       = "allow"
 
-  include = {
+  include {
     email = ["test@example.com"]
   }
 }
@@ -37,7 +37,7 @@ resource "cloudflare_access_policy" "test_policy" {
   precedence     = "1"
   decision       = "allow"
 
-  include = {
+  include {
     email = ["test@example.com"]
   }
 


### PR DESCRIPTION
the example above with the `include =` generates the following error: `An argument named "include" is not expected here. Did you mean to define a block of type "include"?` removing the extra `=` after include removes this error and correctly creates the policy.