### PR TITLE
Add worker kv

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -123,6 +123,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_waf_rule":               resourceCloudflareWAFRule(),
 			"cloudflare_worker_route":           resourceCloudflareWorkerRoute(),
 			"cloudflare_worker_script":          resourceCloudflareWorkerScript(),
+			"cloudflare_workers_kv":             resourceCloudflareWorkerKV(),
 			"cloudflare_workers_kv_namespace":   resourceCloudflareWorkersKVNamespace(),
 			"cloudflare_zone_lockdown":          resourceCloudflareZoneLockdown(),
 			"cloudflare_zone_settings_override": resourceCloudflareZoneSettingsOverride(),

--- a/cloudflare/resource_cloudflare_worker_kv.go
+++ b/cloudflare/resource_cloudflare_worker_kv.go
@@ -1,0 +1,127 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudflareWorkerKV() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareWorkersKVCreate,
+		Read:   resourceCloudflareWorkersKVRead,
+		Update: resourceCloudflareWorkersKVUpdate,
+		Delete: resourceCloudflareWorkersKVDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareWorkersKVImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"namespace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceCloudflareWorkersKVRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	namespaceID, key := parseId(d)
+
+	value, err := client.ReadWorkersKV(context.Background(), namespaceID, key)
+	if err != nil {
+		return errors.Wrap(err, "error reading workers kv")
+	}
+
+	if value == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("value", string(value))
+	return nil
+}
+
+func resourceCloudflareWorkersKVCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	namespaceID := d.Get("namespace_id").(string)
+	key := d.Get("key").(string)
+	value := d.Get("value").(string)
+
+	_, err := client.WriteWorkersKV(context.Background(), namespaceID, key, []byte(value))
+	if err != nil {
+		if err != nil {
+			return errors.Wrap(err, "error creating workers kv")
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%s_%s", namespaceID, key))
+
+	log.Printf("[INFO] Cloudflare Workers KV Namespace ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceCloudflareWorkersKVUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	namespaceID := d.Get("namespace_id").(string)
+	key := d.Get("key").(string)
+	value := d.Get("value").(string)
+
+	_, err := client.WriteWorkersKV(context.Background(), namespaceID, key, []byte(value))
+	if err != nil {
+		if err != nil {
+			return errors.Wrap(err, "error creating workers kv")
+		}
+	}
+
+	return nil
+}
+
+func resourceCloudflareWorkersKVDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	namespaceID, key := parseId(d)
+
+	log.Printf("[INFO] Deleting Cloudflare Workers KV with id: %+v", d.Id())
+
+	_, err := client.DeleteWorkersKV(context.Background(), namespaceID, key)
+	if err != nil {
+		return errors.Wrap(err, "error deleting workers kv")
+	}
+
+	return nil
+}
+
+func resourceCloudflareWorkersKVImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*cloudflare.API)
+	namespaceID, key := parseId(d)
+	value, err := client.ReadWorkersKV(context.Background(), namespaceID, key)
+
+	if err != nil {
+		return nil, fmt.Errorf("error finding workers kv namespace %q: %s", d.Id(), err)
+	}
+
+	d.Set("value", string(value))
+	d.SetId(d.Id())
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func parseId(d *schema.ResourceData) (string, string) {
+	parts := strings.SplitN(d.Id(), "_", 2)
+	return parts[0], parts[1]
+}

--- a/cloudflare/resource_cloudflare_worker_kv.go
+++ b/cloudflare/resource_cloudflare_worker_kv.go
@@ -40,7 +40,7 @@ func resourceCloudflareWorkerKV() *schema.Resource {
 
 func resourceCloudflareWorkersKVRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	namespaceID, key := parseId(d)
+	namespaceID, key := parseId(d.Id())
 
 	value, err := client.ReadWorkersKV(context.Background(), namespaceID, key)
 	if err != nil {
@@ -64,9 +64,7 @@ func resourceCloudflareWorkersKVCreate(d *schema.ResourceData, meta interface{})
 
 	_, err := client.WriteWorkersKV(context.Background(), namespaceID, key, []byte(value))
 	if err != nil {
-		if err != nil {
-			return errors.Wrap(err, "error creating workers kv")
-		}
+		return errors.Wrap(err, "error creating workers kv")
 	}
 
 	d.SetId(fmt.Sprintf("%s_%s", namespaceID, key))
@@ -89,12 +87,12 @@ func resourceCloudflareWorkersKVUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	return nil
+	return resourceCloudflareWorkersKVRead(d, meta)
 }
 
 func resourceCloudflareWorkersKVDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	namespaceID, key := parseId(d)
+	namespaceID, key := parseId(d.Id())
 
 	log.Printf("[INFO] Deleting Cloudflare Workers KV with id: %+v", d.Id())
 
@@ -108,7 +106,7 @@ func resourceCloudflareWorkersKVDelete(d *schema.ResourceData, meta interface{})
 
 func resourceCloudflareWorkersKVImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
-	namespaceID, key := parseId(d)
+	namespaceID, key := parseId(d.Id())
 	value, err := client.ReadWorkersKV(context.Background(), namespaceID, key)
 
 	if err != nil {
@@ -121,7 +119,7 @@ func resourceCloudflareWorkersKVImport(d *schema.ResourceData, meta interface{})
 	return []*schema.ResourceData{d}, nil
 }
 
-func parseId(d *schema.ResourceData) (string, string) {
-	parts := strings.SplitN(d.Id(), "_", 2)
+func parseId(id string) (string, string) {
+	parts := strings.SplitN(id, "_", 2)
 	return parts[0], parts[1]
 }

--- a/cloudflare/resource_cloudflare_worker_kv.go
+++ b/cloudflare/resource_cloudflare_worker_kv.go
@@ -13,7 +13,7 @@ import (
 
 func resourceCloudflareWorkerKV() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudflareWorkersKVCreate,
+		Create: resourceCloudflareWorkersKVUpdate,
 		Read:   resourceCloudflareWorkersKVRead,
 		Update: resourceCloudflareWorkersKVUpdate,
 		Delete: resourceCloudflareWorkersKVDelete,
@@ -57,7 +57,7 @@ func resourceCloudflareWorkersKVRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceCloudflareWorkersKVCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkersKVUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	namespaceID := d.Get("namespace_id").(string)
 	key := d.Get("key").(string)
@@ -71,20 +71,6 @@ func resourceCloudflareWorkersKVCreate(d *schema.ResourceData, meta interface{})
 	d.SetId(fmt.Sprintf("%s/%s", namespaceID, key))
 
 	log.Printf("[INFO] Cloudflare Workers KV Namespace ID: %s", d.Id())
-
-	return resourceCloudflareWorkersKVRead(d, meta)
-}
-
-func resourceCloudflareWorkersKVUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*cloudflare.API)
-	namespaceID := d.Get("namespace_id").(string)
-	key := d.Get("key").(string)
-	value := d.Get("value").(string)
-
-	_, err := client.WriteWorkersKV(context.Background(), namespaceID, key, []byte(value))
-	if err != nil {
-		return errors.Wrap(err, "error creating workers kv")
-	}
 
 	return resourceCloudflareWorkersKVRead(d, meta)
 }

--- a/cloudflare/resource_cloudflare_worker_kv_test.go
+++ b/cloudflare/resource_cloudflare_worker_kv_test.go
@@ -1,0 +1,83 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCloudflareWorkersKV_Basic(t *testing.T) {
+	t.Parallel()
+	var kvPair cloudflare.WorkersKVPair
+	namespaceID := generateRandomResourceName()
+	key := generateRandomResourceName()
+	id := fmt.Sprintf("%s_%s", namespaceID, key)
+	resourceName := "cloudflare_workers_kv." + id
+	value := generateRandomResourceName()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCloudflareWorkersKVDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareWorkersKV(resourceName, namespaceID, key, value),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareWorkersKVExists(namespaceID, key, &kvPair),
+					resource.TestCheckResourceAttr(
+						resourceName, "value", value,
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareWorkersKVDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_workers_kv" {
+			continue
+		}
+
+		namespaceID := rs.Primary.Attributes["namespace_id"]
+		key := rs.Primary.Attributes["key"]
+
+		_, err := client.ReadWorkersKV(context.Background(), namespaceID, key)
+
+		if err == nil {
+			return fmt.Errorf("workers kv pair still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudflareWorkersKV(rName string, namespaceID string, key string, value string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_workers_kv" "%[1]s" {
+	namespace_id = "%[2]s
+	key = "%[3]s"
+	value = "%[4]s"
+}`, rName, namespaceID, key, value)
+}
+
+func testAccCheckCloudflareWorkersKVExists(namespaceID string, key string, kv *cloudflare.WorkersKVPair) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*cloudflare.API)
+		value, err := client.ReadWorkersKV(context.Background(), namespaceID, key)
+		if err != nil {
+			return err
+		}
+
+		if value == nil {
+			return fmt.Errorf("workers kv key %s not found in namespace %s", key, namespaceID)
+		}
+
+		return nil
+	}
+}

--- a/cloudflare/resource_cloudflare_worker_kv_test.go
+++ b/cloudflare/resource_cloudflare_worker_kv_test.go
@@ -19,7 +19,7 @@ func TestAccCloudflareWorkersKV_Basic(t *testing.T) {
 	resourceName := "cloudflare_workers_kv." + name
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckAccount(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCloudflareWorkersKVDestroy,
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func testAccCloudflareWorkersKVDestroy(s *terraform.State) error {
 func testAccCheckCloudflareWorkersKV(rName string, key string, value string) string {
 	return testAccCheckCloudflareWorkersKVNamespace(rName) + fmt.Sprintf(`
 resource "cloudflare_workers_kv" "%[1]s" {
-	namespace_id = "${cloudflare_workers_kv_namespace.%[1]s.id}"
+	namespace_id = cloudflare_workers_kv_namespace.%[1]s.id
 	key = "%[2]s"
 	value = "%[3]s"
 }`, rName, key, value)

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -118,6 +118,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-worker-script") %>>
               <a href="/docs/providers/cloudflare/r/worker_script.html">cloudflare_worker_script</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-workers-kv") %>>
+              <a href="/docs/providers/cloudflare/r/workers_kv.html">cloudflare_workers_kv</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-workers-kv-namespace") %>>
               <a href="/docs/providers/cloudflare/r/workers_kv_namespace.html">cloudflare_workers_kv_namespace</a>
             </li>

--- a/website/docs/r/workers_kv.html.markdown
+++ b/website/docs/r/workers_kv.html.markdown
@@ -28,7 +28,7 @@ resource "cloudflare_workers_kv" "example" {
 
 The following arguments are supported:
 
-* `namespace_id` - (Required) The id of the namespace in which you want to create the KV pair
+* `namespace_id` - (Required) The ID of the Workers KV namespace in which you want to create the KV pair
 * `key` - (Required) The key name
 * `value` - (Required) The string value to be stored in the key
 

--- a/website/docs/r/workers_kv.html.markdown
+++ b/website/docs/r/workers_kv.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_workers_kv"
+sidebar_current: "docs-cloudflare-resource-workers-kv"
+description: |-
+  Provides the ability to manage Cloudflare Workers KV features.
+---
+
+# cloudflare_workers_kv
+
+Provides a Workers KV Pair
+
+## Example Usage
+
+```hcl
+resource "cloudflare_workers_kv_namespace" "example_ns" {
+  title = "test-namespace"
+}
+
+resource "cloudflare_workers_kv" "example" {
+  namespace_id = cloudflare_workers_kv_namespace.example_ns.id
+  key = "test-key"
+  value = "test value"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace_id` - (Required) The id of the namespace in which you want to create the KV pair
+* `key` - (Required) The key name
+* `value` - (Required) The string value to be stored in the key
+
+
+## Import
+
+Workers KV Namespace settings can be imported using it's ID.  **Note:** Because the same key can exist in multiple namespaces, the ID is a composite key of the format <namespace_id>_<key>.
+
+```
+$ terraform import cloudflare_workers_kv_namespace.example beaeb6716c9443eaa4deef11763ccca6_test-key
+```
+
+where:
+- `beaeb6716c9443eaa4deef11763ccca6` is the ID of the namespace and `test-key` is the key

--- a/website/docs/r/workers_kv.html.markdown
+++ b/website/docs/r/workers_kv.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # cloudflare_workers_kv
 
-Provides a Workers KV Pair
+Provides a Workers KV Pair.  *NOTE:*  This resource uses the Cloudflare account APIs.  This requires setting the `CLOUDFLARE_ACCOUNT_ID` environment variable or `account_id` provider argument.
 
 ## Example Usage
 


### PR DESCRIPTION
Support Workers KV Pairs.  This should resolve [#565](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/565)

Proposed resource syntax:
`resource "cloudflare_workers_kv" "example_kv" {
  namespace_id = cloudflare_workers_kv_namespace.example_ns.id
  key = "test-key"
  value = "some value"
}`