### PR TITLE
resource/cloudflare_argo: Allow settings to be individually customised

### DIFF
--- a/cloudflare/resource_cloudflare_argo_test.go
+++ b/cloudflare/resource_cloudflare_argo_test.go
@@ -1,0 +1,70 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCloudflareArgoOnlySetTieredCaching(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_argo.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareArgoTieredCachingConfig(zoneID, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "tiered_caching", "on"),
+					resource.TestCheckNoResourceAttr(name, "smart_routing"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareArgoSetTieredAndSmartRouting(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_argo.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareArgoFullConfig(zoneID, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "tiered_caching", "on"),
+					resource.TestCheckResourceAttr(name, "smart_routing", "on"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareArgoTieredCachingConfig(zoneID, name string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_argo" "%[2]s" {
+	  zone_id        = "%[1]s"
+    tiered_caching = "on"
+  }`, zoneID, name)
+}
+
+func testAccCheckCloudflareArgoFullConfig(zoneID, name string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_argo" "%[2]s" {
+	  zone_id        = "%[1]s"
+    tiered_caching = "on"
+    smart_routing  = "on"
+  }`, zoneID, name)
+}

--- a/website/docs/r/argo.html.markdown
+++ b/website/docs/r/argo.html.markdown
@@ -25,8 +25,8 @@ resource "cloudflare_argo" "example" {
 The following arguments are supported:
 
 * `zone_id` - (Required) The DNS zone ID that you wish to manage Argo on.
-* `tiered_caching` - (Optional) Whether tiered caching is enabled. Valid values: `on` or `off`. Defaults to `off`.
-* `smart_routing` - (Optional) Whether smart routing is enabled. Valid values: `on` or `off`. Defaults to `off`.
+* `tiered_caching` - (Optional) Whether tiered caching is enabled. Valid values: `on` or `off`.
+* `smart_routing` - (Optional) Whether smart routing is enabled. Valid values: `on` or `off`.
 
 
 ## Import


### PR DESCRIPTION
There was an assumption in this resource that when you were applying one
of the settings, that you would have entitlements to both and you would
be explicitly setting both during the resource management. This isn't
the case and there are scenarios where someone will manage the
`tiered_caching` setting without the entitlement to toggle
`smart_routing` to the default value of "off".

This splits the two API calls to be individually managed and only
applied if there is a value provided for both (customised or default
doesn't matter). In this PR, we're also removing the default value for 
these two properties to help differentiate whether or not the value
has been defined.

Fixes #701