### PR TITLE
resource/cloudflare_zone: No need to translate the ID to Name back to ID

### DIFF
--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -217,15 +217,15 @@ func resourceCloudflareZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// In the cases where the zone isn't completely setup yet, we need to
-	// check the `status` field and should it be pending, use the `Name`
+	// check the `status` field and should it be pending, use the `LegacyID`
 	// from `zone.PlanPending` instead to account for paid plans.
 	if zone.Status == "pending" && zone.PlanPending.Name != "" {
-		d.Set("plan", zone.PlanPending.Name)
+		d.Set("plan", zone.PlanPending.LegacyID)
 	}
 
 	if plan, ok := d.GetOk("plan"); ok {
-		planName := planIDForName(plan.(string))
-		if err := setRatePlan(client, zoneID, planName, false); err != nil {
+		planID := plan.(string)
+		if err := setRatePlan(client, zoneID, planID, false); err != nil {
 			return err
 		}
 	}

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -223,13 +223,13 @@ func resourceCloudflareZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 		d.Set("plan", zone.PlanPending.LegacyID)
 	}
 
-	if plan, ok := d.GetOk("plan"); ok {
+	if change := d.HasChange("plan"); change {
 		// If we're upgrading from a free plan, we need to use POST (not PUT) as the
 		// the subscription needs to be created, not modified despite the resource
 		// already existing.
-		existingPlan, _ := d.GetChange("plan")
+		existingPlan, newPlan := d.GetChange("plan")
 		wasFreePlan := existingPlan.(string) == "free"
-		planID := plan.(string)
+		planID := newPlan.(string)
 
 		if err := setRatePlan(client, zoneID, planID, wasFreePlan); err != nil {
 			return err

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -224,8 +224,14 @@ func resourceCloudflareZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if plan, ok := d.GetOk("plan"); ok {
+		// If we're upgrading from a free plan, we need to use POST (not PUT) as the
+		// the subscription needs to be created, not modified despite the resource
+		// already existing.
+		existingPlan, _ := d.GetChange("plan")
+		wasFreePlan := existingPlan.(string) == "free"
 		planID := plan.(string)
-		if err := setRatePlan(client, zoneID, planID, false); err != nil {
+
+		if err := setRatePlan(client, zoneID, planID, wasFreePlan); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Within the `Update` we set the rate plan which requires the
[subscription ID mapped value](https://github.com/terraform-providers/terraform-provider-cloudflare/blob/master/cloudflare/resource_cloudflare_zone.go#L35-L40). We already have the [legacy ID](https://github.com/terraform-providers/terraform-provider-cloudflare/blob/master/cloudflare/resource_cloudflare_zone.go#L35-L40) so we
don't need to pass it through the `planIDForName` method which we
previously.

I suspect this was a copy-paste issue from the `Read` method as we
were also setting the `plan` value to the plan name which would
[haven't have been accepted in the schema anyway](https://github.com/terraform-providers/terraform-provider-cloudflare/blob/master/cloudflare/resource_cloudflare_zone.go#L81). In 
addition to this, I've also updated the call to `setRatePlan` to take 
into account whether or not the old plan was "free" which requires 
a POST (not PUT) HTTP request to create a new subscription despite 
the resource already existing.

Closes #667