### PR TITLE
Closes #429 SSL: adding support for origin_pull setting

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -297,7 +297,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 						"ssl": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"off", "flexible", "full", "strict"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"off", "flexible", "full", "strict", "origin_pull"}, false),
 						},
 					},
 				},

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -76,7 +76,7 @@ Action blocks support the following:
 * `server_side_exclude` - (Optional) Whether this action is `"on"` or `"off"`.
 * `smart_errors` - (Optional) Whether this action is `"on"` or `"off"`.
 * `sort_query_string_for_cache` - (Optional) Whether this action is `"on"` or `"off"`.
-* `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, or `"strict"`.
+* `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, `"strict"`, or `"origin_pull"`
 * `true_client_ip_header` - (Optional) Whether this action is `"on"` or `"off"`.
 * `waf` - (Optional) Whether this action is `"on"` or `"off"`.
 

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -76,7 +76,7 @@ Action blocks support the following:
 * `server_side_exclude` - (Optional) Whether this action is `"on"` or `"off"`.
 * `smart_errors` - (Optional) Whether this action is `"on"` or `"off"`.
 * `sort_query_string_for_cache` - (Optional) Whether this action is `"on"` or `"off"`.
-* `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, `"strict"`, or `"origin_pull"`
+* `ssl` - (Optional) Whether to set the SSL mode to `"off"`, `"flexible"`, `"full"`, `"strict"`, or `"origin_pull"`.
 * `true_client_ip_header` - (Optional) Whether this action is `"on"` or `"off"`.
 * `waf` - (Optional) Whether this action is `"on"` or `"off"`.
 


### PR DESCRIPTION
Adding "origin_pull" SSL pageActionRule for Cloudflare Enterprise support. 
[Issue](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/429)
[Cloudflare ssl] https://support.cloudflare.com/hc/en-us/articles/200170416