### PR TITLE
sweeper/zones: Sweep all zones

### DIFF
--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -24,7 +24,7 @@ func testSweepCloudflareZones(r string) error {
 		log.Printf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
 	}
 
-	zones, zoneErr := client.ListZones("baa-com.cfapi.net", "baa-net.cfapi.net", "baa-org.cfapi.net", "foo-net.cfapi.net")
+	zones, zoneErr := client.ListZones()
 	if zoneErr != nil {
 		log.Printf("[ERROR] Failed to fetch Cloudflare zones: %s", zoneErr)
 	}
@@ -35,6 +35,11 @@ func testSweepCloudflareZones(r string) error {
 	}
 
 	for _, zone := range zones {
+		// Don't try and sweep the static domains.
+		if zone.Name == "terraform.cfapi.net" || zone.Name == "terraform2.cfapi.net" {
+			continue
+		}
+
 		log.Printf("[INFO] Deleting Cloudflare Zone ID: %s", zone.ID)
 		_, err := client.DeleteZone(zone.ID)
 


### PR DESCRIPTION
When we initially put the zone sweeper into place, it was in a shared
account that we couldn't just remove everything. This meant the
`ListZones` needed to only look up the zones we were expecting to
remove and clear those out. This is no longer the case as the tests run
against a dedicated account so we can blow everything away that isn't
the static `cfapi.net` domains (`terraform` and `terraform2`).

Fixes the following integration test failure.

```
=== RUN   TestAccCloudflareZoneBasic
--- FAIL: TestAccCloudflareZoneBasic (0.79s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error creating zone "example.cfapi.net": error from makeRequest: HTTP status 400: content "{\"success\":false,\"errors\":[{\"code\":1061,\"message\":\"example.cfapi.net already exists\"}],\"messages\":[],\"result\":null}"

          on /opt/teamcity-agent/temp/buildTmp/tf-test007851057/main.tf line 2:
          (source code not available)

FAIL
```