### PR TITLE
Update import example command to reflect reality

### DIFF
--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -69,7 +69,7 @@ The following attributes are exported:
 Records can be imported using a composite ID formed of zone name and record ID, e.g.
 
 ```
-$ terraform import cloudflare_record.default ae36f999674d196762efcc5abb06b345/d41d8cd98f00b204e9800998ecf8427e
+$ terraform import cloudflare_record.default example.com/d41d8cd98f00b204e9800998ecf8427e
 ```
 
 where:

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -66,10 +66,10 @@ The following attributes are exported:
 
 ## Import
 
-Records can be imported using a composite ID formed of zone name and record ID, e.g.
+Records can be imported using a composite ID formed of zone ID and record ID, e.g.
 
 ```
-$ terraform import cloudflare_record.default example.com/d41d8cd98f00b204e9800998ecf8427e
+$ terraform import cloudflare_record.default ae36f999674d196762efcc5abb06b345/d41d8cd98f00b204e9800998ecf8427e
 ```
 
 where:


### PR DESCRIPTION
Update the `terraform import` command to reflect the instructions provided alongside. I.e., to use the zone name, instead of the zone ID.