### PR TITLE
datasource/waf_rules: Update test to check presence instead of value

### DIFF
--- a/cloudflare/data_source_waf_rules_test.go
+++ b/cloudflare/data_source_waf_rules_test.go
@@ -24,7 +24,7 @@ func TestAccCloudflareWAFRules_NoFilter(t *testing.T) {
 				Config: testAccCloudflareWAFRulesConfig(zoneID, map[string]string{}, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareWAFRulesDataSourceID(name),
-					resource.TestCheckResourceAttr(name, "rules.#", "40"),
+					resource.TestCheckResourceAttrSet(name, "rules.#"),
 				),
 			},
 		},
@@ -45,7 +45,7 @@ func TestAccCloudflareWAFRules_MatchDescription(t *testing.T) {
 				Config: testAccCloudflareWAFRulesConfig(zoneID, map[string]string{"description": "^SLR: .*"}, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareWAFRulesDataSourceID(name),
-					resource.TestCheckResourceAttr(name, "rules.#", "20"),
+					resource.TestCheckResourceAttrSet(name, "rules.#"),
 				),
 			},
 		},


### PR DESCRIPTION
Due to the fragility (and specificity) of this test, it broke when the
upstream client fixed pagination for this resource. To assert we still
get a usable result, swap the test to just check the presence of the
expected attributes instead.

Fixes #589