### PR TITLE
Update docs to denote plan-dependent arguments

### DIFF
--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -52,7 +52,8 @@ configured for the zone will result in an error:
 > Error: invalid zone setting "\<argument\>" (value: \<value\>) found - cannot be set as it is read only
 
 This is true even when setting the argument to its default value. These values should either be omitted or set to `null` for zones
-with plans that don't support the feature. 
+with plans that don't support the feature. See the [plan feature matrices](https://www.cloudflare.com/plans/) for details on
+feature support by plan.
 
 ### On/Off Values
 

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -44,6 +44,16 @@ The following arguments are supported:
 
 The **settings** block supports settings that may be applied to the zone. These may be on/off values, unitary fields, string values, integers or nested objects.
 
+### Plan-Dependent Settings
+
+Note that some settings are only available on certain plans. Setting an argument for a feature that is not available on the plan
+configured for the zone will result in an error:
+
+> Error: invalid zone setting "\<argument\>" (value: \<value\>) found - cannot be set as it is read only
+
+This is true even when setting the argument to its default value. These values should either be omitted or set to `null` for zones
+with plans that don't support the feature. 
+
 ### On/Off Values
 
 These can be specified as "on" or "off" string. Similar to boolean values, but here the empty string also means to use the existing value. Attributes available:


### PR DESCRIPTION
Updates documentation with a note on plan based features and side effects of enabling them when they are within the plan entitlements.