### PR TITLE
Handle errors properly in Logpush resource

### DIFF
--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -49,9 +49,8 @@ func resourceCloudflareLogpushJob() *schema.Resource {
 
 func getJobFromResource(d *schema.ResourceData) cloudflare.LogpushJob {
 	id, err := strconv.Atoi(d.Id())
-
 	if err != nil {
-		fmt.Errorf("Could not extract Logpush job from resource - invalid identifier: %+v", id)
+		fmt.Errorf("could not extract Logpush job from resource - invalid identifier (%s): %v", d.Id(), err)
 	}
 
 	job := cloudflare.LogpushJob{
@@ -68,9 +67,11 @@ func getJobFromResource(d *schema.ResourceData) cloudflare.LogpushJob {
 func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	jobId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		fmt.Errorf("could not extract Logpush job from resource - invalid identifier (%s): %v", d.Id(), err)
+	}
 
 	job, err := client.LogpushJob(d.Get("zone_id").(string), jobId)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			log.Printf("[INFO] Could not find LogpushJob with id: %q", jobId)
@@ -100,11 +101,9 @@ func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Creating Cloudflare Logpush Job from struct: %+v", job)
 
 	j, err := client.CreateLogpushJob(d.Get("zone_id").(string), job)
-
 	if err != nil {
-		return fmt.Errorf("error creating logpush job")
+		return fmt.Errorf("error creating logpush job: %v", err)
 	}
-
 	if j.ID == 0 {
 		return fmt.Errorf("failed to find ID in Create response; resource was empty")
 	}
@@ -114,7 +113,6 @@ func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}
 	log.Printf("[INFO] Created Cloudflare Logpush Job ID: %s", d.Id())
 
 	return resourceCloudflareLogpushJobRead(d, meta)
-
 }
 
 func resourceCloudflareLogpushJobUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -145,5 +143,4 @@ func resourceCloudflareLogpushJobDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	return resourceCloudflareLogpushJobRead(d, meta)
-
 }


### PR DESCRIPTION
I was unable to create a Logpush resource in Cloudflare and error is not printed out. Here is example apply:

```
Error: error creating logpush job

  on cloudflare-log-push.tf line 34, in resource "cloudflare_logpush_job" "cloudflare_logpush":
  34: resource "cloudflare_logpush_job" "cloudflare_logpush" {
```

This is resource I'm trying to create:

```
// To generate ownership_challenge see: https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#ownership
resource "cloudflare_logpush_job" "cloudflare_logpush" {
  count               = var.cloudflare_logpush_challenge == "" ? 0 : 1
  zone_id             = var.cloudflare_zone_id_map[var.environment]
  name                = "Logpush Job for ${var.environment}"
  destination_conf    = "s3://${module.cloudflare_logpush_bucket.name}/{DATE}?region=${var.region}&sse=AES256"
  logpull_options     = "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339"
  ownership_challenge = var.cloudflare_logpush_challenge
}
```

I've noticed that `error creating logpush job` log line is swallowing original error, probably from Cloudflare API, so I've created this PR to fill the gaps. Also fixed some other error messages.