### PR TITLE
Update cloudflare page rule attribute

### DIFF
--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -15,7 +15,7 @@ Provides a Cloudflare page rule resource.
 ```hcl
 # Add a page rule to the domain
 resource "cloudflare_page_rule" "foobar" {
-  zone = var.cloudflare_zone
+  zone_id = var.cloudflare_zone
   target = "sub.${var.cloudflare_zone}/page"
   priority = 1
 
@@ -35,7 +35,7 @@ resource "cloudflare_page_rule" "foobar" {
 
 The following arguments are supported:
 
-* `zone` - (Required) The DNS zone to which the page rule should be added.
+* `zone_id` - (Required) The DNS zone id to which the page rule should be added.
 * `target` - (Required) The URL pattern to target with the page rule.
 * `actions` - (Required) The actions taken by the page rule, options given below.
 * `priority` - (Optional) The priority of the page rule among others for this target, the higher the number the higher the priority as per [API documentation](https://api.cloudflare.com/#page-rules-for-a-zone-create-page-rule).


### PR DESCRIPTION
Since `zone` is deprecated in favour of explicit `zone_id` which is settable so I have updated the docs to reflect the same change 

https://github.com/terraform-providers/terraform-provider-cloudflare/pull/452