### PR TITLE
resource/logpush_job: Add support for "dataset" parameter

### DIFF
--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceCloudflareLogpushJob() *schema.Resource {
@@ -33,6 +34,11 @@ func resourceCloudflareLogpushJob() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"dataset": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"http_requests", "spectrum_events"}, false),
 			},
 			"logpull_options": {
 				Type:     schema.TypeString,
@@ -60,6 +66,7 @@ func getJobFromResource(d *schema.ResourceData) cloudflare.LogpushJob {
 		ID:                 id,
 		Enabled:            d.Get("enabled").(bool),
 		Name:               d.Get("name").(string),
+		Dataset:            d.Get("dataset").(string),
 		LogpullOptions:     d.Get("logpull_options").(string),
 		DestinationConf:    d.Get("destination_conf").(string),
 		OwnershipChallenge: d.Get("ownership_challenge").(string),

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -37,7 +37,7 @@ func resourceCloudflareLogpushJob() *schema.Resource {
 			},
 			"dataset": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"http_requests", "spectrum_events"}, false),
 			},
 			"logpull_options": {

--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -20,6 +20,7 @@ resource "cloudflare_logpush_job" "example_job" {
   logpull_options = "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339"
   destination_conf = "s3://my-bucket-path?region=us-west-2"
   ownership_challenge = "00000000000000000"
+  dataset = "http_requests"
 }
 ```
 
@@ -32,8 +33,6 @@ The following arguments are supported:
 * `zone_id` - (Required) The zone ID where the logpush job should be created.
 * `destination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#destination).
 * `ownership_challenge` - (Required) Ownership challenge token to prove destination ownership. See [Developer documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage).
-
-- - -
-
+* `dataset` - (Optional) Which type of dataset resource to use. Available values are `"http_requests"` or `"spectrum_events"`.
 * `logpull_options` - (Optional) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpull options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).
 * `enable` - (Optional) Whether to enable to job to create or not.

--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -33,6 +33,6 @@ The following arguments are supported:
 * `zone_id` - (Required) The zone ID where the logpush job should be created.
 * `destination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#destination).
 * `ownership_challenge` - (Required) Ownership challenge token to prove destination ownership. See [Developer documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage).
-* `dataset` - (Optional) Which type of dataset resource to use. Available values are `"http_requests"` or `"spectrum_events"`.
+* `dataset` - (Required) Which type of dataset resource to use. Available values are `"http_requests"` or `"spectrum_events"`.
 * `logpull_options` - (Optional) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpull options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).
 * `enable` - (Optional) Whether to enable to job to create or not.


### PR DESCRIPTION
Updates the `logpush_job` resource to support the "dataset" parameter
which allows different configurations for different types of data.

See https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/

Closes #641