### PR TITLE
Support use of API tokens in addition to API Keys

### DIFF
--- a/cloudflare/config.go
+++ b/cloudflare/config.go
@@ -8,17 +8,26 @@ import (
 )
 
 type Config struct {
-	Email   string
-	Token   string
-	Options []cloudflare.Option
+	Email    string
+	Token    string
+	APIToken string
+	Options  []cloudflare.Option
 }
 
-// Client() returns a new client for accessing cloudflare.
+// Client returns a new client for accessing cloudflare.
 func (c *Config) Client() (*cloudflare.API, error) {
-	client, err := cloudflare.New(c.Token, c.Email, c.Options...)
+	var err error
+	var client *cloudflare.API
+
+	if c.APIToken != "" {
+		client, err = cloudflare.NewWithAPIToken(c.APIToken, c.Options...)
+	} else {
+		client, err = cloudflare.New(c.Token, c.Email, c.Options...)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("Error creating new Cloudflare client: %s", err)
 	}
+
 	log.Printf("[INFO] Cloudflare Client configured for user: %s", c.Email)
 	return client, nil
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,11 +37,14 @@ resource "cloudflare_page_rule" "www" {
 
 The following arguments are supported:
 
-* `email` - (Required) The email associated with the account. This can also be
+* `email` - (Optional) The email associated with the account. This can also be
   specified with the `CLOUDFLARE_EMAIL` shell environment variable.
-* `token` - (Required) The Cloudflare API token. This can also be specified
+* `token` - (Optional) The Cloudflare API key. This can also be specified
   with the `CLOUDFLARE_TOKEN` shell environment variable.
-* `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4. 
+* `api_token` - (Optional) The Cloudflare API Token. This can also be specified with
+  the `CLOUDFLARE_API_TOKEN` shell environment variable. This is an alternative to
+  `email`+`token`(key). If both are specified, `api_token` will be used over `email`+`token`(key) fields.
+* `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4.
   This can also be specified with the `CLOUDFLARE_RPS` shell environment variable.
 * `retries` - (Optional) Maximum number of retries to perform when an API request fails. Default: 3.
   This can also be specified with the `CLOUDFLARE_RETRIES` shell environment variable.


### PR DESCRIPTION
This is the alternative way to add support of using API Tokens. We can use this one if the release date of the breaking changes is too far away.

This pull request introduced a new field called "api_token" as alternative to the "email"+"token" (api key) auth scheme.

**Changes**
- Added optional api_token as an alternative to email+token (api key)
- Marked email and token (api key) as optional