### PR TITLE
Add attributes reference for cloudflare_access_application

### DIFF
--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -33,6 +33,16 @@ The following arguments are supported:
   Cloudflare Access in front of. Can include subdomains or paths. Or both.
 * `session_duration` - (Optional) How often a user will be forced to
   re-authorise. Must be one of `30m`, `6h`, `12h`, `24h`, `168h`, `730h`.
+  
+## Attributes Reference
+
+The following additional attributes are exported:
+
+* `id` - ID of the application
+* `aud` - Application Audience (AUD) Tag of the application
+* `domain` - Domain of the application
+* `session_duration` - Session duriation of the application
+
 
 ## Import
 

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -41,7 +41,7 @@ The following additional attributes are exported:
 * `id` - ID of the application
 * `aud` - Application Audience (AUD) Tag of the application
 * `domain` - Domain of the application
-* `session_duration` - Session duriation of the application
+* `session_duration` - Length of session for the application before prompting for a sign in
 
 ## Import
 

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -43,7 +43,6 @@ The following additional attributes are exported:
 * `domain` - Domain of the application
 * `session_duration` - Session duriation of the application
 
-
 ## Import
 
 Access Applications can be imported using a composite ID formed of zone


### PR DESCRIPTION
Find myself difficult to cross-reference the attributes from the doc, until I find the attributes from source code.

ref. https://github.com/terraform-providers/terraform-provider-cloudflare/blob/master/cloudflare/resource_cloudflare_access_application.go