### PR TITLE
update Spectrum application resource to use string enum for proxy_pro…

### DIFF
--- a/cloudflare/resource_cloudflare_spectrum_application.go
+++ b/cloudflare/resource_cloudflare_spectrum_application.go
@@ -101,9 +101,12 @@ func resourceCloudflareSpectrumApplication() *schema.Resource {
 			},
 
 			"proxy_protocol": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeString,
 				Optional: true,
-				Default:  false,
+				Default:  "off",
+				ValidateFunc: validation.StringInSlice([]string{
+					"off", "v1", "v2", "simple",
+				}, false),
 			},
 		},
 	}
@@ -292,7 +295,7 @@ func applicationFromResource(d *schema.ResourceData) cloudflare.SpectrumApplicat
 	}
 
 	if proxyProtocol, ok := d.GetOk("proxy_protocol"); ok {
-		application.ProxyProtocol = proxyProtocol.(bool)
+		application.ProxyProtocol = cloudflare.ProxyProtocol(proxyProtocol.(string))
 	}
 
 	return application

--- a/website/docs/r/spectrum_application.html.markdown
+++ b/website/docs/r/spectrum_application.html.markdown
@@ -39,7 +39,7 @@ resource "cloudflare_spectrum_application" "ssh_proxy" {
 * `origin_port` - (Optional) If using `origin_dns` this is a required attribute. Origin port to proxy traffice to e.g. `22`.
 * `tls` - (Optional) TLS configuration option for Cloudflare to connect to your origin. Valid values are: `off`, `flexible`, `full` and `strict`. Defaults to `off`.
 * `ip_firewall` - (Optional) Enables the IP Firewall for this application. Defaults to `true`.
-* `proxy_protocol` - (Optional) Enables Proxy Protocol v1 to the origin. Defaults to `false`.
+* `proxy_protocol` - (Optional) Enables a proxy protocol to the origin. Valid values are: `off`, `v1`, `v2`, and `simple`. Defaults to `off`.
 * `traffic_type` - (Optional) Set's application type. Valid values are: `direct`, `http`, `https`.  Defaults to `direct`.
 
 **dns**


### PR DESCRIPTION
…tocol field

Opening this PR against the renovate branch since this depends on the version bump in that branch. Once that's merged this can be retargeted to master if desired. This should fix the CI build for that PR as well.