### PR TITLE
Add 'open' option for image_resizing setting

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -471,7 +471,7 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 
 	"image_resizing": {
 		Type:         schema.TypeString,
-		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+		ValidateFunc: validation.StringInSlice([]string{"on", "off", "open"}, false),
 		Optional:     true,
 		Computed:     true,
 	},

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -58,7 +58,6 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `hotlink_protection` (default: `off`)
 * `http2` (default: `off`)
 * `http3` (default: `off`)
-* `image_resizing` (default: `off`)
 * `ip_geolocation` (default: `on`)
 * `ipv6` (default: `off`)
 * `mirage` (default: `off`)
@@ -83,6 +82,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 * `cache_level`. Allowed values: "aggressive" (default) - delivers a different resource each time the query string changes, "basic" - delivers resources from cache when there is no query string, "simplified" - delivers the same resource to everyone independent of the query string.
 * `cname_flattening`. Allowed values: "flatten_at_root" (default), "flatten_all", "flatten_none".
 * `h2_prioritization`. Allowed values: "on", "off" (default), "custom".
+* `image_resizing`. Allowed values: "on", "off" (default), "open".
 * `min_tls_version`. Allowed values: "1.0" (default), "1.1", "1.2", "1.3".
 * `polish`. Allowed values: "off" (default), "lossless", "lossy".
 * `pseudo_ipv4`. Allowed values: "off" (default), "add_header", "overwrite_header".


### PR DESCRIPTION
The Cloudflare `image_resizing` setting accepts three values: `no`, `yes` and `open`:

https://api.cloudflare.com/#zone-settings-change-image-resizing-setting

Currently, only `no` and `yes` are supported. This commit adds `open` as an allowed value.