### PR TITLE
Adding example with cloudflare_zones

### DIFF
--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -38,6 +38,20 @@ resource "cloudflare_record" "_sip_tls" {
     target   = "example.com"
   }
 }
+
+data "cloudflare_zones" "infra" {
+  filter {
+    name   = "example.com"
+    status = "active"
+    paused = false
+  }
+}
+
+resource "cloudflare_record" "infra" {
+  zone_id = "${lookup(data.cloudflare_zones.infra.zones[0], "id")}"
+  name    = "..."
+...
+}
 ```
 
 ## Argument Reference


### PR DESCRIPTION
It's handy to know how to use `cloudflare_zones` with `cloudflare_record`, because it's not obvious that you need to use `lookup`.
