### PR TITLE
Add note mentioning use of `account_id`

### DIFF
--- a/website/docs/r/worker_script.html.markdown
+++ b/website/docs/r/worker_script.html.markdown
@@ -10,7 +10,6 @@ description: |-
 
 Provides a Cloudflare worker script resource. In order for a script to be active, you'll also need to setup a `cloudflare_worker_route`. *NOTE:*  This resource uses the Cloudflare account APIs. This requires setting the `CLOUDFLARE_ACCOUNT_ID` environment variable or `account_id` provider argument.
 
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/worker_script.html.markdown
+++ b/website/docs/r/worker_script.html.markdown
@@ -8,7 +8,8 @@ description: |-
 
 # cloudflare_worker_script
 
-Provides a Cloudflare worker script resource. In order for a script to be active, you'll also need to setup a `cloudflare_worker_route`.
+Provides a Cloudflare worker script resource. In order for a script to be active, you'll also need to setup a `cloudflare_worker_route`. *NOTE:*  This resource uses the Cloudflare account APIs. This requires setting the `CLOUDFLARE_ACCOUNT_ID` environment variable or `account_id` provider argument.
+
 
 ## Example Usage
 


### PR DESCRIPTION
Updates the `worker_script` documention to mention setting `account_id` as the functionality may now rely on it.