### PR TITLE
zone_settings_overrid: Remap 0rtt attribute name to zero_rtt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 **Improvements:**
 
 * `resource/cloudflare_zone_settings_override`: Add `non_identity` to allowed `decision` schema ([#541](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/541))
-* `resource/cloudflare_zone_settings_override`: Add support for `0rtt` and `http3` settings ([#542](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/542))
+* `resource/cloudflare_zone_settings_override`: Add support for `zero_rtt` and `http3` settings ([#542](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/542))
 * `resource/cloudflare_load_balancer_monitor`: Allow empty string for `expected_body` ([#539](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/539))
 * `resource/cloudflare_worker_script`: Add support for Worker KV Namespace Bindings ([#544](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/544))
 * `data_source/waf_rules`, `resource/cloudflare_waf_rule`, Support allowed modes for WAF Rules ([#550](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/550))

--- a/cloudflare/resource_cloudflare_zone_settings_override_test.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override_test.go
@@ -58,6 +58,8 @@ func TestAccCloudflareZoneSettingsOverride_Full(t *testing.T) {
 						name, "settings.0.security_level", "high"),
 					resource.TestCheckResourceAttr(
 						name, "settings.0.h2_prioritization", "on"),
+					resource.TestCheckResourceAttr(
+						name, "settings.0.zero_rtt", "off"),
 				),
 			},
 		},
@@ -230,6 +232,7 @@ resource "cloudflare_zone_settings_override" "test" {
 		security_header {
 			enabled = true
 		}
+		zero_rtt = "off"
 	}
 }`, zoneID)
 }

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -76,7 +76,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `waf` (default: `off`)
 * `webp` (default: `off`). Note that the value specified will be ignored unless `polish` is turned on (i.e. is "lossless" or "lossy")
 * `websockets` (default: `off`)
-* `0rtt` (default: `off`)
+* `zero_rtt` (default: `off`)
 
 ### String Values
 


### PR DESCRIPTION
`0rtt` is not a valid HCL attribute name (the scanner begins to process this as
a digit, not a string).  See [my comment in #542](https://github.com/terraform-providers/terraform-provider-cloudflare/pull/542/files#r356458215) for details.

Fixes: #555