### PR TITLE
Add deprecation notice for `zone`, take 2

### DIFF
--- a/cloudflare/resource_cloudflare_worker_route.go
+++ b/cloudflare/resource_cloudflare_worker_route.go
@@ -22,15 +22,16 @@ func resourceCloudflareWorkerRoute() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				// Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 
 			"zone_id": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"multi_script": {
@@ -77,18 +78,30 @@ func getRouteFromResource(d *schema.ResourceData) cloudflare.WorkerRoute {
 func resourceCloudflareWorkerRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	route := getRouteFromResource(d)
-
 	zoneName := d.Get("zone").(string)
-	zoneId, err := client.ZoneIDByName(zoneName)
-	if err != nil {
-		return fmt.Errorf("error finding zone %q: %s", zoneName, err)
+	zoneID := d.Get("zone_id").(string)
+
+	// While we are deprecating `zone`, we need to perform the validation
+	// inside the `Create` to ensure we get at least one of the expected
+	// values.
+	if zoneName == "" && zoneID == "" {
+		return fmt.Errorf("either zone name or ID must be provided")
 	}
-	d.Set("zone_id", zoneId)
+
+	if zoneID == "" {
+		var err error
+		zoneID, err = client.ZoneIDByName(zoneName)
+		if err != nil {
+			return fmt.Errorf("error finding zone %q: %s", zoneName, err)
+		}
+	}
+
+	d.Set("zone_id", zoneID)
 	d.Set("multi_script", route.Script != "")
 
 	log.Printf("[INFO] Creating Cloudflare Worker Route from struct: %+v", route)
 
-	r, err := client.CreateWorkerRoute(zoneId, route)
+	r, err := client.CreateWorkerRoute(zoneID, route)
 	if err != nil {
 		return errors.Wrap(err, "error creating worker route")
 	}
@@ -106,12 +119,12 @@ func resourceCloudflareWorkerRouteCreate(d *schema.ResourceData, meta interface{
 
 func resourceCloudflareWorkerRouteRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneId := d.Get("zone_id").(string)
-	routeId := d.Id()
+	zoneID := d.Get("zone_id").(string)
+	routeID := d.Id()
 
 	// There isn't a dedicated endpoint for retrieving a specific route, so we
 	// list all routes and find the target route by comparing IDs
-	resp, err := client.ListWorkerRoutes(zoneId)
+	resp, err := client.ListWorkerRoutes(zoneID)
 
 	if err != nil {
 		return errors.Wrap(err, "error reading worker routes")
@@ -119,7 +132,7 @@ func resourceCloudflareWorkerRouteRead(d *schema.ResourceData, meta interface{})
 
 	var route cloudflare.WorkerRoute
 	for _, r := range resp.Routes {
-		if r.ID == routeId {
+		if r.ID == routeID {
 			route = r
 			break
 		}
@@ -145,12 +158,12 @@ func resourceCloudflareWorkerRouteRead(d *schema.ResourceData, meta interface{})
 
 func resourceCloudflareWorkerRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneId := d.Get("zone_id").(string)
+	zoneID := d.Get("zone_id").(string)
 	route := getRouteFromResource(d)
 
 	log.Printf("[INFO] Updating Cloudflare Worker Route from struct: %+v", route)
 
-	_, err := client.UpdateWorkerRoute(zoneId, route.ID, route)
+	_, err := client.UpdateWorkerRoute(zoneID, route.ID, route)
 	if err != nil {
 		return errors.Wrap(err, "error updating worker route")
 	}
@@ -161,12 +174,12 @@ func resourceCloudflareWorkerRouteUpdate(d *schema.ResourceData, meta interface{
 
 func resourceCloudflareWorkerRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneId := d.Get("zone_id").(string)
+	zoneID := d.Get("zone_id").(string)
 	route := getRouteFromResource(d)
 
-	log.Printf("[INFO] Deleting Cloudflare Worker Route from zone %+v with id: %+v", zoneId, route.ID)
+	log.Printf("[INFO] Deleting Cloudflare Worker Route from zone %+v with id: %+v", zoneID, route.ID)
 
-	_, err := client.DeleteWorkerRoute(zoneId, route.ID)
+	_, err := client.DeleteWorkerRoute(zoneID, route.ID)
 	if err != nil {
 		return errors.Wrap(err, "error deleting worker route")
 	}
@@ -181,19 +194,19 @@ func resourceCloudflareWorkerRouteImport(d *schema.ResourceData, meta interface{
 	// split the id so we can lookup
 	idAttr := strings.SplitN(d.Id(), "/", 2)
 	var zoneName string
-	var routeId string
+	var routeID string
 	if len(idAttr) == 2 {
 		zoneName = idAttr[0]
-		routeId = idAttr[1]
+		routeID = idAttr[1]
 	} else {
-		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneName/routeId\"", d.Id())
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneName/routeID\"", d.Id())
 	}
 
 	zoneID, err := client.ZoneIDByName(zoneName)
 	routes, err := client.ListWorkerRoutes(zoneID)
 
 	for _, r := range routes.Routes {
-		if r.ID == routeId && client.OrganizationID != "" {
+		if r.ID == routeID && client.OrganizationID != "" {
 			isEnterpriseWorker = true
 		}
 	}
@@ -205,7 +218,7 @@ func resourceCloudflareWorkerRouteImport(d *schema.ResourceData, meta interface{
 	d.Set("zone", zoneName)
 	d.Set("zone_id", zoneID)
 	d.Set("multi_script", isEnterpriseWorker)
-	d.SetId(routeId)
+	d.SetId(routeID)
 
 	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
We have been working to perform some breaking changes in #227 and the
first attempt at this in #421 neglected to allow people to set `zone_id`
and action the deprecation notice :facepalm:

This second attempt has the same goal of deprecating `zone` in favour of
explicit `zone_id` however this time I've updated both schema properties
to be optional and added some validation in the various `Create` methods
to ensure that we get at least one of them during the swap over period.
That code can be removed as soon we've cut a breaking change release.

Closes #439