### PR TITLE
resources: WAF: handles properly when the target has been deleted on Cloudflare's side

### DIFF
--- a/cloudflare/resource_cloudflare_waf_group.go
+++ b/cloudflare/resource_cloudflare_waf_group.go
@@ -59,7 +59,14 @@ func resourceCloudflareWAFGroupRead(d *schema.ResourceData, meta interface{}) er
 
 	group, err := client.WAFGroup(zoneID, packageID, groupID)
 	if err != nil {
-		return (err)
+		// 1002 is the 'Invalid or missing WAF Package ID' error
+		// 1003 is the 'Invalid or missing WAF Rule Set ID' error
+		if cloudflareErrorIsOneOfCodes(err, []int{1002, 1003}) {
+			d.SetId("")
+			return nil
+		}
+
+		return err
 	}
 
 	// Only need to set mode as that is the only attribute that could have changed

--- a/cloudflare/resource_cloudflare_waf_package.go
+++ b/cloudflare/resource_cloudflare_waf_package.go
@@ -59,7 +59,13 @@ func resourceCloudflareWAFPackageRead(d *schema.ResourceData, meta interface{}) 
 
 	pkg, err := client.WAFPackage(zoneID, packageID)
 	if err != nil {
-		return (err)
+		// 1002 is the 'Invalid or missing WAF Package ID' error
+		if cloudflareErrorIsCode(err, 1002) {
+			d.SetId("")
+			return nil
+		}
+
+		return err
 	}
 
 	d.Set("sensitivity", pkg.Sensitivity)

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -59,7 +59,14 @@ func resourceCloudflareWAFRuleRead(d *schema.ResourceData, meta interface{}) err
 
 	rule, err := client.WAFRule(zoneID, packageID, ruleID)
 	if err != nil {
-		return (err)
+		// 1002 is the 'Invalid or missing WAF Package ID' error
+		// 1004 is the 'Invalid or missing WAF Rule ID' error
+		if cloudflareErrorIsOneOfCodes(err, []int{1002, 1004}) {
+			d.SetId("")
+			return nil
+		}
+
+		return err
 	}
 
 	// Only need to set mode as that is the only attribute that could have changed

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+const CLOUDFLARE_INVALID_OR_REMOVED_WAF_RULE_ID_ERROR = 1004
+
 func resourceCloudflareWAFRule() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudflareWAFRuleCreate,
@@ -50,6 +52,13 @@ func resourceCloudflareWAFRule() *schema.Resource {
 	}
 }
 
+func errorIsWAFRuleNotFound(err error) bool {
+	return cloudflareErrorIsOneOfCodes(err, []int{
+		CLOUDFLARE_INVALID_OR_REMOVED_WAF_PACKAGE_ID_ERROR,
+		CLOUDFLARE_INVALID_OR_REMOVED_WAF_RULE_ID_ERROR,
+	})
+}
+
 func resourceCloudflareWAFRuleRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
@@ -59,9 +68,7 @@ func resourceCloudflareWAFRuleRead(d *schema.ResourceData, meta interface{}) err
 
 	rule, err := client.WAFRule(zoneID, packageID, ruleID)
 	if err != nil {
-		// 1002 is the 'Invalid or missing WAF Package ID' error
-		// 1004 is the 'Invalid or missing WAF Rule ID' error
-		if cloudflareErrorIsOneOfCodes(err, []int{1002, 1004}) {
+		if errorIsWAFRuleNotFound(err) {
 			d.SetId("")
 			return nil
 		}

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -2,9 +2,14 @@ package cloudflare
 
 import (
 	"crypto/md5"
+	"encoding/json"
 	"fmt"
+	"log"
+	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	errors "github.com/pkg/errors"
 )
 
 func expandInterfaceToStringList(list interface{}) []string {
@@ -61,4 +66,45 @@ func contains(slice []string, item string) bool {
 
 	_, ok := set[item]
 	return ok
+}
+
+type CloudflareAPIError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type CloudflareAPIErrorResponse struct {
+	Errors []CloudflareAPIError `json:"errors"`
+}
+
+func cloudflareErrorIsCode(err error, code int) bool {
+	return cloudflareErrorIsOneOfCodes(err, []int{code})
+}
+
+func cloudflareErrorIsOneOfCodes(err error, codes []int) bool {
+	errorMsg := errors.Cause(err).Error()
+
+	// We will parse the error message only if it's an error 400, in which
+	// case we need to verify the kind of error.
+	r := regexp.MustCompile(`^HTTP status 400: content "(.*)"$`)
+	submatchs := r.FindStringSubmatch(errorMsg)
+	if submatchs != nil {
+		jsonData := strings.Replace(submatchs[1], "\\\"", "\"", -1)
+		log.Printf("[DEBUG][cloudflareErrorIsCode] error matching status 400, content: %#v", jsonData)
+
+		var cfer CloudflareAPIErrorResponse
+		unmarshalErr := json.Unmarshal([]byte(jsonData), &cfer)
+
+		// We check that there is only one error and that its code
+		// matches what we expected
+		if unmarshalErr == nil && len(cfer.Errors) == 1 {
+			for _, code := range codes {
+				if cfer.Errors[0].Code == code {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -77,10 +77,6 @@ type CloudflareAPIErrorResponse struct {
 	Errors []CloudflareAPIError `json:"errors"`
 }
 
-func cloudflareErrorIsCode(err error, code int) bool {
-	return cloudflareErrorIsOneOfCodes(err, []int{code})
-}
-
 func cloudflareErrorIsOneOfCodes(err error, codes []int) bool {
 	errorMsg := errors.Cause(err).Error()
 


### PR DESCRIPTION
In the previous situation, when the target had been deleted, the Read
accion would fail and return an error. However, this would be expected
that when this happen, the object should be considered as not existing
anymore and the process should continue.  This thus fixes that and makes
sure that we avoid erroring out when a WAF Rule, Group or Package has
been deleted on Cloudflare's side.