### PR TITLE
cloudflare_zone_settings_override: Add support for 0rtt and http3

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -415,9 +415,17 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 	},
 
 	"http2": {
-		Type: schema.TypeString, ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
-		Optional: true,
-		Computed: true,
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+		Optional:     true,
+		Computed:     true,
+	},
+
+	"http3": {
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+		Optional:     true,
+		Computed:     true,
 	},
 
 	"pseudo_ipv4": {
@@ -462,6 +470,13 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 	},
 
 	"image_resizing": {
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+		Optional:     true,
+		Computed:     true,
+	},
+
+	"0rtt": {
 		Type:         schema.TypeString,
 		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 		Optional:     true,

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -57,6 +57,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `email_obfuscation` (default: `on`)
 * `hotlink_protection` (default: `off`)
 * `http2` (default: `off`)
+* `http3` (default: `off`)
 * `image_resizing` (default: `off`)
 * `ip_geolocation` (default: `on`)
 * `ipv6` (default: `off`)
@@ -75,6 +76,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `waf` (default: `off`)
 * `webp` (default: `off`). Note that the value specified will be ignored unless `polish` is turned on (i.e. is "lossless" or "lossy")
 * `websockets` (default: `off`)
+* `0rtt` (default: `off`)
 
 ### String Values
 


### PR DESCRIPTION
Adds documentation and functionality to support the use of `0rtt` and
`http3` for zone configurations.

Closes #528