### PR TITLE
SDK-95: cache_ttl_by_status support for Page Rules

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -442,6 +442,9 @@ func TestAccCloudflarePageRuleCacheTTLByStatus(t *testing.T) {
 	var pageRule cloudflare.PageRule
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_page_rule.%s", rnd)
 	target := fmt.Sprintf("test-cache-ttl-by-status.%s", domain)
 
 	resource.Test(t, resource.TestCase{
@@ -450,9 +453,9 @@ func TestAccCloudflarePageRuleCacheTTLByStatus(t *testing.T) {
 		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflarePageRuleConfigCacheTTLByStatus(zoneID, target),
+				Config: testAccCheckCloudflarePageRuleConfigCacheTTLByStatus(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
+					testAccCheckCloudflarePageRuleExists(name, &pageRule),
 				),
 			},
 		},
@@ -788,11 +791,11 @@ resource "cloudflare_page_rule" "test" {
 }`, zoneID, target)
 }
 
-func testAccCheckCloudflarePageRuleConfigCacheTTLByStatus(zoneID, target string) string {
+func testAccCheckCloudflarePageRuleConfigCacheTTLByStatus(zoneID, target, rnd string) string {
 	return fmt.Sprintf(`
-resource "cloudflare_page_rule" "test" {
-	zone_id = "%s"
-	target = "%s"
+resource "cloudflare_page_rule" "%[3]s" {
+	zone_id = "%[1]s"
+	target = "%[2]s"
 	actions {
 		cache_ttl_by_status {
 			codes = "200-299"
@@ -819,7 +822,7 @@ resource "cloudflare_page_rule" "test" {
 			ttl = 0
 		}
 	}
-}`, zoneID, target)
+}`, zoneID, target, rnd)
 }
 func buildPageRuleConfig(resourceName string, actions string) string {
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")

--- a/website/docs/r/page_rule.html.markdown
+++ b/website/docs/r/page_rule.html.markdown
@@ -51,9 +51,10 @@ Action blocks support the following:
 * `bypass_cache_on_cookie` - (Optional) String value of cookie name to conditionally bypass cache the page.
 * `cache_by_device_type` - (Optional) Whether this action is `"on"` or `"off"`.
 * `cache_deception_armor` - (Optional) Whether this action is `"on"` or `"off"`.
-* `cache_key_fields` - (Optional) Controls how Cloudflare creates Cache Keys used to identify files in cache. See below for full description.
+* `cache_key_fields` - (Optional) Controls how Cloudflare creates Cache Keys used to identify files in cache. [See below](#cache-key-fields) for full description.
 * `cache_level` - (Optional) Whether to set the cache level to `"bypass"`, `"basic"`, `"simplified"`, `"aggressive"`, or `"cache_everything"`.
 * `cache_on_cookie` - (Optional) String value of cookie name to conditionally cache the page.
+* `cache_ttl_by_status` - (Optional) Set cache TTL based on the response status from the origin web server. Can be specified multiple times. [See below](#cache-ttl-by-status) for full description.
 * `disable_apps` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `disable_performance` - (Optional) Boolean of whether this action is enabled. Default: false.
 * `disable_railgun` - (Optional) Boolean of whether this action is enabled. Default: false.
@@ -180,6 +181,57 @@ resource "cloudflare_page_rule" "foobar" {
       }
     }
   }
+}
+```
+
+### Cache TTL by status
+
+-> This setting is available to Enterprise customers only.
+
+Set cache TTL based on the response status from the origin web server. Cache TTL (time-to-live) refers to the duration a resource lives in the Cloudflare network before it is marked as stale or discarded from cache. Status codes are returned by a resource’s origin. 
+
+For detailed description please refer to [Cloudflare Support article](https://support.cloudflare.com/hc/en-us/articles/360043842472-Configuring-cache-TTL-by-status-code).
+
+* `codes` - (Required) A HTTP code (e.g. `404`) or range of codes (e.g. `400-499`)
+* `ttl` - (Required) Duration a resource lives in the Cloudflare cache.
+  * positive number - cache for specified duration in seconds
+  * `0` - sets `no-cache`, saved to cache, but expired immediately (revalidate from origin every time)
+  * `-1` - sets `no-store`, never save to cache
+
+Example:
+
+```hcl
+resource "cloudflare_page_rule" "test" {
+	zone_id = var.cloudflare_zone_id
+	target = "${var.cloudflare_zone}/app/*"
+	priority = 1
+
+	actions {
+		cache_ttl_by_status {
+			codes = "200-299"
+			ttl = 300
+		}
+		cache_ttl_by_status {
+			codes = "300-399"
+			ttl = 60
+		}
+		cache_ttl_by_status {
+			codes = "400-403"
+			ttl = -1
+		}
+		cache_ttl_by_status {
+			codes = "404"
+			ttl = 30
+		}
+		cache_ttl_by_status {
+			codes = "405-499"
+			ttl = -1
+		}
+		cache_ttl_by_status {
+			codes = "500-599"
+			ttl = 0
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
This PR adds support for Cache TTL by status code.

https://support.cloudflare.com/hc/en-us/articles/360043842472-Configuring-cache-TTL-by-status-code