### PR TITLE
Add a 'tcp' type monitor to cloudflare_load_balancer_monitor

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -147,9 +147,6 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 		Retries:  d.Get("retries").(int),
 	}
 
-	//
-	// common
-	//
 	if description, ok := d.GetOk("description"); ok {
 		loadBalancerMonitor.Description = description.(string)
 	}
@@ -203,9 +200,6 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 		}
 	}
 
-	//
-	// create
-	//
 	log.Printf("[DEBUG] Creating Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	r, err := client.CreateLoadBalancerMonitor(loadBalancerMonitor)
@@ -235,9 +229,6 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, met
 		Retries:  d.Get("retries").(int),
 	}
 
-	//
-	// common
-	//
 	if description, ok := d.GetOk("description"); ok {
 		loadBalancerMonitor.Description = description.(string)
 	}
@@ -291,9 +282,6 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, met
 		}
 	}
 
-	//
-	// update
-	//
 	log.Printf("[DEBUG] Update Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	_, err := client.ModifyLoadBalancerMonitor(loadBalancerMonitor)

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -25,33 +25,12 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
-			"expected_body": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"expected_codes": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"method": {
+			//
+			// common
+			//
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "GET",
-			},
-
-			"timeout": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      5,
-				ValidateFunc: validation.IntBetween(1, 10),
-			},
-
-			"path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "/",
 			},
 
 			"interval": {
@@ -61,6 +40,18 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 			},
 			// interval has to be larger than (retries+1) * probe_timeout:
 
+			"method": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 65535),
+			},
+
 			"retries": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -68,11 +59,51 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 5),
 			},
 
+			"timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      5,
+				ValidateFunc: validation.IntBetween(1, 10),
+			},
+
 			"type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "http",
-				ValidateFunc: validation.StringInSlice([]string{"http", "https"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"http", "https", "tcp"}, false),
+			},
+
+			"created_on": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"modified_on": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			//
+			// http/https only
+			//
+			"allow_insecure": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"expected_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"expected_codes": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"follow_redirects": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 
 			"header": {
@@ -97,34 +128,9 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 				Set: HashByMapKey("header"),
 			},
 
-			"description": {
+			"path": {
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-
-			"port": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 65535),
-			},
-
-			"allow_insecure": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
-			"follow_redirects": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
-			"created_on": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"modified_on": {
-				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -135,20 +141,15 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 	client := meta.(*cloudflare.API)
 
 	loadBalancerMonitor := cloudflare.LoadBalancerMonitor{
-		ExpectedBody:  d.Get("expected_body").(string),
-		ExpectedCodes: d.Get("expected_codes").(string),
-		Method:        d.Get("method").(string),
-		Timeout:       d.Get("timeout").(int),
-		Type:          d.Get("type").(string),
-		Path:          d.Get("path").(string),
-		Interval:      d.Get("interval").(int),
-		Retries:       d.Get("retries").(int),
+		Timeout:  d.Get("timeout").(int),
+		Type:     d.Get("type").(string),
+		Interval: d.Get("interval").(int),
+		Retries:  d.Get("retries").(int),
 	}
 
-	if header, ok := d.GetOk("header"); ok {
-		loadBalancerMonitor.Header = expandLoadBalancerMonitorHeader(header)
-	}
-
+	//
+	// common
+	//
 	if description, ok := d.GetOk("description"); ok {
 		loadBalancerMonitor.Description = description.(string)
 	}
@@ -157,14 +158,54 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 		loadBalancerMonitor.Port = uint16(port.(int))
 	}
 
-	if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
-		loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
+	switch loadBalancerMonitor.Type {
+	case "tcp":
+		if method, ok := d.GetOk("method"); ok {
+			loadBalancerMonitor.Method = method.(string)
+		} else {
+			loadBalancerMonitor.Method = "connection_established"
+		}
+	case "http", "https":
+		if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
+			loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
+		}
+
+		if expectedBody, ok := d.GetOk("expected_body"); ok {
+			loadBalancerMonitor.ExpectedBody = expectedBody.(string)
+		} else {
+			return fmt.Errorf("expected_body must be set")
+		}
+
+		if expectedCodes, ok := d.GetOk("expected_codes"); ok {
+			loadBalancerMonitor.ExpectedCodes = expectedCodes.(string)
+		} else {
+			return fmt.Errorf("expected_codes must be set")
+		}
+
+		if followRedirects, ok := d.GetOk("follow_redirects"); ok {
+			loadBalancerMonitor.FollowRedirects = followRedirects.(bool)
+		}
+
+		if method, ok := d.GetOk("method"); ok {
+			loadBalancerMonitor.Method = method.(string)
+		} else {
+			loadBalancerMonitor.Method = "GET"
+		}
+
+		if header, ok := d.GetOk("header"); ok {
+			loadBalancerMonitor.Header = expandLoadBalancerMonitorHeader(header)
+		}
+
+		if path, ok := d.GetOk("path"); ok {
+			loadBalancerMonitor.Path = path.(string)
+		} else {
+			loadBalancerMonitor.Path = "/"
+		}
 	}
 
-	if followRedirects, ok := d.GetOk("follow_redirects"); ok {
-		loadBalancerMonitor.FollowRedirects = followRedirects.(bool)
-	}
-
+	//
+	// create
+	//
 	log.Printf("[DEBUG] Creating Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	r, err := client.CreateLoadBalancerMonitor(loadBalancerMonitor)
@@ -173,7 +214,7 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("cailed to find id in create response; resource was empty")
+		return fmt.Errorf("failed to find id in create response; resource was empty")
 	}
 
 	d.SetId(r.ID)
@@ -187,21 +228,16 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, met
 	client := meta.(*cloudflare.API)
 
 	loadBalancerMonitor := cloudflare.LoadBalancerMonitor{
-		ID:            d.Id(),
-		ExpectedBody:  d.Get("expected_body").(string),
-		ExpectedCodes: d.Get("expected_codes").(string),
-		Method:        d.Get("method").(string),
-		Timeout:       d.Get("timeout").(int),
-		Type:          d.Get("type").(string),
-		Path:          d.Get("path").(string),
-		Interval:      d.Get("interval").(int),
-		Retries:       d.Get("retries").(int),
+		ID:       d.Id(),
+		Timeout:  d.Get("timeout").(int),
+		Type:     d.Get("type").(string),
+		Interval: d.Get("interval").(int),
+		Retries:  d.Get("retries").(int),
 	}
 
-	if header, ok := d.GetOk("header"); ok {
-		loadBalancerMonitor.Header = expandLoadBalancerMonitorHeader(header)
-	}
-
+	//
+	// common
+	//
 	if description, ok := d.GetOk("description"); ok {
 		loadBalancerMonitor.Description = description.(string)
 	}
@@ -210,14 +246,54 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, met
 		loadBalancerMonitor.Port = uint16(port.(int))
 	}
 
-	if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
-		loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
+	switch loadBalancerMonitor.Type {
+	case "tcp":
+		if method, ok := d.GetOk("method"); ok {
+			loadBalancerMonitor.Method = method.(string)
+		} else {
+			loadBalancerMonitor.Method = "connection_established"
+		}
+	case "http", "https":
+		if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
+			loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
+		}
+
+		if expectedBody, ok := d.GetOk("expected_body"); ok {
+			loadBalancerMonitor.ExpectedBody = expectedBody.(string)
+		} else {
+			return fmt.Errorf("expected_body must be set")
+		}
+
+		if expectedCodes, ok := d.GetOk("expected_codes"); ok {
+			loadBalancerMonitor.ExpectedCodes = expectedCodes.(string)
+		} else {
+			return fmt.Errorf("expected_codes must be set")
+		}
+
+		if header, ok := d.GetOk("header"); ok {
+			loadBalancerMonitor.Header = expandLoadBalancerMonitorHeader(header)
+		}
+
+		if followRedirects, ok := d.GetOk("follow_redirects"); ok {
+			loadBalancerMonitor.FollowRedirects = followRedirects.(bool)
+		}
+
+		if method, ok := d.GetOk("method"); ok {
+			loadBalancerMonitor.Method = method.(string)
+		} else {
+			loadBalancerMonitor.Method = "GET"
+		}
+
+		if path, ok := d.GetOk("path"); ok {
+			loadBalancerMonitor.Path = path.(string)
+		} else {
+			loadBalancerMonitor.Path = "/"
+		}
 	}
 
-	if followRedirects, ok := d.GetOk("follow_redirects"); ok {
-		loadBalancerMonitor.FollowRedirects = followRedirects.(bool)
-	}
-
+	//
+	// update
+	//
 	log.Printf("[DEBUG] Update Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
 	_, err := client.ModifyLoadBalancerMonitor(loadBalancerMonitor)
@@ -256,24 +332,27 @@ func resourceCloudflareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta 
 	}
 	log.Printf("[DEBUG] Read Cloudflare Load Balancer Monitor from API as struct: %+v", loadBalancerMonitor)
 
-	d.Set("expected_body", loadBalancerMonitor.ExpectedBody)
-	d.Set("expected_codes", loadBalancerMonitor.ExpectedCodes)
-	d.Set("method", loadBalancerMonitor.Method)
-	d.Set("timeout", loadBalancerMonitor.Timeout)
-	d.Set("path", loadBalancerMonitor.Path)
-	d.Set("interval", loadBalancerMonitor.Interval)
-	d.Set("retries", loadBalancerMonitor.Retries)
-	d.Set("type", loadBalancerMonitor.Type)
+	if loadBalancerMonitor.Type == "http" || loadBalancerMonitor.Type == "https" {
+		d.Set("allow_insecure", loadBalancerMonitor.AllowInsecure)
+		d.Set("expected_body", loadBalancerMonitor.ExpectedBody)
+		d.Set("expected_codes", loadBalancerMonitor.ExpectedCodes)
+		d.Set("follow_redirects", loadBalancerMonitor.FollowRedirects)
+		d.Set("path", loadBalancerMonitor.Path)
+
+		if err := d.Set("header", flattenLoadBalancerMonitorHeader(loadBalancerMonitor.Header)); err != nil {
+			log.Printf("[WARN] Error setting header for load balancer monitor %q: %s", d.Id(), err)
+		}
+	}
+
 	d.Set("description", loadBalancerMonitor.Description)
+	d.Set("interval", loadBalancerMonitor.Interval)
+	d.Set("method", loadBalancerMonitor.Method)
 	d.Set("port", loadBalancerMonitor.Port)
-	d.Set("allow_insecure", loadBalancerMonitor.AllowInsecure)
-	d.Set("follow_redirects", loadBalancerMonitor.FollowRedirects)
+	d.Set("retries", loadBalancerMonitor.Retries)
+	d.Set("timeout", loadBalancerMonitor.Timeout)
+	d.Set("type", loadBalancerMonitor.Type)
 	d.Set("created_on", loadBalancerMonitor.CreatedOn.Format(time.RFC3339Nano))
 	d.Set("modified_on", loadBalancerMonitor.ModifiedOn.Format(time.RFC3339Nano))
-
-	if err := d.Set("header", flattenLoadBalancerMonitorHeader(loadBalancerMonitor.Header)); err != nil {
-		log.Printf("[WARN] Error setting header for load balancer monitor %q: %s", d.Id(), err)
-	}
 
 	return nil
 }

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -8,12 +8,14 @@ description: |-
 
 # cloudflare_load_balancer_monitor
 
-If you're using Cloudflare's Load Balancing to load-balance across multiple origin servers or data centers, you configure one of these Monitors to actively check the availability of those servers over HTTP(S).
+If you're using Cloudflare's Load Balancing to load-balance across multiple origin servers or data centers, you configure one of these Monitors to actively check the availability of those servers over HTTP(S) or TCP.
 
 ## Example Usage
 
+### HTTP Monitor
 ```hcl
-resource "cloudflare_load_balancer_monitor" "test" {
+resource "cloudflare_load_balancer_monitor" "http_monitor" {
+  type = "http"
   expected_body = "alive"
   expected_codes = "2xx"
   method = "GET"
@@ -21,7 +23,7 @@ resource "cloudflare_load_balancer_monitor" "test" {
   path = "/health"
   interval = 60
   retries = 5
-  description = "example load balancer"
+  description = "example http load balancer"
   header {
     header = "Host"
     values = ["example.com"]
@@ -31,22 +33,34 @@ resource "cloudflare_load_balancer_monitor" "test" {
 }
 ```
 
+### TCP Monitor
+```hcl
+resource "cloudflare_load_balancer_monitor" "tcp_monitor" {
+  type = "tcp"
+  method = "connection_established"
+  timeout = 7
+  interval = 60
+  retries = 5
+  description = "example tcp load balancer"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `expected_body` - (Required) A case-insensitive sub-string to look for in the response body. If this string is not found, the origin will be marked as unhealthy.
-* `expected_codes` - (Required) The expected HTTP response code or code range of the health check. Eg `2xx`
-* `method` - (Optional) The HTTP method to use for the health check. Default: "GET".
+* `expected_body` - (Optional) A case-insensitive sub-string to look for in the response body. If this string is not found, the origin will be marked as unhealthy. Only valid and required if `type` is "http" or "https".
+* `expected_codes` - (Optional) The expected HTTP response code or code range of the health check. Eg `2xx`. Only valid and required if `type` is "http" or "https".
+* `method` - (Optional) The method to use for the health check. Valid values are any valid HTTP verb if `type` is "http" or "https", or `connection_established` if `type` is "tcp". Default: "GET" if `type` is "http" or "https", or "connection_established" if `type` is "tcp" .
 * `timeout` - (Optional) The timeout (in seconds) before marking the health check as failed. Default: 5.
-* `path` - (Optional) The endpoint path to health check against. Default: "/".
+* `path` - (Optional) The endpoint path to health check against. Default: "/". Only valid if `type` is "http" or "https".
 * `interval` - (Optional) The interval between each health check. Shorter intervals may improve failover time, but will increase load on the origins as we check from multiple locations. Default: 60.
 * `retries` - (Optional) The number of retries to attempt in case of a timeout before marking the origin as unhealthy. Retries are attempted immediately. Default: 2.
-* `header` - (Optional) The HTTP request headers to send in the health check. It is recommended you set a Host header by default. The User-Agent header cannot be overridden. Fields documented below.
-* `type` - (Optional) The protocol to use for the healthcheck. Currently supported protocols are 'HTTP' and 'HTTPS'. Default: "http".
+* `header` - (Optional) The HTTP request headers to send in the health check. It is recommended you set a Host header by default. The User-Agent header cannot be overridden. Fields documented below. Only valid if `type` is "http" or "https".
+* `type` - (Optional) The protocol to use for the healthcheck. Currently supported protocols are 'HTTP', 'HTTPS' and 'TCP'. Default: "http".
 * `description` - (Optional) Free text description.
-* `allow_insecure` - (Optional) Do not validate the certificate when monitor use HTTPS.
-* `follow_redirects` - (Optional) Follow redirects if returned by the origin.
+* `allow_insecure` - (Optional) Do not validate the certificate when monitor use HTTPS. Only valid if `type` is "http" or "https".
+* `follow_redirects` - (Optional) Follow redirects if returned by the origin. Only valid if `type` is "http" or "https".
 
 **header** requires the following:
 


### PR DESCRIPTION
This fix #427

I am not comfortable with go and terraform-provider dev, so I hope it's ok.