### PR TITLE
Fix expected_body not accepting empty string

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -93,7 +93,7 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 
 			"expected_body": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 			},
 
 			"expected_codes": {
@@ -163,14 +163,11 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 			loadBalancerMonitor.Method = "connection_established"
 		}
 	case "http", "https":
+		expectedBody := d.Get("expected_body")
+		loadBalancerMonitor.ExpectedBody = expectedBody.(string)
+
 		if allowInsecure, ok := d.GetOk("allow_insecure"); ok {
 			loadBalancerMonitor.AllowInsecure = allowInsecure.(bool)
-		}
-
-		if expectedBody, ok := d.GetOk("expected_body"); ok {
-			loadBalancerMonitor.ExpectedBody = expectedBody.(string)
-		} else {
-			return fmt.Errorf("expected_body must be set")
 		}
 
 		if expectedCodes, ok := d.GetOk("expected_codes"); ok {

--- a/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
@@ -265,6 +265,15 @@ resource "cloudflare_load_balancer_monitor" "test" {
 }`
 }
 
+func testAccCheckCloudflareLoadBalancerMonitorConfigEmptyExpectedBody() string {
+	return `
+resource "cloudflare_load_balancer_monitor" "test" {
+  expected_body = ""
+  expected_codes = "2xx"
+
+}`
+}
+
 func testAccCheckCloudflareLoadBalancerMonitorConfigFullySpecified() string {
 	return `
 resource "cloudflare_load_balancer_monitor" "test" {


### PR DESCRIPTION
This string is perfectly valid in the CloudFlare API but is rejected
because it counts as a "zero value" in the Terraform schema libraries.

Closes #447 