### PR TITLE
APILIB-901: h2_prioritization setting not able to be set in bulk

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -665,13 +665,3 @@ func resourceCloudflarePageRuleImport(d *schema.ResourceData, meta interface{}) 
 
 	return []*schema.ResourceData{d}, nil
 }
-
-func contains(slice []string, item string) bool {
-	set := make(map[string]struct{}, len(slice))
-	for _, s := range slice {
-		set[s] = struct{}{}
-	}
-
-	_, ok := set[item]
-	return ok
-}

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -470,7 +470,9 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 }
 
 var fetchAsSingleSetting = []string{
+	"binary_ast",
 	"h2_prioritization",
+	"image_resizing",
 }
 
 func resourceCloudflareZoneSettingsOverrideCreate(d *schema.ResourceData, meta interface{}) error {

--- a/cloudflare/resource_cloudflare_zone_settings_override_test.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override_test.go
@@ -56,6 +56,8 @@ func TestAccCloudflareZoneSettingsOverride_Full(t *testing.T) {
 						name, "settings.0.challenge_ttl", "2700"),
 					resource.TestCheckResourceAttr(
 						name, "settings.0.security_level", "high"),
+					resource.TestCheckResourceAttr(
+						name, "settings.0.h2_prioritization", "on"),
 				),
 			},
 		},
@@ -219,6 +221,7 @@ resource "cloudflare_zone_settings_override" "test" {
 		security_level = "high"
 		opportunistic_encryption = "on"
 		automatic_https_rewrites = "on"
+		h2_prioritization = "on"
 		minify {
 			css = "on"
 			js = "off"

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -51,3 +51,14 @@ func stringChecksum(s string) string {
 
 	return fmt.Sprintf("%x", bs)
 }
+
+// Returns true if string value exists in string slice
+func contains(slice []string, item string) bool {
+	set := make(map[string]struct{}, len(slice))
+	for _, s := range slice {
+		set[s] = struct{}{}
+	}
+
+	_, ok := set[item]
+	return ok
+}


### PR DESCRIPTION
Because the API is fronted by API Gateway which routes various endpoints into different upstreams, `h2_prioritization` cannot be set through general `/zone/settings` endpoint. We need to call it directly as a separate API call.