### PR TITLE
Mark `zone` to always be Computed

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -29,6 +29,7 @@ func resourceCloudflareLoadBalancer() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
+				Computed:   true,
 				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -27,6 +27,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
+				Computed:   true,
 				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -27,6 +27,7 @@ func resourceCloudflareRateLimit() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
+				Computed:   true,
 				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -29,6 +29,7 @@ func resourceCloudflareWAFRule() *schema.Resource {
 			"zone": {
 				Type:       schema.TypeString,
 				Optional:   true,
+				Computed:   true,
 				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 

--- a/cloudflare/resource_cloudflare_worker_route.go
+++ b/cloudflare/resource_cloudflare_worker_route.go
@@ -25,6 +25,7 @@ func resourceCloudflareWorkerRoute() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
+				Computed:   true,
 				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 

--- a/cloudflare/resource_cloudflare_worker_script.go
+++ b/cloudflare/resource_cloudflare_worker_script.go
@@ -27,6 +27,7 @@ func resourceCloudflareWorkerScript() *schema.Resource {
 				ForceNew: true,
 				// zone is used for single-script, name is used for multi-script
 				ConflictsWith: []string{"name"},
+				Computed:      true,
 				Deprecated:    "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 

--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -25,6 +25,7 @@ func resourceCloudflareZoneLockdown() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
+				Computed:   true,
 				Deprecated: "`zone` is deprecated in favour of explicit `zone_id` and will be removed in the next major release",
 			},
 			"zone_id": {


### PR DESCRIPTION
While we're deprecating `zone` we will need it to be Computed as we
manage getting and unsetting the values in the action methods.

Fixes #461