### PR TITLE
Fix firewall rule products support which was missing handling

### DIFF
--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -52,7 +52,8 @@ func resourceCloudflareFirewallRule() *schema.Resource {
 			"products": {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"zoneLockdown", "uaBlock", "bic", "hot", "securityLevel", "rateLimit", "waf"}, false),
 				},
 				Optional: true,
 			},
@@ -88,6 +89,10 @@ func resourceCloudflareFirewallRuleCreate(d *schema.ResourceData, meta interface
 		newFirewallRule.Filter = cloudflare.Filter{
 			ID: filterID.(string),
 		}
+	}
+
+	if products, ok := d.GetOk("products"); ok {
+		newFirewallRule.Products = expandInterfaceToStringList(products.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] Creating Cloudflare Firewall Rule from struct: %+v", newFirewallRule)
@@ -131,11 +136,13 @@ func resourceCloudflareFirewallRuleRead(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] Cloudflare Firewall Rule read configuration: %#v", firewallRule)
 
+	products := expandStringListToSet(firewallRule.Products)
 	d.Set("paused", firewallRule.Paused)
 	d.Set("description", firewallRule.Description)
 	d.Set("action", firewallRule.Action)
 	d.Set("priority", firewallRule.Priority)
 	d.Set("filter_id", firewallRule.Filter.ID)
+	d.Set("products", products)
 
 	return nil
 }
@@ -167,6 +174,10 @@ func resourceCloudflareFirewallRuleUpdate(d *schema.ResourceData, meta interface
 		newFirewallRule.Filter = cloudflare.Filter{
 			ID: filterID.(string),
 		}
+	}
+
+	if products, ok := d.GetOk("products"); ok {
+		newFirewallRule.Products = expandInterfaceToStringList(products.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] Updating Cloudflare Firewall Rule from struct: %+v", newFirewallRule)

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -21,6 +21,14 @@ func expandInterfaceToStringList(list interface{}) []string {
 	return vs
 }
 
+func expandStringListToSet(list []string) *schema.Set {
+	values := schema.NewSet(schema.HashString, []interface{}{})
+	for _, h := range list {
+		values.Add(h)
+	}
+	return values
+}
+
 func flattenStringList(list []string) []interface{} {
 	vs := make([]interface{}, 0, len(list))
 	for _, v := range list {


### PR DESCRIPTION
Resource `cloudflare_firewall_rule` contained action `bypass` and field `products`, however there was no handling implemented what was resulting in error:
```
products must be specified for the 'bypass' action
```