### PR TITLE
Redo #509

### DIFF
--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -111,6 +111,10 @@ func resourceCloudflareZone() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"verification_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -190,6 +194,7 @@ func resourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("meta", flattenMeta(d, zone.Meta))
 	d.Set("zone", zone.Name)
 	d.Set("plan", planIDForName(plan))
+	d.Set("verification_key", zone.VerificationKey)
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -73,6 +73,28 @@ func TestAccCloudflareZonePartialSetup(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareZonePartialSetupEnterprise(t *testing.T) {
+	name := "cloudflare_zone.tf-acc-partial-setup-zone"
+	resourceName := strings.Split(name, ".")[1]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testZoneConfigWithPartialSetup(resourceName, "foo.net", "false", "false", "enterprise"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone", "foo.net"),
+					resource.TestCheckResourceAttr(name, "paused", "false"),
+					resource.TestCheckResourceAttr(name, "plan", planIDEnterprise),
+					resource.TestCheckResourceAttr(name, "type", "partial"),
+					resource.TestCheckResourceAttrSet(name, "verification_key"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareZoneFullSetup(t *testing.T) {
 	name := "cloudflare_zone.tf-acc-full-setup-zone"
 	resourceName := strings.Split(name, ".")[1]

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -82,9 +82,9 @@ func TestAccCloudflareZonePartialSetupEnterprise(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testZoneConfigWithPartialSetup(resourceName, "foo.net", "false", "false", "enterprise"),
+				Config: testZoneConfigWithPartialSetup(resourceName, "tf-acc-partial-enterprise.cfapi.net", "false", "false", "enterprise"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "foo.net"),
+					resource.TestCheckResourceAttr(name, "zone", "tf-acc-partial-enterprise.cfapi.net"),
 					resource.TestCheckResourceAttr(name, "paused", "false"),
 					resource.TestCheckResourceAttr(name, "plan", planIDEnterprise),
 					resource.TestCheckResourceAttr(name, "type", "partial"),

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -39,6 +39,7 @@ The following attributes are exported:
 * `meta.phishing_detected` - Indicates if URLs on the zone have been identified as hosting phishing content.
 * `status` - Status of the zone. Valid values: `active`, `pending`, `initializing`, `moved`, `deleted`, `deactivated`.
 * `name_servers` - Cloudflare-assigned name servers. This is only populated for zones that use Cloudflare DNS.
+* `verification_key` - Contains the TXT record value to validate domain ownership. This is only populated for zones of type `partial`. 
 
 ## Import
 


### PR DESCRIPTION
#509 ended up with a bunch of extra commits in it and hard to merge.
This makes the intended change without any of the whacky merge
conflicts.