### PR TITLE
resource/zone_settings_override: Remove `edge_cache_ttl`

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -456,12 +456,6 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 		Computed: true,
 	},
 
-	"edge_cache_ttl": {
-		Type:     schema.TypeInt,
-		Optional: true,
-		Computed: true,
-	},
-
 	"h2_prioritization": {
 		Type:         schema.TypeString,
 		ValidateFunc: validation.StringInSlice([]string{"on", "off", "custom"}, false),

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -94,7 +94,6 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 
 * `browser_cache_ttl` (default: `14400`)
 * `challenge_ttl` (default: `1800`)
-* `edge_cache_ttl` (default: `7200`)
 * `max_upload` (default: `100`)
 
 ### Nested Objects


### PR DESCRIPTION
It doesn't do anything and shouldn't be in the Terraform provider. 

Closes #653