### PR TITLE
Add support for Access Groups in policies

### DIFF
--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -97,6 +97,13 @@ var policyOptionElement = &schema.Resource{
 			Type:     schema.TypeBool,
 			Optional: true,
 		},
+		"group": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"everyone": {
 			Type:     schema.TypeBool,
 			Optional: true,
@@ -279,6 +286,10 @@ func buildAccessPolicyCondition(options map[string]interface{}) []interface{} {
 				case "service_token":
 					policy = append(policy, cloudflare.AccessPolicyServiceToken{ServiceToken: struct {
 						ID string `json:"token_id"`
+					}{ID: value.(string)}})
+				case "group":
+					policy = append(policy, cloudflare.AccessPolicyAccessGroup{Group: struct {
+						ID string `json:"id"`
 					}{ID: value.(string)}})
 				}
 			}

--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -81,6 +81,8 @@ conditions which can be applied. The conditions are:
   `service_token = cloudflare_access_service_token.demo.id`
 * `any_valid_service_token` - (Optional) Boolean indicating if allow
   all tokens to be granted. Example: `any_valid_service_token = true`
+* `group` - (Optional) A list of access group ids. Example:
+  `group = [cloudflare_access_group.demo.id]`
 * `everyone` - (Optional) Boolean indicating permitting access for all
   requests. Example: `everyone = true`
 


### PR DESCRIPTION
This feature is supported in Cloudflare Go: https://github.com/cloudflare/cloudflare-go/blob/master/access_policy.go#L82

So adding here.