### PR TITLE
access_group: Consolidate access conditions schema

### DIFF
--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -32,25 +32,25 @@ func resourceCloudflareAccessGroup() *schema.Resource {
 			"require": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     groupOptionElement,
+				Elem:     AccessGroupOptionSchemaElement,
 			},
 			"exclude": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     groupOptionElement,
+				Elem:     AccessGroupOptionSchemaElement,
 			},
 			"include": {
 				Type:     schema.TypeList,
 				Required: true,
-				Elem:     groupOptionElement,
+				Elem:     AccessGroupOptionSchemaElement,
 			},
 		},
 	}
 }
 
-// groupOptionElement is used by `require`, `exclude` and `include`
+// AccessGroupOptionSchemaElement is used by `require`, `exclude` and `include`
 // attributes to build out the expected access conditions.
-var groupOptionElement = &schema.Resource{
+var AccessGroupOptionSchemaElement = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"email": {
 			Type:     schema.TypeList,
@@ -73,7 +73,14 @@ var groupOptionElement = &schema.Resource{
 				Type: schema.TypeString,
 			},
 		},
-		"everyone": {
+		"service_token": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"any_valid_service_token": {
 			Type:     schema.TypeBool,
 			Optional: true,
 		},
@@ -82,6 +89,102 @@ var groupOptionElement = &schema.Resource{
 			Optional: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
+			},
+		},
+		"everyone": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"certificate": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"common_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"gsuite": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"email": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"identity_provider_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"github": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"identity_provider_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"azure": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"identity_provider_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"okta": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"identity_provider_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"saml": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"attribute_name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"attribute_value": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"identity_provider_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
 			},
 		},
 	},

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -45,162 +45,20 @@ func resourceCloudflareAccessPolicy() *schema.Resource {
 			"require": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     policyOptionElement,
+				Elem:     AccessGroupOptionSchemaElement,
 			},
 			"exclude": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     policyOptionElement,
+				Elem:     AccessGroupOptionSchemaElement,
 			},
 			"include": {
 				Type:     schema.TypeList,
 				Required: true,
-				Elem:     policyOptionElement,
+				Elem:     AccessGroupOptionSchemaElement,
 			},
 		},
 	}
-}
-
-// policyOptionElement is used by `require`, `exclude` and `include`
-// attributes to build out the expected access conditions.
-var policyOptionElement = &schema.Resource{
-	Schema: map[string]*schema.Schema{
-		"email": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
-		"email_domain": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
-		"ip": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
-		"service_token": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
-		"any_valid_service_token": {
-			Type:     schema.TypeBool,
-			Optional: true,
-		},
-		"group": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
-		"everyone": {
-			Type:     schema.TypeBool,
-			Optional: true,
-		},
-		"certificate": {
-			Type:     schema.TypeBool,
-			Optional: true,
-		},
-		"common_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"gsuite": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"email": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"identity_provider_id": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"github": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"identity_provider_id": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"azure": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"id": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"identity_provider_id": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"okta": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"identity_provider_id": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"saml": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"attribute_name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"attribute_value": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"identity_provider_id": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-	},
 }
 
 func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Updates the schema conditions used in the
`include`/`require`/`exclude` to use a shared schema definition for
Access Groups and Access Policies as they can be used in a similar
way.

Closes #644