### PR TITLE
Use the correct method for fetching all provider

### DIFF
--- a/cloudflare/resource_cloudflare_access_identity_provider_test.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider_test.go
@@ -23,7 +23,7 @@ func testSweepCloudflareAccessIdentityProviders(r string) error {
 		log.Printf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
 	}
 
-	accessIDPs, accessIDPsErr := client.ListZones()
+	accessIDPs, accessIDPsErr := client.AccessIdentityProviders(accountID)
 	if accessIDPsErr != nil {
 		log.Printf("[ERROR] Failed to fetch Access Identity Providers: %s", accessIDPsErr)
 	}


### PR DESCRIPTION
Updates the sweeper to pull all identity providers, not zones :facepalm:

Ensures we are cleaning up extra resources when they aren't used.