### PR TITLE
Add support for Access Service Tokens

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -93,6 +93,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_access_application":     resourceCloudflareAccessApplication(),
 			"cloudflare_access_policy":          resourceCloudflareAccessPolicy(),
 			"cloudflare_access_rule":            resourceCloudflareAccessRule(),
+			"cloudflare_access_service_token":   resourceCloudflareAccessServiceToken(),
 			"cloudflare_account_member":         resourceCloudflareAccountMember(),
 			"cloudflare_argo":                   resourceCloudflareArgo(),
 			"cloudflare_custom_pages":           resourceCloudflareCustomPages(),

--- a/cloudflare/resource_cloudflare_access_service_tokens.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens.go
@@ -1,0 +1,126 @@
+package cloudflare
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceCloudflareAccessServiceToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareAccessServiceTokenCreate,
+		Read:   resourceCloudflareAccessServiceTokenRead,
+		Update: resourceCloudflareAccessServiceTokenUpdate,
+		Delete: resourceCloudflareAccessServiceTokenDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareAccessServiceTokenImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"client_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_secret": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceCloudflareAccessServiceTokenRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+
+	// The Cloudflare API doesn't support fetching a single service token
+	// so instead we loop over all the service tokens and only continue
+	// when we have a match.
+	serviceTokens, _, err := client.AccessServiceTokens(accountID)
+	if err != nil {
+		return fmt.Errorf("error fetching access service tokens: %s", err)
+	}
+	for _, token := range serviceTokens {
+		if token.ID == d.Id() {
+			d.Set("name", token.Name)
+			d.Set("client_id", token.ClientID)
+		}
+	}
+
+	return nil
+}
+
+func resourceCloudflareAccessServiceTokenCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+	tokenName := d.Get("name").(string)
+
+	serviceToken, err := client.CreateAccessServiceToken(accountID, tokenName)
+	if err != nil {
+		return fmt.Errorf("error creating access service token: %s", err)
+	}
+
+	d.SetId(serviceToken.ID)
+	d.Set("name", serviceToken.Name)
+	d.Set("client_id", serviceToken.ClientID)
+	d.Set("client_secret", serviceToken.ClientSecret)
+
+	resourceCloudflareAccessServiceTokenRead(d, meta)
+
+	return nil
+}
+
+func resourceCloudflareAccessServiceTokenUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+	tokenName := d.Get("name").(string)
+
+	serviceToken, err := client.UpdateAccessServiceToken(accountID, d.Id(), tokenName)
+	if err != nil {
+		return fmt.Errorf("error updating access service token: %s", err)
+	}
+
+	d.Set("name", serviceToken.Name)
+
+	return resourceCloudflareAccessServiceTokenRead(d, meta)
+}
+
+func resourceCloudflareAccessServiceTokenDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+
+	_, err := client.DeleteAccessServiceToken(accountID, d.Id())
+	if err != nil {
+		return fmt.Errorf("error deleting access service token: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceCloudflareAccessServiceTokenImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	attributes := strings.SplitN(d.Id(), "/", 2)
+
+	if len(attributes) != 2 {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/serviceTokenID\"", d.Id())
+	}
+
+	d.Set("account_id", attributes[0])
+	d.SetId(attributes[1])
+
+	resourceCloudflareAccessServiceTokenRead(d, meta)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/cloudflare/resource_cloudflare_access_service_tokens_test.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens_test.go
@@ -12,6 +12,16 @@ import (
 )
 
 func TestAccAccessServiceTokenCreate(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// Service Tokens endpoint does not yet support the API tokens and it
+	// results in misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_service_token.tf-acc-%s", rnd)
@@ -35,6 +45,16 @@ func TestAccAccessServiceTokenCreate(t *testing.T) {
 }
 
 func TestAccAccessServiceTokenUpdate(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// Service Tokens endpoint does not yet support the API tokens and it
+	// results in misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_service_token.tf-acc-%s", rnd)
@@ -61,6 +81,16 @@ func TestAccAccessServiceTokenUpdate(t *testing.T) {
 }
 
 func TestAccAccessServiceTokenDelete(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// Service Tokens endpoint does not yet support the API tokens and it
+	// results in misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_service_token.tf-acc-%s", rnd)

--- a/cloudflare/resource_cloudflare_access_service_tokens_test.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens_test.go
@@ -1,0 +1,110 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAccessServiceTokenCreate(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_access_service_token.tf-acc-%s", rnd)
+	resourceName := strings.Split(name, ".")[1]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testCloudflareAccessServiceTokenBasicConfig(resourceName, accountID, resourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "name", resourceName),
+					resource.TestCheckResourceAttrSet(name, "client_id"),
+					resource.TestCheckResourceAttrSet(name, "client_secret"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAccessServiceTokenUpdate(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_access_service_token.tf-acc-%s", rnd)
+	resourceName := strings.Split(name, ".")[1]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testCloudflareAccessServiceTokenBasicConfig(resourceName, accountID, resourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", resourceName),
+				),
+			},
+			{
+				Config: testCloudflareAccessServiceTokenBasicConfig(resourceName, accountID, resourceName+"-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", resourceName+"-updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAccessServiceTokenDelete(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_access_service_token.tf-acc-%s", rnd)
+	resourceName := strings.Split(name, ".")[1]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareAccessServiceTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCloudflareAccessServiceTokenBasicConfig(resourceName, accountID, resourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "name", resourceName),
+					resource.TestCheckResourceAttrSet(name, "client_id"),
+					resource.TestCheckResourceAttrSet(name, "client_secret"),
+				),
+			},
+		},
+	})
+}
+
+func testCloudflareAccessServiceTokenBasicConfig(resourceName, accountID, tokenName string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_access_service_token" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[3]s"
+}`, resourceName, accountID, tokenName)
+}
+
+func testAccCheckCloudflareAccessServiceTokenDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_access_service_token" {
+			continue
+		}
+
+		_, err := client.DeleteAccessServiceToken(rs.Primary.Attributes["account_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("access service token still exists")
+		}
+	}
+
+	return nil
+}

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -49,6 +49,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-access-rule") %>>
               <a href="/docs/providers/cloudflare/r/access_rule.html">cloudflare_access_rule</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-access-service-token") %>>
+              <a href="/docs/providers/cloudflare/r/access_service_token.html">cloudflare_access_service_token</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-account-member") %>>
               <a href="/docs/providers/cloudflare/r/account_member.html">cloudflare_account_member</a>
             </li>

--- a/website/docs/r/access_service_token.html.markdown
+++ b/website/docs/r/access_service_token.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_access_service_token"
+sidebar_current: "docs-cloudflare-resource-access-service-token"
+description: |-
+  Provides a Cloudflare Access Service Token resource.
+---
+
+# cloudflare_access_service_token
+
+Access Service Tokens are used for service-to-service communication
+when an application is behind Cloudflare Access.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_access_service_token" "my_app" {
+  account_id = "d41d8cd98f00b204e9800998ecf8427e"
+  name       = "CI/CD app"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) The ID of the account where the Access
+Service is being created.
+* `name` - (Required) Friendly name of the token's intent.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `client_id` - UUID client ID associated with the Service Token.
+* `client_secret` - A secret for interacting with Access protocols.
+
+## Import
+
+~> **Important:** If you are importing an Access Service Token you will
+not have the `client_secret` available in the state for use. The
+`client_secret` is only available once, at creation. In most cases, it
+is better to just create a new resource should you need to reference it
+in other resources.
+
+Access Service Tokens can be imported using a composite ID formed of
+account ID and Service Token ID.
+
+```
+$ terraform import cloudflare_access_service_token.my_app cb029e245cfdd66dc8d2e570d5dd3322/d41d8cd98f00b204e9800998ecf8427e
+```
+
+where
+
+* `cb029e245cfdd66dc8d2e570d5dd3322` - Account ID
+* `d41d8cd98f00b204e9800998ecf8427e` - Access Service Token ID


### PR DESCRIPTION
Introduces the ability to manage Cloudflare Access Service Tokens via
Terraform.

See https://developers.cloudflare.com/access/service-auth/service-token/

Closes #209

### Screenshots

**Inactive sidebar** 

![](https://shares.jacobbednarz.com/4dbXq9juaIgI9GUoIFEeWnwwG1BvdTdMze.png)

**Active sidebar**

![](https://shares.jacobbednarz.com/g6COX8vDL8PyOBmowi9OZtF94IL1ZeyCA9.png)

**Documentation** 

![](https://shares.jacobbednarz.com/rhsaX4nwU1OCXVf3qZPOltNUhPxDQ12epL.png)