### PR TITLE
Add ip6 as valid type for access rules

### DIFF
--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -46,7 +46,7 @@ func resourceCloudflareAccessRule() *schema.Resource {
 						"target": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"ip", "ip_range", "asn", "country"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"ip", "ip6", "ip_range", "asn", "country"}, false),
 						},
 						"value": {
 							Type:     schema.TypeString,

--- a/website/docs/r/access_rule.html.markdown
+++ b/website/docs/r/access_rule.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 The **configuration** block supports:
 
-* `target` - (Required) The request property to target. Allowed values: "ip", "ip_range", "asn", "country"
+* `target` - (Required) The request property to target. Allowed values: "ip", "ip6", "ip_range", "asn", "country"
 * `value` - (Required) The value to target. Depends on target's type.
 
 ## Attributes Reference


### PR DESCRIPTION
It's not yet in the API docs (Which I've raised with CF), a valid type option for Access Rules is `ip6` for IPv6 addresses.

Currently if you use type `ip` with an IPv6 address your rule is successfully created, however subsequent TF plans will try to change the resource:

```
-/+ resource "cloudflare_access_rule" "example" {
      ~ configuration = { # forces replacement
          ~ "target" = "ip6" -> "ip"
          ~ "value"  = "2604:a880:0800:00a1:0000:0000:171e:5001" -> "2604:a880:800:a1::171e:5001"
        }
      ~ id            = "e5860588ab3b4a598c86da69676017ad" -> (known after apply)
        mode          = "block"
        notes         = "Block"
        zone_id       = "123abc456def"
    }
```

If you require any tests let me know, wasn't sure if it was necessary for a change to the allowed inputs (Only one type is currently tested anyway)