### PR TITLE
Deprecation for `zone` in favour of explicit `zone_id`

### DIFF
--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -22,10 +22,11 @@ func resourceCloudflareAccessRule() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 			"zone_id": {
 				Type:     schema.TypeString,

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -22,10 +22,11 @@ func resourceCloudflareFilter() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 			"zone_id": {
 				Type:     schema.TypeString,

--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -22,10 +22,11 @@ func resourceCloudflareFirewallRule() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 			"zone_id": {
 				Type:     schema.TypeString,

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -26,9 +26,10 @@ func resourceCloudflareLoadBalancer() *schema.Resource {
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Required:   true,
+				ForceNew:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 
 			"zone_id": {

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -24,9 +24,10 @@ func resourceCloudflarePageRule() *schema.Resource {
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Required:   true,
+				ForceNew:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 
 			"zone_id": {

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -24,9 +24,10 @@ func resourceCloudflareRateLimit() *schema.Resource {
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Required:   true,
+				ForceNew:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 
 			"zone_id": {

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -27,8 +27,9 @@ func resourceCloudflareWAFRule() *schema.Resource {
 			},
 
 			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:       schema.TypeString,
+				Required:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 
 			"zone_id": {

--- a/cloudflare/resource_cloudflare_worker_route.go
+++ b/cloudflare/resource_cloudflare_worker_route.go
@@ -22,9 +22,10 @@ func resourceCloudflareWorkerRoute() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Required:   true,
+				ForceNew:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 
 			"zone_id": {

--- a/cloudflare/resource_cloudflare_worker_script.go
+++ b/cloudflare/resource_cloudflare_worker_script.go
@@ -27,6 +27,7 @@ func resourceCloudflareWorkerScript() *schema.Resource {
 				ForceNew: true,
 				// zone is used for single-script, name is used for multi-script
 				ConflictsWith: []string{"name"},
+				Deprecated:    "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 
 			"zone_id": {

--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -22,9 +22,10 @@ func resourceCloudflareZoneLockdown() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 			"zone_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Zone names within Cloudflare are not universally unique which makes
performing a lookup based on just the name a little troublesome. Two
accounts can have the same zone name and both of these can be returned
if the lookups are not restricted to the zone ID or account ID.

To rememdy this, `zone` is being deprecated in favour of explicit
`zone_id` values. See the [discussion](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/161#issuecomment-441128985) on this for full details.

Following Terraform's [guidelines for deprecations](https://www.terraform.io/docs/extend/best-practices/deprecations.html#provider-attribute-removal), we are putting in
a deprecation notice as part of a minor release and then in our next
major release, we will actually perform the schema and functionality
removal. This update will not prevent people from using `zone` however
use will trigger a warning that it's going away and they should migrate
themselves.