### PR TITLE
Missing = sign in the configuration block

### DIFF
--- a/website/docs/r/access_rule.html.markdown
+++ b/website/docs/r/access_rule.html.markdown
@@ -17,7 +17,7 @@ Provides a Cloudflare IP Firewall Access Rule resource. Access control can be ap
 resource "cloudflare_access_rule" "tor_exit_nodes" {
   notes = "Requests coming from known Tor exit nodes"
   mode = "challenge"
-  configuration {
+  configuration = {
     target = "country"
     value = "T1"
   }
@@ -27,7 +27,7 @@ resource "cloudflare_access_rule" "tor_exit_nodes" {
 resource "cloudflare_access_rule" "antarctica" {
   notes = "Requests coming from Antarctica"
   mode = "whitelist"
-  configuration {
+  configuration = {
     target = "country"
     value = "AQ"
   }
@@ -48,7 +48,7 @@ resource "cloudflare_access_rule" "office_network" {
   count = length(var.my_office)
   notes = "Requests coming from office network"
   mode = "whitelist"
-  configuration {
+  configuration = {
     target = "ip_range"
     value = element(var.my_office, count.index)
   }


### PR DESCRIPTION
Missing = sign in the configuration block. Otherwise Terraform v0.12.3 and CloudFlare provider v1.18.1 will complain about "Error: Missing required argument" and "Error: Unsupported block type"

`Error: Missing required argument

  on firewall_access_rules.tf line 1, in resource "cloudflare_access_rule" "omitted":
   1: resource "cloudflare_access_rule" "omitted" {

The argument "configuration" is required, but no definition was found.


Error: Unsupported block type

  on firewall_access_rules.tf line 9, in resource "cloudflare_access_rule" "omitted":
   9:   configuration {

Blocks of type "configuration" are not expected here. Did you mean to define
argument "configuration"? If so, use the equals sign to assign it a value.

`