### PR TITLE
Update example resources to v0.12 syntax, and fix depends_on for worker_route

### DIFF
--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -42,7 +42,7 @@ resource "cloudflare_access_policy" "test_policy" {
   }
 
   require = {
-    ip = ["${var.office_ip}"]
+    ip = [var.office_ip]
   }
 }
 ```

--- a/website/docs/r/access_rule.html.markdown
+++ b/website/docs/r/access_rule.html.markdown
@@ -45,12 +45,12 @@ variable "my_office" {
   default = ["192.0.2.0/24", "198.51.100.0/24", "2001:db8::/56"]
 }
 resource "cloudflare_access_rule" "office_network" {
-  count = "${length(var.my_office)}"
+  count = length(var.my_office)
   notes = "Requests coming from office network"
   mode = "whitelist"
   configuration {
     target = "ip_range"
-    value = "${element(var.my_office, count.index)}"
+    value = element(var.my_office, count.index)
   }
 }
 ```

--- a/website/docs/r/firewall_rule.markdown
+++ b/website/docs/r/firewall_rule.markdown
@@ -25,7 +25,7 @@ resource "cloudflare_filter" "wordpress" {
 resource "cloudflare_firewall_rule" "wordpress" {
   zone_id = "d41d8cd98f00b204e9800998ecf8427e"
   description = "Block wordpress break-in attempts"
-  filter_id = "${cloudflare_filter.wordpress.id}"
+  filter_id = cloudflare_filter.wordpress.id
   action = "block"
 }
 ```

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -19,18 +19,18 @@ Provides a Cloudflare Load Balancer resource. This sits in front of a number of 
 resource "cloudflare_load_balancer" "bar" {
   zone = "example.com"
   name = "example-load-balancer"
-  fallback_pool_id = "${cloudflare_load_balancer_pool.foo.id}"
-  default_pool_ids = ["${cloudflare_load_balancer_pool.foo.id}"]
+  fallback_pool_id = cloudflare_load_balancer_pool.foo.id
+  default_pool_ids = [cloudflare_load_balancer_pool.foo.id]
   description = "example load balancer using geo-balancing"
   proxied = true
   steering_policy = "geo"
   pop_pools {
     pop = "LAX"
-    pool_ids = ["${cloudflare_load_balancer_pool.foo.id}"]
+    pool_ids = [cloudflare_load_balancer_pool.foo.id]
   }
   region_pools {
     region = "WNAM"
-    pool_ids = ["${cloudflare_load_balancer_pool.foo.id}"]
+    pool_ids = [cloudflare_load_balancer_pool.foo.id"]
   }
 }
 

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -30,7 +30,7 @@ resource "cloudflare_load_balancer" "bar" {
   }
   region_pools {
     region = "WNAM"
-    pool_ids = [cloudflare_load_balancer_pool.foo.id"]
+    pool_ids = [cloudflare_load_balancer_pool.foo.id]
   }
 }
 

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -15,7 +15,7 @@ Provides a Cloudflare page rule resource.
 ```hcl
 # Add a page rule to the domain
 resource "cloudflare_page_rule" "foobar" {
-  zone = "${var.cloudflare_zone}"
+  zone = var.cloudflare_zone
   target = "sub.${var.cloudflare_zone}/page"
   priority = 1
 

--- a/website/docs/r/rate_limit.html.markdown
+++ b/website/docs/r/rate_limit.html.markdown
@@ -14,7 +14,7 @@ Provides a Cloudflare rate limit resource for a given zone. This can be used to 
 
 ```hcl
 resource "cloudflare_rate_limit" "example" {
-  zone = "${var.cloudflare_zone}"
+  zone = var.cloudflare_zone
   threshold = 2000
   period = 2
   match {

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -15,7 +15,7 @@ Provides a Cloudflare record resource.
 ```hcl
 # Add a record to the domain
 resource "cloudflare_record" "foobar" {
-  domain = "${var.cloudflare_zone}"
+  domain = var.cloudflare_zone
   name   = "terraform"
   value  = "192.168.0.11"
   type   = "A"
@@ -24,7 +24,7 @@ resource "cloudflare_record" "foobar" {
 
 # Add a record requiring a data map
 resource "cloudflare_record" "_sip_tls" {
-  domain = "${var.cloudflare_zone}"
+  domain = var.cloudflare_zone
   name   = "_sip._tls"
   type   = "SRV"
 

--- a/website/docs/r/worker_route.html.markdown
+++ b/website/docs/r/worker_route.html.markdown
@@ -24,7 +24,7 @@ resource "cloudflare_worker_route" "my_route" {
   # it's recommended to set `depends_on` to point to the cloudflare_worker_script
   # resource in order to make sure that the script is uploaded before the route
   # is created
-  depends_on = ["cloudflare_worker_script.my_script"]
+  depends_on = [cloudflare_worker_script.my_script]
 }
 
 resource "cloudflare_worker_script" "my_script" {

--- a/website/docs/r/worker_route.html.markdown
+++ b/website/docs/r/worker_route.html.markdown
@@ -41,7 +41,7 @@ __NOTE:__ This is only for enterprise accounts. With multi-script, each route po
 resource "cloudflare_worker_route" "my_route" {
   zone = "example.com"
   pattern = "example.com/*"
-  script_name = "${cloudflare_worker_script.my_script.name}"
+  script_name = cloudflare_worker_script.my_script.name
 }
 
 resource "cloudflare_worker_script" "my_script" {

--- a/website/docs/r/worker_script.html.markdown
+++ b/website/docs/r/worker_script.html.markdown
@@ -18,7 +18,7 @@ __NOTE:__ This is for non-enterprise accounts where there is one script per zone
 # Sets the script for the example.com zone
 resource "cloudflare_worker_script" "my_script" {
   zone = "example.com"
-  content = "${file("script.js")}"
+  content = file("script.js")
 }
 ```
 
@@ -30,7 +30,7 @@ __NOTE:__ This is only for enterprise accounts. With multi-script, each script i
 # Sets the script with the name "script_1"
 resource "cloudflare_worker_script" "my_script" {
   name = "script_1"
-  content = "${file("script.js")}"
+  content = file("script.js")
 }
 ```
 

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -14,7 +14,7 @@ Provides a resource which customizes Cloudflare zone settings. Note that after d
 
 ```hcl
 resource "cloudflare_zone_settings_override" "test" {
-	name = "${var.cloudflare_zone}"
+	name = var.cloudflare_zone
 	settings {
 		brotli = "on"
 		challenge_ttl = 2700


### PR DESCRIPTION
This PR updates the resource examples in the documentation to be more Terraform 0.12 friendly by removing the unnecessary use of interpolation `${}` when not required.

It also fixes an incorrect `depends_on` meta-argument in the cloudflare_worker_route resource. The resource in the `depends_on` meta-argument should not be in quotes.

`depends_on = ["cloudflare_worker_script.my_script"]` therefore becomes `depends_on = [cloudflare_worker_script.my_script]`