### PR TITLE
Fix cloudflare_access_group.service_token example to mention a list of ids

### DIFF
--- a/website/docs/r/access_group.html.markdown
+++ b/website/docs/r/access_group.html.markdown
@@ -67,7 +67,7 @@ conditions which can be applied. The conditions are:
 * `email_domain` - (Optional) A list of email domains. Example:
   `email_domain = ["example.com"]`
 * `service_token` - (Optional) A list of service token ids. Example:
-  `service_token = cloudflare_access_service_token.demo.id`
+  `service_token = [cloudflare_access_service_token.demo.id]`
 * `any_valid_service_token` - (Optional) Boolean indicating if allow
   all tokens to be granted. Example: `any_valid_service_token = true`
 * `group` - (Optional) A list of access group ids. Example:


### PR DESCRIPTION
The description says `A list of service token ids`, but the example mentions a single string.