### PR TITLE
resource/cloudflare_page_rule: Remove `HasChange` for `edge_cache_ttl`

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -593,8 +593,6 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 
 	pageRuleAction.ID = id
 
-	changed := d.HasChange(fmt.Sprintf("actions.0.%s", id))
-
 	if strValue, ok := value.(string); ok {
 		if id == "browser_cache_ttl" {
 			intValue, err := strconv.Atoi(strValue)
@@ -621,7 +619,7 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 			}
 		}
 	} else if intValue, ok := value.(int); ok {
-		if id == "edge_cache_ttl" && intValue > 0 && changed {
+		if id == "edge_cache_ttl" && intValue > 0 {
 			pageRuleAction.Value = intValue
 		} else {
 			pageRuleAction.Value = nil


### PR DESCRIPTION
Prior to swapping to PUT requests for updating page rules, we used to
perform manual diff checks that would determine which actions we would
add to the page rule before sending it. This is no longer now as we
swapped to using a PUT request which replaces the whole rule and we are
able to send the whole page rule as-is without doing the work ourselves.

This popped up as it's caused a bug whereby updating a page rule that
includes a `edge_cache_ttl` (but not change it) results in the
`edge_cache_ttl` being dropped completely.

`TestAccCloudflarePageRuleEdgeCacheTTLNotClobbered` is the regression
test case that demonstrates the behaviour.