### PR TITLE
document `cache_level` settings with their meaning

### DIFF
--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -80,7 +80,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 
 ### String Values
 
-* `cache_level`. Allowed values: "aggressive" (default) - Standard use query string, "basic" - no query string, "simplified" - ignore query string.
+* `cache_level`. Allowed values: "aggressive" (default) - delivers a different resource each time the query string changes, "basic" - delivers resources from cache when there is no query string, "simplified" - delivers the same resource to everyone independent of the query string.
 * `cname_flattening`. Allowed values: "flatten_at_root" (default), "flatten_all", "flatten_none".
 * `h2_prioritization`. Allowed values: "on", "off" (default), "custom".
 * `min_tls_version`. Allowed values: "1.0" (default), "1.1", "1.2", "1.3".

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -80,7 +80,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 
 ### String Values
 
-* `cache_level`. Allowed values: "aggressive" (default), "basic", "simplified".
+* `cache_level`. Allowed values: "aggressive" (default) - Standard use query string, "basic" - no query string, "simplified" - ignore query string.
 * `cname_flattening`. Allowed values: "flatten_at_root" (default), "flatten_all", "flatten_none".
 * `h2_prioritization`. Allowed values: "on", "off" (default), "custom".
 * `min_tls_version`. Allowed values: "1.0" (default), "1.1", "1.2", "1.3".


### PR DESCRIPTION
Sadly the Cloudflare WebUI and documentation (e.g. in
https://support.cloudflare.com/hc/en-us/articles/200168256) uses
different terminoly, compared to the settings on the API level.
To spare everyone the confusion and task to look up what is what,
add the short description to the documentation here.