### PR TITLE
Implement Origin CA certificate resource

### DIFF
--- a/cloudflare/config.go
+++ b/cloudflare/config.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Config struct {
-	Email    string
-	APIKey   string
-	APIToken string
-	Options  []cloudflare.Option
+	Email             string
+	APIKey            string
+	APIUserServiceKey string
+	APIToken          string
+	Options           []cloudflare.Option
 }
 
 // Client returns a new client for accessing cloudflare.
@@ -26,6 +27,10 @@ func (c *Config) Client() (*cloudflare.API, error) {
 	}
 	if err != nil {
 		return nil, fmt.Errorf("Error creating new Cloudflare client: %s", err)
+	}
+
+	if c.APIUserServiceKey != "" {
+		client.APIUserServiceKey = c.APIUserServiceKey
 	}
 
 	log.Printf("[INFO] Cloudflare Client configured for user: %s", c.Email)

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -39,6 +39,13 @@ func Provider() terraform.ResourceProvider {
 				Description: "The API Token for operations.",
 			},
 
+			"api_user_service_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_API_USER_SERVICE_KEY", nil),
+				Description: "A special Cloudflare API key good for a restricted set of endpoints.",
+			},
+
 			"rps": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -106,6 +113,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_load_balancer_pool":     resourceCloudflareLoadBalancerPool(),
 			"cloudflare_load_balancer":          resourceCloudflareLoadBalancer(),
 			"cloudflare_logpush_job":            resourceCloudflareLogpushJob(),
+			"cloudflare_origin_ca_certificate":  resourceCloudflareOriginCACertificate(),
 			"cloudflare_page_rule":              resourceCloudflarePageRule(),
 			"cloudflare_rate_limit":             resourceCloudflareRateLimit(),
 			"cloudflare_record":                 resourceCloudflareRecord(),
@@ -166,6 +174,10 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		}
 	} else {
 		return nil, fmt.Errorf("credentials are not set correctly")
+	}
+
+	if v, ok := d.GetOk("api_user_service_key"); ok {
+		config.APIUserServiceKey = v.(string)
 	}
 
 	client, err := config.Client()

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -1,0 +1,160 @@
+package cloudflare
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceCloudflareOriginCACertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareOriginCACertificateCreate,
+		Read:   resourceCloudflareOriginCACertificateRead,
+		Delete: resourceCloudflareOriginCACertificateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"csr": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCSR,
+			},
+			"expires_on": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hostnames": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"request_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"origin-rsa", "origin-ecc", "keyless-certificate"}, false),
+			},
+			"requested_validity": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntInSlice([]int{7, 30, 90, 365, 730, 1095, 5475}),
+			},
+		},
+	}
+}
+
+func resourceCloudflareOriginCACertificateCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	hostnames := []string{}
+	hostnamesRaw := d.Get("hostnames").(*schema.Set)
+	for _, h := range hostnamesRaw.List() {
+		hostnames = append(hostnames, h.(string))
+	}
+
+	certInput := cloudflare.OriginCACertificate{
+		CSR:         d.Get("csr").(string),
+		Hostnames:   hostnames,
+		RequestType: d.Get("request_type").(string),
+	}
+
+	requestValidity, ok := d.GetOk("requested_validity")
+	if ok {
+		certInput.RequestValidity = requestValidity.(int)
+	}
+
+	log.Printf("[INFO] Creating Cloudflare OriginCACertificate: hostnames %v", hostnames)
+	cert, err := client.CreateOriginCertificate(certInput)
+
+	if err != nil {
+		return fmt.Errorf("Error creating origin certificate: %s", err)
+	}
+
+	d.SetId(cert.ID)
+	d.Set("certificate", cert.Certificate)
+	d.Set("expires_on", cert.ExpiresOn.Format(time.RFC3339))
+	return nil
+}
+
+func resourceCloudflareOriginCACertificateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	certID := d.Id()
+	cert, err := client.OriginCertificate(certID)
+
+	log.Printf("[DEBUG] OriginCACertificate: %#v", cert)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "Failed to read certificate from Database") {
+			log.Printf("[INFO] OriginCACertificate %s does not exist", certID)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error finding OriginCACertificate %q: %s", certID, err)
+	}
+
+	if cert.RevokedAt != (time.Time{}) {
+		log.Printf("[INFO] OriginCACertificate %s has been revoked", certID)
+		d.SetId("")
+		return nil
+	}
+
+	hostnames := schema.NewSet(schema.HashString, []interface{}{})
+	for _, h := range cert.Hostnames {
+		hostnames.Add(h)
+	}
+
+	d.Set("certificate", cert.Certificate)
+	d.Set("expires_on", cert.ExpiresOn.Format(time.RFC3339))
+	d.Set("hostnames", hostnames)
+	d.Set("request_type", cert.RequestType)
+
+	return nil
+}
+
+func resourceCloudflareOriginCACertificateDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	certID := d.Id()
+
+	log.Printf("[INFO] Revoking Cloudflare OriginCACertificate: id %s", certID)
+
+	_, err := client.RevokeOriginCertificate(certID)
+
+	if err != nil {
+		return fmt.Errorf("Error revoking Cloudflare OriginCACertificate: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func validateCSR(v interface{}, k string) (ws []string, errors []error) {
+	block, _ := pem.Decode([]byte(v.(string)))
+	if block == nil {
+		errors = append(errors, fmt.Errorf("%q: invalid PEM data", k))
+		return
+	}
+
+	_, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %s", k, err.Error()))
+	}
+	return
+}

--- a/cloudflare/resource_cloudflare_origin_ca_certificate_test.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate_test.go
@@ -1,0 +1,152 @@
+package cloudflare
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCloudflareOriginCACertificate_Basic(t *testing.T) {
+	var cert cloudflare.OriginCACertificate
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := generateRandomResourceName()
+	name := "cloudflare_origin_ca_certificate." + rnd
+
+	csr, err := generateCSR(zoneName)
+	if err != nil {
+		t.Errorf("unable to generate CSR: %v", err)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareOriginCACertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareOriginCACertificateConfigBasic(rnd, zoneName, csr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareOriginCACertificateExists(name, &cert),
+					testAccCheckCloudflareOriginCACertificateAttributes(zoneName, &cert),
+					resource.TestMatchResourceAttr(name, "id", regexp.MustCompile("^[0-9]+$")),
+					resource.TestCheckResourceAttr(name, "csr", csr),
+					resource.TestCheckResourceAttr(name, "request_type", "origin-rsa"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareOriginCACertificateDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_origin_ca_certificate" {
+			continue
+		}
+
+		cert, err := client.OriginCertificate(rs.Primary.ID)
+		if err == nil && cert.RevokedAt == (time.Time{}) {
+			return fmt.Errorf("Origin CA Certificate still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudflareOriginCACertificateExists(name string, cert *cloudflare.OriginCACertificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Origin CA Certificate ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+		foundOriginCACertificate, err := client.OriginCertificate(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*cert = *foundOriginCACertificate
+		return nil
+	}
+}
+
+func testAccCheckCloudflareOriginCACertificateAttributes(zone string, cert *cloudflare.OriginCACertificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		actual := schema.NewSet(schema.HashString, []interface{}{})
+		for _, h := range cert.Hostnames {
+			actual.Add(h)
+		}
+		expected := schema.NewSet(schema.HashString, []interface{}{zone, fmt.Sprintf("*.%s", zone)})
+		if actual.Difference(expected).Len() > 0 {
+			return fmt.Errorf("Incorrect hostnames: expected %v, got %v", expected, actual)
+		}
+
+		block, _ := pem.Decode([]byte(cert.Certificate))
+		if block == nil {
+			return fmt.Errorf("Bad certificate: %s", cert.Certificate)
+		}
+
+		_, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return err
+		}
+
+		if !cert.ExpiresOn.After(time.Now()) {
+			return fmt.Errorf("Expiration date of new cert is in the past: %s", cert.ExpiresOn.Format(time.RFC3339))
+		}
+
+		return nil
+	}
+}
+
+func generateCSR(zone string) (string, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", err
+	}
+
+	template := x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName: zone,
+		},
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, key)
+	if err != nil {
+		return "", err
+	}
+
+	csrPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+	return string(csrPem), nil
+}
+
+func testAccCheckCloudflareOriginCACertificateConfigBasic(name string, zoneName, csr string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_origin_ca_certificate" "%[1]s" {
+	csr                = <<EOT
+%[3]sEOT
+	hostnames          = [ "%[2]s", "*.%[2]s" ]
+	request_type       = "origin-rsa"
+	requested_validity = 7
+}
+`, name, zoneName, csr)
+}

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -88,6 +88,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-logpush-job") %>>
               <a href="/docs/providers/cloudflare/r/logpush_job.html">cloudflare_logpush_job</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-origin-ca-certificate") %>>
+              <a href="/docs/providers/cloudflare/r/origin_ca_certificate.html">cloudflare_origin_ca_certificate</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-page-rule") %>>
                 <a href="/docs/providers/cloudflare/r/page_rule.html">cloudflare_page_rule</a>
             </li>

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -48,9 +48,9 @@ The following arguments are supported:
   with the `CLOUDFLARE_API_TOKEN` shell environment variable. This is an
   alternative to `email`+`api_key`. If both are specified, `api_token` will be
   used over `email`+`api_key` fields.
-* `api_user_service_key` - (Optional) The Cloudflare API Key. This can also be specified
-  with the `CLOUDFLARE_API_USER_SERVICE_KEY` shell environment variable. This is used
-  for a specific set of endpoints, such as creating Origin CA certificates.
+* `api_user_service_key` - (Optional) The Cloudflare API User Service Key. This can also 
+  be specified with the `CLOUDFLARE_API_USER_SERVICE_KEY` shell environment variable. 
+  This is used for a specific set of endpoints, such as creating Origin CA certificates.
 * `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4.
   This can also be specified with the `CLOUDFLARE_RPS` shell environment variable.
 * `retries` - (Optional) Maximum number of retries to perform when an API request fails. Default: 3.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -48,6 +48,9 @@ The following arguments are supported:
   with the `CLOUDFLARE_API_TOKEN` shell environment variable. This is an
   alternative to `email`+`api_key`. If both are specified, `api_token` will be
   used over `email`+`api_key` fields.
+* `api_user_service_key` - (Optional) The Cloudflare API Key. This can also be specified
+  with the `CLOUDFLARE_API_USER_SERVICE_KEY` shell environment variable. This is used
+  for a specific set of endpoints, such as creating Origin CA certificates.
 * `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4.
   This can also be specified with the `CLOUDFLARE_RPS` shell environment variable.
 * `retries` - (Optional) Maximum number of retries to perform when an API request fails. Default: 3.

--- a/website/docs/r/origin_ca_certificate.html.markdown
+++ b/website/docs/r/origin_ca_certificate.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_origin_ca_certificate"
+sidebar_current: "docs-cloudflare-resource-origin-ca-certificate"
+description: |-
+  Provides a Cloudflare Origin CA certificate resource.
+---
+
+# cloudflare_origin_ca_certificate
+
+Provides a Cloudflare Origin CA certificate used to protect traffic to your origin without involving a third party Certificate Authority.
+
+**This resource requires you use your Origin CA Key as the [`api_user_service_key`](../index.html#api_user_service_key).**
+
+## Example Usage
+
+```hcl
+# Create a CSR and generate a CA certificate
+resource "tls_private_key" "example" {
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "example" {
+  key_algorithm   = tls_private_key.example.algorithm
+  private_key_pem = tls_private_key.example.private_key_pem
+
+  subject {
+    common_name  = ""
+    organization = "Terraform Test"
+  }
+}
+
+resource "cloudflare_origin_ca_certificate" "example" {
+  csr                = tls_cert_request.example.cert_request_pem
+  hostnames          = [ "example.com" ]
+  request_type       = "origin-rsa"
+  requested_validity = 7
+}
+```
+
+## Argument Reference
+
+* `csr`  - (Required) The Certificate Signing Request. Must be newline-encoded.
+* `hostnames` - (Required) An array of hostnames or wildcard names bound to the certificate.
+* `request_type` - (Required) The signature type desired on the certificate.
+* `requested_validity` - (Required) The number of days for which the certificate should be valid.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The x509 serial number of the Origin CA certificate.
+* `certificate` - The Origin CA certificate
+* `expires_on` - The datetime when the certificate will expire.
+
+## Import
+
+Origin CA certificate resource can be imported using an ID, e.g.
+
+```
+$ terraform import cloudflare_origin_ca_certificate.example 276266538771611802607153687288146423901027769273
+```


### PR DESCRIPTION
Fixes #433
Depends on https://github.com/cloudflare/cloudflare-go/pull/387

Before the sdk pr is merged, this can only be tested via
```
go mod edit -replace github.com/cloudflare/cloudflare-go=/path/to/cloudflare-go
make build
make testacc TESTARGS='-run TestAccCloudflareOriginCACertificate_Basic'
```

I'm not terribly confident about the `api_user_service_key` - is there ever a case where it would be set to something other than the Origin CA key?  If so, I think we'd need a way to save both and have this resource's methods create a new client.