### PR TITLE
Allow `zone_id` to be `Computed`

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -36,6 +36,7 @@ func resourceCloudflareLoadBalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"name": {

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -34,6 +34,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"target": {

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -34,6 +34,7 @@ func resourceCloudflareRateLimit() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"threshold": {

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -35,6 +35,7 @@ func resourceCloudflareWAFRule() *schema.Resource {
 			"zone_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"package_id": {

--- a/cloudflare/resource_cloudflare_worker_route.go
+++ b/cloudflare/resource_cloudflare_worker_route.go
@@ -32,6 +32,7 @@ func resourceCloudflareWorkerRoute() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"multi_script": {


### PR DESCRIPTION
While we are deprecating `zone`, there will be times when `zone` is
provided by the end user and `zone_id` isn't. Despite this, we set the
`zone_id` in the `Create` method. To achieve this, the schemas need to
be updated to allow computed fields.