### PR TITLE
Support allowed modes for WAF Rules

### DIFF
--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -80,6 +80,13 @@ func dataSourceCloudflareWAFRules() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"allowed_modes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
 					},
 				},
 			},
@@ -139,13 +146,14 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 			}
 
 			ruleDetails = append(ruleDetails, map[string]interface{}{
-				"id":          rule.ID,
-				"description": rule.Description,
-				"priority":    rule.Priority,
-				"mode":        rule.Mode,
-				"group_id":    rule.Group.ID,
-				"group_name":  rule.Group.Name,
-				"package_id":  pkg.ID,
+				"id":            rule.ID,
+				"description":   rule.Description,
+				"priority":      rule.Priority,
+				"mode":          rule.Mode,
+				"group_id":      rule.Group.ID,
+				"group_name":    rule.Group.Name,
+				"package_id":    pkg.ID,
+				"allowed_modes": rule.AllowedModes,
 			})
 		}
 

--- a/cloudflare/import_cloudflare_waf_rule_test.go
+++ b/cloudflare/import_cloudflare_waf_rule_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccCloudflareWAFRule_Import(t *testing.T) {
 	t.Parallel()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-	ruleID := "100000"
+	ruleID := "100001"
 	name := generateRandomResourceName()
 
 	resource.Test(t, resource.TestCase{

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -111,9 +111,15 @@ func resourceCloudflareWAFRuleDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	// Find the default mode to be used
+	defaultMode := "default"
+	if !contains(rule.AllowedModes, defaultMode) {
+		defaultMode = "on"
+	}
+
 	// Can't delete WAF Rule so instead reset it to default
-	if rule.Mode != "default" {
-		_, err = client.UpdateWAFRule(zoneID, packageID, ruleID, "default")
+	if rule.Mode != defaultMode {
+		_, err = client.UpdateWAFRule(zoneID, packageID, ruleID, defaultMode)
 		if err != nil {
 			return err
 		}

--- a/website/docs/d/waf_rules.html.md
+++ b/website/docs/d/waf_rules.html.md
@@ -57,5 +57,6 @@ values must match in order to be included, see below for full list.
 - `group_id` - The ID of the WAF Rule Group that contains the WAF Rule
 - `group_name` - The Name of the WAF Rule Group that contains the WAF Rule
 - `package_id` - The ID of the WAF Rule Package that contains the WAF Rule
+- `allowed_modes` - The list of allowed `mode` values for the WAF Rule
 
 [1]: https://api.cloudflare.com/#waf-rule-groups-properties


### PR DESCRIPTION
This was causing an issue when using WAF Rules that did not use the
'default' mode but the on/off approach. This fixes that by switching
the default value to reset depending in the available values in the
`AllowedModes` field.

This also returns the `AllowedModes` when using the WAF rules data source, as the `allowed_modes` parameter in each item of the `rules` list, in order for users to know which modes can be used.