### PR TITLE
datasource/zones: Perform filtering on server side

### DIFF
--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -134,7 +134,6 @@ func expandFilter(d interface{}) (*searchFilter, error) {
 	match, ok := m["match"]
 	if ok {
 		match, err := regexp.Compile(match.(string))
-		filter.regexValue = match
 		if err != nil {
 			return nil, err
 		}

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -1,11 +1,14 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -24,17 +27,19 @@ func testSweepCloudflareZones(r string) error {
 		log.Printf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
 	}
 
-	zones, zoneErr := client.ListZones()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	zoneFilter := cloudflare.WithZoneFilters("", accountID, "")
+	zones, zoneErr := client.ListZonesContext(context.TODO(), zoneFilter)
 	if zoneErr != nil {
 		log.Printf("[ERROR] Failed to fetch Cloudflare zones: %s", zoneErr)
 	}
 
-	if len(zones) == 0 {
+	if len(zones.Result) == 0 {
 		log.Print("[DEBUG] No Cloudflare Zones to sweep")
 		return nil
 	}
 
-	for _, zone := range zones {
+	for _, zone := range zones.Result {
 		// Don't try and sweep the static domains.
 		if zone.Name == "terraform.cfapi.net" || zone.Name == "terraform2.cfapi.net" {
 			continue

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -140,7 +140,7 @@ func testAccCloudflareZonesConfigMatchName() string {
 	return fmt.Sprintf(`
 data "cloudflare_zones" "examples_domains" {
   filter {
-    name   = "baa.*"
+    name   = "baa"
     paused = "${cloudflare_zone.foo_net.paused}" // true
   }
 }
@@ -153,7 +153,7 @@ func testAccCloudflareZonesConfigMatchPaused() string {
 	return fmt.Sprintf(`
 data "cloudflare_zones" "examples_domains" {
   filter {
-    name   = "baa.*"
+    name   = "baa"
     paused = "${cloudflare_zone.baa_com.paused}" // false
   }
 }

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -1,14 +1,11 @@
 package cloudflare
 
 import (
-	"context"
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -27,19 +24,17 @@ func testSweepCloudflareZones(r string) error {
 		log.Printf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
 	}
 
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	zoneFilter := cloudflare.WithZoneFilters("", accountID, "")
-	zones, zoneErr := client.ListZonesContext(context.TODO(), zoneFilter)
+	zones, zoneErr := client.ListZones()
 	if zoneErr != nil {
 		log.Printf("[ERROR] Failed to fetch Cloudflare zones: %s", zoneErr)
 	}
 
-	if len(zones.Result) == 0 {
+	if len(zones) == 0 {
 		log.Print("[DEBUG] No Cloudflare Zones to sweep")
 		return nil
 	}
 
-	for _, zone := range zones.Result {
+	for _, zone := range zones {
 		// Don't try and sweep the static domains.
 		if zone.Name == "terraform.cfapi.net" || zone.Name == "terraform2.cfapi.net" {
 			continue
@@ -57,15 +52,22 @@ func testSweepCloudflareZones(r string) error {
 }
 
 func TestAccCloudflareZonesMatchName(t *testing.T) {
+
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_zones.%s", rnd)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudflareZonesConfigMatchName(),
+				Config: testAccCloudflareZonesConfigMatchName(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareZonesDataSourceID("data.cloudflare_zones.examples_domains"),
-					resource.TestCheckResourceAttr("data.cloudflare_zones.examples_domains", "zones.#", "2"),
+					testAccCheckCloudflareZonesDataSourceID(name),
+					resource.TestCheckResourceAttr(name, "filter.0.name", "baa-com.cfapi.net"),
+					resource.TestCheckResourceAttr(name, "filter.0.paused", "false"),
+					resource.TestCheckResourceAttr(name, "zones.#", "1"),
 				),
 			},
 		},
@@ -73,33 +75,63 @@ func TestAccCloudflareZonesMatchName(t *testing.T) {
 }
 
 func TestAccCloudflareZonesMatchPaused(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_zones.%s", rnd)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudflareZonesConfigMatchPaused(),
+				Config: testAccCloudflareZonesConfigMatchPaused(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareZonesDataSourceID("data.cloudflare_zones.examples_domains"),
-					resource.TestCheckResourceAttrSet("data.cloudflare_zones.examples_domains", "zones.#"),
+					resource.TestCheckResourceAttr(name, "filter.0.name", "baa-org.cfapi.net"),
+					resource.TestCheckResourceAttr(name, "filter.0.paused", "true"),
+					resource.TestCheckResourceAttr(name, "zones.#", "1"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCloudflareZonesMatchStatus(t *testing.T) {
+func TestAccCloudflareZonesMatchRegexFilter(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_zones.%s", rnd)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudflareZonesConfigMatchStatus(),
+				Config: testAccCloudflareZonesConfigMatchRegex(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareZonesDataSourceID("data.cloudflare_zones.examples_domains"),
-					testAccCheckCloudflareZonesReturned("data.cloudflare_zones.examples_domains", "zones.#", func(i int) bool {
-						return i > 0
-					}),
+					testAccCheckCloudflareZonesDataSourceID(name),
+					resource.TestCheckResourceAttr(name, "filter.0.match", "baa-*"),
+					resource.TestCheckResourceAttr(name, "zones.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZonesMatchFuzzyLookup(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_zones.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareZonesMatchFuzzyLookup(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareZonesDataSourceID(name),
+					resource.TestCheckResourceAttr(name, "filter.0.name", "foo-net"),
+					resource.TestCheckResourceAttr(name, "filter.0.lookup_type", "contains"),
+					resource.TestCheckResourceAttr(name, "zones.#", "1"),
 				),
 			},
 		},
@@ -141,43 +173,63 @@ func testAccCheckCloudflareZonesReturned(n string, a string, check func(int) boo
 	}
 }
 
-func testAccCloudflareZonesConfigMatchName() string {
+func testAccCloudflareZonesConfigMatchName(rnd string) string {
 	return fmt.Sprintf(`
-data "cloudflare_zones" "examples_domains" {
+data "cloudflare_zones" "%[2]s" {
   filter {
-    name   = "baa"
-    paused = "${cloudflare_zone.foo_net.paused}" // true
+    name   = "baa-com.cfapi.net"
+    // This is an ordering fix to ensure that the test suite doesn't assert
+    // state before all the resources are available.
+    paused = "${cloudflare_zone.foo_net.paused}"
   }
 }
 
-%s
-`, testZones)
+%[1]s
+`, testZones, rnd)
 }
 
-func testAccCloudflareZonesConfigMatchPaused() string {
+func testAccCloudflareZonesConfigMatchPaused(rnd string) string {
 	return fmt.Sprintf(`
-data "cloudflare_zones" "examples_domains" {
+data "cloudflare_zones" "%[2]s" {
   filter {
-    name   = "baa"
-    paused = "${cloudflare_zone.baa_com.paused}" // false
+    name   = "baa-org.cfapi.net"
+    paused = "${cloudflare_zone.baa_org.paused}"
   }
 }
 
-%s
-`, testZones)
+%[1]s
+`, testZones, rnd)
 }
 
-func testAccCloudflareZonesConfigMatchStatus() string {
+func testAccCloudflareZonesConfigMatchRegex(rnd string) string {
 	return fmt.Sprintf(`
-data "cloudflare_zones" "examples_domains" {
+data "cloudflare_zones" "%[2]s" {
   filter {
-    status = "active"
-    paused = "${cloudflare_zone.baa_com.paused}" // false
+    match  = "baa-*"
+    // This is an ordering fix to ensure that the test suite doesn't assert
+    // state before all the resources are available.
+    paused = "${cloudflare_zone.foo_net.paused}"
   }
 }
 
-%s
-`, testZones)
+%[1]s
+`, testZones, rnd)
+}
+
+func testAccCloudflareZonesMatchFuzzyLookup(rnd string) string {
+	return fmt.Sprintf(`
+data "cloudflare_zones" "%[2]s" {
+  filter {
+    name = "foo-net"
+    lookup_type = "contains"
+    // This is an ordering fix to ensure that the test suite doesn't assert
+    // state before all the resources are available.
+    paused = "${cloudflare_zone.foo_net.paused}"
+  }
+}
+
+%[1]s
+`, testZones, rnd)
 }
 
 const testZones = `resource "cloudflare_zone" "baa_com" {
@@ -200,7 +252,7 @@ resource "cloudflare_zone" "baa_net" {
 
 resource "cloudflare_zone" "foo_net" {
   zone       = "foo-net.cfapi.net"
-  paused     = true
+  paused     = false
   jump_start = false
   depends_on = ["cloudflare_zone.baa_net", "cloudflare_zone.baa_org", "cloudflare_zone.baa_com"]
 }`

--- a/website/docs/d/zones.html.md
+++ b/website/docs/d/zones.html.md
@@ -19,7 +19,7 @@ Given you have the following zones in Cloudflare.
 - not-example.com
 
 ```hcl
-# Look for a single domain that you know exists using an exact match.
+# Look for a single zone that you know exists using an exact match.
 # API request will be for zones?name=example.com. Will not match not-example.com
 # or example.net.
 data "cloudflare_zones" "example" {
@@ -44,7 +44,7 @@ data "cloudflare_zones" "example" {
 ```hcl
 # Look for all zones which include "example" but start with "not-".
 # API request will be for zones?name=contains:example. Will perform client side
-# filtering using the provided regex and will only match the single domain,
+# filtering using the provided regex and will only match the single zone,
 # not-example.com.
 data "cloudflare_zones" "example" {
   filter {

--- a/website/docs/d/zones.html.md
+++ b/website/docs/d/zones.html.md
@@ -44,7 +44,8 @@ data "cloudflare_zones" "example" {
 ```hcl
 # Look for all zones which include "example" but start with "not-".
 # API request will be for zones?name=contains:example. Will perform client side
-# filtering using the provided regex and will only match one domain.
+# filtering using the provided regex and will only match the single domain,
+# not-example.com.
 data "cloudflare_zones" "example" {
   filter {
     name        = "example"

--- a/website/docs/d/zones.html.md
+++ b/website/docs/d/zones.html.md
@@ -10,17 +10,63 @@ description: |-
 
 Use this data source to look up [Zone][1] records.
 
-## Example Usage
+## Example usage
 
-The example below matches all `active` zones that begin with `example.` and are not paused. The matched zones are then
-locked down using the `cloudflare_zone_lockdown` resource.
+Given you have the following zones in Cloudflare.
+
+- example.com
+- example.net
+- not-example.com
+
+```hcl
+# Look for a single domain that you know exists using an exact match.
+# API request will be for zones?name=example.com. Will not match not-example.com
+# or example.net.
+data "cloudflare_zones" "example" {
+  filter {
+    name = "example.com"
+  }
+}
+```
+
+```hcl
+# Look for all zones which include "example".
+# API request will be for zones?name=contains:example. Will return all three
+# zones.
+data "cloudflare_zones" "example" {
+  filter {
+    name        = "example"
+    lookup_type = "contains"
+  }
+}
+```
+
+```hcl
+# Look for all zones which include "example" but start with "not-".
+# API request will be for zones?name=contains:example. Will perform client side
+# filtering using the provided regex and will only match one domain.
+data "cloudflare_zones" "example" {
+  filter {
+    name        = "example"
+    lookup_type = "contains"
+    match       = "^not-"
+  }
+}
+```
+
+### Example usage with other resources
+
+The example below matches all zones which have "example" in their value, end
+with ".com" and are active. The matched zone is then referenced in the zone
+lockdown resource.
 
 ```hcl
 data "cloudflare_zones" "test" {
   filter {
-    name   = "example.*"
-    status = "active"
-    paused = false
+    name        = "example"
+    lookup_type = "contains"
+    match       = ".com$"
+    status      = "active"
   }
 }
 
@@ -44,9 +90,18 @@ values must match in order to be included, see below for full list.
 
 **filter**
 
-- `name` - (Optional) A regular expression matching the zone to lookup.
-- `status` - (Optional) Status of the zone to lookup. Valid values: active, pending, initializing, moved, deleted, deactivated and read only.
-- `paused` - (Optional) Paused status of the zone to lookup. Valid values are `true` or `false`.
+- `name` - (Optional) A string value to search for.
+- `lookup_type` - (Optional) The type of search to perform for the `name` value
+  when querying the zone API. Valid values: `"exact"` and `"contains"`. Defaults
+  to `"exact"`.
+- `match` - (Optional) A RE2 compatible regular expression to filter the
+  results. This is performed client side whereas the `name` and `lookup_type`
+  are performed on the Cloudflare server side.
+- `status` - (Optional) Status of the zone to lookup. Valid values: `"active"`,
+  `"pending"`, `"initializing"`, `"moved"`, `"deleted"`, `"deactivated"` and
+  `"read only"`.
+- `paused` - (Optional) Paused status of the zone to lookup. Valid values are
+  `true` or `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The initial implementation of the datasource had the provider request all
the available zones and then we would perform some logic within the
provider to filter down to the match the attributes. This is slightly
inefficient for a couple of reasons:

- We are requesting *all* zones (even if we only want a small subset of
them); and
- We are duplicating the zone filtering logic in the provider that is
 already available in the API

This change replaces that functionality by pushing the responsibility of
filtering back to the API using inbuilt functionality. It maintains a reasonable
amount of backwards compatibility outlined in the initial PR (#168) where the
"name" had to accept wildcards but under the hood accepted a full regex.
Instead, we will be making:

- `name` value a string of the broad lookup term 
- `match` an optional refined regex which to further filter the result by
- `lookup_type` whether you're wanting to perform an exact or fuzzy lookup on 
  the value

### Examples (also in the website documentation)

Given you have the following domains in Cloudflare.

- example.com
- example.net
- not-example.com

```hcl
# Look for a single domain that you know exists using an exact match.
# API request will be for zones?name=example.com. Will not match not-example.com
data "cloudflare_zones" "example" {
  filter {
    name = "example.com"
  }
}
```

```hcl
# Look for all domains which include "example".
# API request will be for zones?name=contains:example. Will return all three 
# domains.
data "cloudflare_zones" "example" {
  filter {
    name        = "example"
    lookup_type = "contains"
  }
}
```

```hcl
# Look for all domains which include "example" but start with "not-".
# API request will be for zones?name=contains:example. Will perform client side
# filtering using the provided regex and will only match the single domain,
# not-example.com.
data "cloudflare_zones" "example" {
  filter {
    name        = "example"
    lookup_type = "contains"
    match       = "^not-"
  }
}
```

A side effect of this change is that we can also update the
`cloudflare_zone_sweeper` to be restricted to an account ID provided.
This prevents using API keys with global access from sweeping the wrong
zones/accounts.

Fixes #707
Fixes #648

Depends on cloudflare/cloudflare-go#478