### PR TITLE
test/firewall_rule: Add sweeper

### DIFF
--- a/cloudflare/resource_cloudflare_firewall_rule_test.go
+++ b/cloudflare/resource_cloudflare_firewall_rule_test.go
@@ -15,6 +15,14 @@ func init() {
 		Name: "cloudflare_firewall_rule",
 		F:    testSweepCloudflareFirewallRuleSweeper,
 	})
+
+	// Defined in the filter test but referenced here as the firewall uses
+	// filters for the expressions and need to be cleaned out with the
+	// firewall_rule resources.
+	resource.AddTestSweepers("cloudflare_filter", &resource.Sweeper{
+		Name: "cloudflare_filter",
+		F:    testSweepCloudflareFilterSweeper,
+	})
 }
 
 func testSweepCloudflareFirewallRuleSweeper(r string) error {

--- a/cloudflare/resource_cloudflare_firewall_rule_test.go
+++ b/cloudflare/resource_cloudflare_firewall_rule_test.go
@@ -15,14 +15,6 @@ func init() {
 		Name: "cloudflare_firewall_rule",
 		F:    testSweepCloudflareFirewallRuleSweeper,
 	})
-
-	// Defined in the filter test but referenced here as the firewall uses
-	// filters for the expressions and need to be cleaned out with the
-	// firewall_rule resources.
-	resource.AddTestSweepers("cloudflare_filter", &resource.Sweeper{
-		Name: "cloudflare_filter",
-		F:    testSweepCloudflareFilterSweeper,
-	})
 }
 
 func testSweepCloudflareFirewallRuleSweeper(r string) error {

--- a/cloudflare/resource_cloudflare_firewall_rule_test.go
+++ b/cloudflare/resource_cloudflare_firewall_rule_test.go
@@ -2,11 +2,44 @@ package cloudflare
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
+	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
+
+func init() {
+	resource.AddTestSweepers("cloudflare_firewall_rule", &resource.Sweeper{
+		Name: "cloudflare_firewall_rule",
+		F:    testSweepCloudflareFirewallRuleSweeper,
+	})
+}
+
+func testSweepCloudflareFirewallRuleSweeper(r string) error {
+	client, clientErr := sharedClient()
+	if clientErr != nil {
+		log.Printf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
+	}
+
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rules, rulesErr := client.FirewallRules(zoneID, cloudflare.PaginationOptions{})
+
+	if rulesErr != nil {
+		log.Printf("[ERROR] Failed to fetch Cloudflare firewall rules: %s", rulesErr)
+	}
+
+	for _, rule := range rules {
+		err := client.DeleteFirewallRule(zoneID, rule.ID)
+
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete Cloudflare firewall rule (%s) in zone ID: %s", rule.ID, zoneID)
+		}
+	}
+
+	return nil
+}
 
 func TestAccFirewallRuleSimple(t *testing.T) {
 	rnd := generateRandomResourceName()


### PR DESCRIPTION
We've had some failing tests due to firewall rules being left over
following CI runs. This introduces a sweeper to clean up before test
runs to have a clean starting point.