### PR TITLE
Handle the errors when fetching data for the Argo resource

### DIFF
--- a/cloudflare/resource_cloudflare_argo.go
+++ b/cloudflare/resource_cloudflare_argo.go
@@ -50,8 +50,15 @@ func resourceCloudflareArgoRead(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] zone ID: %s", zoneID)
 
-	tieredCaching, _ := client.ArgoTieredCaching(zoneID)
-	smartRouting, _ := client.ArgoSmartRouting(zoneID)
+	tieredCaching, err := client.ArgoTieredCaching(zoneID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get tiered caching setting")
+	}
+
+	smartRouting, err := client.ArgoSmartRouting(zoneID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get smart routing setting")
+	}
 
 	checksum := stringChecksum(fmt.Sprintf("%s/argo", zoneID))
 	d.SetId(checksum)


### PR DESCRIPTION
The errors were so far only ignored, which let terraform behave
as if everything was fine, even if we were unable to fetch the
current value for the smart routing or tiered caching.

cc @sbfaulkner