### PR TITLE
checks if universal_ssl is set in resource configuration to avoid permission issues with strictly scoped API tokens

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -509,9 +509,11 @@ func resourceCloudflareZoneSettingsOverrideCreate(d *schema.ResourceData, meta i
 		return err
 	}
 
-	// pulling USSL status and wrapping it into a cloudflare.ZoneSetting that we can set initial_settings
-	if err = updateZoneSettingsResponseWithUniversalSSLSettings(zoneSettings, d.Id(), client); err != nil {
-		return err
+	if d.Get("universal_ssl") != nil {
+		// pulling USSL status and wrapping it into a cloudflare.ZoneSetting that we can set initial_settings
+		if err = updateZoneSettingsResponseWithUniversalSSLSettings(zoneSettings, d.Id(), client); err != nil {
+			return err
+		}
 	}
 
 	log.Printf("[DEBUG] Read CloudflareZone initial settings: %#v", zoneSettings)
@@ -587,8 +589,10 @@ func resourceCloudflareZoneSettingsOverrideRead(d *schema.ResourceData, meta int
 		return err
 	}
 
-	if err = updateZoneSettingsResponseWithUniversalSSLSettings(zoneSettings, d.Id(), client); err != nil {
-		return err
+	if d.Get("universal_ssl") != nil {
+		if err = updateZoneSettingsResponseWithUniversalSSLSettings(zoneSettings, d.Id(), client); err != nil {
+			return err
+		}
 	}
 
 	log.Printf("[DEBUG] Read CloudflareZone Settings: %#v", zoneSettings)

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -509,7 +509,7 @@ func resourceCloudflareZoneSettingsOverrideCreate(d *schema.ResourceData, meta i
 		return err
 	}
 
-	if d.Get("universal_ssl") != nil {
+	if d.Get("settings.0.universal_ssl") != nil {
 		// pulling USSL status and wrapping it into a cloudflare.ZoneSetting that we can set initial_settings
 		if err = updateZoneSettingsResponseWithUniversalSSLSettings(zoneSettings, d.Id(), client); err != nil {
 			return err
@@ -589,7 +589,7 @@ func resourceCloudflareZoneSettingsOverrideRead(d *schema.ResourceData, meta int
 		return err
 	}
 
-	if d.Get("universal_ssl") != nil {
+	if d.Get("settings.0.universal_ssl") != nil {
 		if err = updateZoneSettingsResponseWithUniversalSSLSettings(zoneSettings, d.Id(), client); err != nil {
 			return err
 		}

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -693,10 +693,13 @@ func updateSingleZoneSettings(zoneSettings []cloudflare.ZoneSetting, client *clo
 func updateUniversalSSLSetting(zoneSettings []cloudflare.ZoneSetting, client *cloudflare.API, zoneID string) ([]cloudflare.ZoneSetting, error) {
 	indexToCut := -1
 	for i, setting := range zoneSettings {
+		// Skipping USSL Update if value is empty, especially when we are reverting to the initial state and we did not had the information
 		if setting.ID == "universal_ssl" {
-			_, err := client.EditUniversalSSLSetting(zoneID, cloudflare.UniversalSSLSetting{Enabled: boolFromString(setting.Value.(string))})
-			if err != nil {
-				return zoneSettings, err
+			if setting.Value.(string) != "" {
+				_, err := client.EditUniversalSSLSetting(zoneID, cloudflare.UniversalSSLSetting{Enabled: boolFromString(setting.Value.(string))})
+				if err != nil {
+					return zoneSettings, err
+				}
 			}
 			indexToCut = i
 		}

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -509,7 +509,7 @@ func resourceCloudflareZoneSettingsOverrideCreate(d *schema.ResourceData, meta i
 		return err
 	}
 
-	if d.Get("settings.0.universal_ssl") != nil {
+	if _, ok := d.GetOk("settings.0.universal_ssl"); ok {
 		// pulling USSL status and wrapping it into a cloudflare.ZoneSetting that we can set initial_settings
 		if err = updateZoneSettingsResponseWithUniversalSSLSettings(zoneSettings, d.Id(), client); err != nil {
 			return err
@@ -589,7 +589,7 @@ func resourceCloudflareZoneSettingsOverrideRead(d *schema.ResourceData, meta int
 		return err
 	}
 
-	if d.Get("settings.0.universal_ssl") != nil {
+	if _, ok := d.GetOk("settings.0.universal_ssl"); ok {
 		if err = updateZoneSettingsResponseWithUniversalSSLSettings(zoneSettings, d.Id(), client); err != nil {
 			return err
 		}

--- a/cloudflare/resource_cloudflare_zone_settings_override_test.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override_test.go
@@ -221,6 +221,9 @@ func testAccCheckInitialZoneSettings(zoneID string, initialSettings map[string]i
 		}
 
 		for _, zs := range foundZone.Result {
+			if zs.ID == "universal_ssl" {
+				continue
+			}
 			if !reflect.DeepEqual(zs.Value, initialSettings[zs.ID]) {
 				return fmt.Errorf("Final setting for %q: %+v not equal to initial setting: %+v", zs.ID, zs.Value, initialSettings[zs.ID])
 			}

--- a/cloudflare/resource_cloudflare_zone_settings_override_test.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override_test.go
@@ -112,6 +112,11 @@ func testAccCheckCloudflareZoneSettingsEmpty(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No Zone ID is set")
 		}
 
+		// Test if universal_ssl is not read from the API when it's not provided in the configuration
+		if rs.Primary.Attributes["initial_settings.0.universal_ssl"] != "" {
+			return fmt.Errorf("initial_settings.0.universal_ssl is not empty when it should be")
+		}
+
 		for k, v := range rs.Primary.Attributes {
 			if strings.Contains(k, "initial_settings") && k != "initial_settings_read_at" && !strings.Contains(k, "#") {
 				currentSettingKey := strings.TrimPrefix(k, "initial_")


### PR DESCRIPTION
@jacobbednarz  we came across backwards compatibility issues with strictly scoped API tokens, causing Reads to fail when the token has no permissions reading from the Universal SSL API.

I'm checking if unviersal_ssl is set in the current configuration and skipping API calls if that's not the case