### PR TITLE
Add support for worker text bindings

### DIFF
--- a/cloudflare/resource_cloudflare_worker_script.go
+++ b/cloudflare/resource_cloudflare_worker_script.go
@@ -72,7 +72,8 @@ func resourceCloudflareWorkerScript() *schema.Resource {
 						},
 					},
 				},
-				Set: resourceCloudflareWorkerScriptKvNamespaceBindingHash,
+				Set:        resourceCloudflareWorkerScriptKvNamespaceBindingHash,
+				Deprecated: "`kv_namespace_binding` has been deprecated in favour of using `binding.kv_namespace_id` instead.",
 			},
 		},
 	}

--- a/cloudflare/resource_cloudflare_worker_script.go
+++ b/cloudflare/resource_cloudflare_worker_script.go
@@ -81,22 +81,15 @@ func resourceCloudflareWorkerScript() *schema.Resource {
 func resourceCloudflareWorkerScriptBindingHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	name := m["name"].(string)
-
-	kvNamespaceID, ok := m["kv_namespace_id"]
-	if ok {
-		return hashcode.String(fmt.Sprintf("%s-%s", name, kvNamespaceID.(string)))
+	if v := m["kv_namespace_id"].(string); v != "" {
+		return hashcode.String(fmt.Sprintf("%s-%s", name, v))
 	}
-
-	plainText, ok := m["plain_text"]
-	if ok {
-		return hashcode.String(fmt.Sprintf("%s-%s", name, plainText.(string)))
+	if v := m["plain_text"].(string); v != "" {
+		return hashcode.String(fmt.Sprintf("%s-%s", name, v))
 	}
-
-	secretText, ok := m["secret_text"]
-	if ok {
-		return hashcode.String(fmt.Sprintf("%s-%s", name, secretText.(string)))
+	if v := m["secret_text"].(string); v != "" {
+		return hashcode.String(fmt.Sprintf("%s-%s", name, v))
 	}
-
 	return 0
 }
 
@@ -158,27 +151,21 @@ func parseWorkerBindings(d *schema.ResourceData, bindings ScriptBindings) {
 }
 
 func parseWorkerBinding(data map[string]interface{}) cloudflare.WorkerBinding {
-	kvNamespaceID, ok := data["kv_namespace_id"]
-	if ok {
+	if v := data["kv_namespace_id"].(string); v != "" {
 		return cloudflare.WorkerKvNamespaceBinding{
-			NamespaceID: kvNamespaceID.(string),
+			NamespaceID: v,
 		}
 	}
-
-	plainText, ok := data["plain_text"]
-	if ok {
+	if v := data["plain_text"].(string); v != "" {
 		return cloudflare.WorkerPlainTextBinding{
-			Text: plainText.(string),
+			Text: v,
 		}
 	}
-
-	secretText, ok := data["secret_text"]
-	if ok {
+	if v := data["secret_text"].(string); v != "" {
 		return cloudflare.WorkerSecretTextBinding{
-			Text: secretText.(string),
+			Text: v,
 		}
 	}
-
 	return nil
 }
 

--- a/cloudflare/resource_cloudflare_worker_script.go
+++ b/cloudflare/resource_cloudflare_worker_script.go
@@ -233,23 +233,17 @@ func resourceCloudflareWorkerScriptRead(d *schema.ResourceData, meta interface{}
 		case cloudflare.WorkerKvNamespaceBinding:
 			workerBindings.Add(map[string]interface{}{
 				"name":            name,
-				"plain_text":      "",
-				"secret_text":     "",
 				"kv_namespace_id": v.NamespaceID,
 			})
 		case cloudflare.WorkerPlainTextBinding:
 			workerBindings.Add(map[string]interface{}{
-				"name":            name,
-				"plain_text":      v.Text,
-				"secret_text":     "",
-				"kv_namespace_id": "",
+				"name":       name,
+				"plain_text": v.Text,
 			})
 		case cloudflare.WorkerSecretTextBinding:
 			workerBindings.Add(map[string]interface{}{
-				"name":            name,
-				"plain_text":      "",
-				"secret_text":     v.Text,
-				"kv_namespace_id": "",
+				"name":        name,
+				"secret_text": v.Text,
 			})
 		}
 	}

--- a/cloudflare/resource_cloudflare_worker_script_test.go
+++ b/cloudflare/resource_cloudflare_worker_script_test.go
@@ -49,7 +49,7 @@ func TestAccCloudflareWorkerScript_MultiScriptEnt(t *testing.T) {
 			{
 				Config: testAccCheckCloudflareWorkerScriptConfigMultiScriptUpdateBinding(rnd),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareWorkerScriptExists(name, &script, []string{"KV_NAMESPACE", "PLAIN_TEXT", "SECRET_TEXT"}),
+					testAccCheckCloudflareWorkerScriptExists(name, &script, []string{"MY_KV_NAMESPACE", "MY_PLAIN_TEXT", "MY_SECRET_TEXT"}),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "content", scriptContent2),
 				),
@@ -85,17 +85,17 @@ resource "cloudflare_worker_script" "%[1]s" {
   content = "%[2]s"
 
   kv_namespace_binding {
-    name         = "KV_NAMESPACE"
+    name         = "MY_KV_NAMESPACE"
     namespace_id = cloudflare_workers_kv_namespace.%[1]s.id
   }
 
   plain_text_binding {
-    name = "PLAIN_TEXT"
+    name = "MY_PLAIN_TEXT"
     text = "%[1]s"
   }
 
   secret_text_binding {
-    name = "SECRET_TEXT"
+    name = "MY_SECRET_TEXT"
     text = "%[1]s"
   }
 }`, rnd, scriptContent2)

--- a/cloudflare/resource_cloudflare_worker_script_test.go
+++ b/cloudflare/resource_cloudflare_worker_script_test.go
@@ -54,14 +54,6 @@ func TestAccCloudflareWorkerScript_MultiScriptEnt(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "content", scriptContent2),
 				),
 			},
-			{
-				Config: testAccCheckCloudflareWorkerScriptConfigMultiScriptUpdateKvNamespaceBinding(rnd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareWorkerScriptExists(name, &script, []string{rnd, fmt.Sprintf("%s-copy", rnd)}),
-					resource.TestCheckResourceAttr(name, "name", rnd),
-					resource.TestCheckResourceAttr(name, "content", scriptContent2),
-				),
-			},
 		},
 	})
 }
@@ -89,44 +81,22 @@ resource "cloudflare_workers_kv_namespace" "%[1]s" {
 }
 
 resource "cloudflare_worker_script" "%[1]s" {
-  name = "%[1]s"
+  name    = "%[1]s"
   content = "%[2]s"
 
-  binding {
-    name = "KV_NAMESPACE"
-    kv_namespace_id = cloudflare_workers_kv_namespace.%[1]s.id
+  kv_namespace_binding {
+    name         = "KV_NAMESPACE"
+    namespace_id = cloudflare_workers_kv_namespace.%[1]s.id
   }
 
-  binding {
+  plain_text_binding {
     name = "PLAIN_TEXT"
-    plain_text = "%[1]s"
+    text = "%[1]s"
   }
 
-  binding {
+  secret_text_binding {
     name = "SECRET_TEXT"
-    secret_text = "%[1]s"
-  }
-}`, rnd, scriptContent2)
-}
-
-func testAccCheckCloudflareWorkerScriptConfigMultiScriptUpdateKvNamespaceBinding(rnd string) string {
-	return fmt.Sprintf(`
-resource "cloudflare_workers_kv_namespace" "%[1]s" {
-  title = "%[1]s"
-}
-
-resource "cloudflare_worker_script" "%[1]s" {
-  name = "%[1]s"
-  content = "%[2]s"
-
-  kv_namespace_binding {
-	name = "%[1]s"
-	namespace_id = cloudflare_workers_kv_namespace.%[1]s.id
-  }
-
-  kv_namespace_binding {
-	name = "%[1]s-copy"
-	namespace_id = cloudflare_workers_kv_namespace.%[1]s.id
+    text = "%[1]s"
   }
 }`, rnd, scriptContent2)
 }

--- a/cloudflare/resource_cloudflare_worker_script_test.go
+++ b/cloudflare/resource_cloudflare_worker_script_test.go
@@ -47,6 +47,14 @@ func TestAccCloudflareWorkerScript_MultiScriptEnt(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccCheckCloudflareWorkerScriptConfigMultiScriptUpdateBinding(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareWorkerScriptExists(name, &script, []string{"KV_NAMESPACE", "PLAIN_TEXT", "SECRET_TEXT"}),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "content", scriptContent2),
+				),
+			},
+			{
 				Config: testAccCheckCloudflareWorkerScriptConfigMultiScriptUpdateKvNamespaceBinding(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareWorkerScriptExists(name, &script, []string{rnd, fmt.Sprintf("%s-copy", rnd)}),
@@ -74,10 +82,37 @@ resource "cloudflare_worker_script" "%[1]s" {
 }`, rnd, scriptContent2)
 }
 
+func testAccCheckCloudflareWorkerScriptConfigMultiScriptUpdateBinding(rnd string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_workers_kv_namespace" "%[1]s" {
+  title = "%[1]s"
+}
+
+resource "cloudflare_worker_script" "%[1]s" {
+  name = "%[1]s"
+  content = "%[2]s"
+
+  binding {
+    name = "KV_NAMESPACE"
+    kv_namespace_id = cloudflare_workers_kv_namespace.%[1]s.id
+  }
+
+  binding {
+    name = "PLAIN_TEXT"
+    plain_text = "%[1]s"
+  }
+
+  binding {
+    name = "SECRET_TEXT"
+    secret_text = "%[1]s"
+  }
+}`, rnd, scriptContent2)
+}
+
 func testAccCheckCloudflareWorkerScriptConfigMultiScriptUpdateKvNamespaceBinding(rnd string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_workers_kv_namespace" "%[1]s" {
- title = "%[1]s"
+  title = "%[1]s"
 }
 
 resource "cloudflare_worker_script" "%[1]s" {

--- a/website/docs/r/worker_script.html.markdown
+++ b/website/docs/r/worker_script.html.markdown
@@ -23,18 +23,18 @@ resource "cloudflare_worker_script" "my_script" {
   content = file("script.js")
 
   kv_namespace_binding {
-    name = "DB"
+    name         = "MY_EXAMPLE_KV_NAMESPACE"
     namespace_id = cloudflare_workers_kv_namespace.my_namespace.id
   }
 
   plain_text_binding {
-    name = "ENVIRONMENT"
-    text = "staging"
+    name = "MY_EXAMPLE_PLAIN_TEXT"
+    text = "foobar"
   }
 
   secret_text_binding {
-    name = "SENTRY_DSN"
-    text = var.sentry_dsn
+    name = "MY_EXAMPLE_SECRET_TEXT"
+    text = var.secret_foo_value
   }
 }
 ```

--- a/website/docs/r/worker_script.html.markdown
+++ b/website/docs/r/worker_script.html.markdown
@@ -21,10 +21,10 @@ resource "cloudflare_workers_kv_namespace" "my_namespace" {
 resource "cloudflare_worker_script" "my_script" {
   name = "script_1"
   content = file("script.js")
-  
-  kv_namespace_binding {
-    name = "my_binding"
-    namespace_id = cloudflare_workers_kv_namespace.my_namespace.id
+
+  binding {
+    name = "KV_NAMESPACE"
+    kv_namespace_id = cloudflare_workers_kv_namespace.my_namespace.id
   }
 }
 ```
@@ -36,10 +36,12 @@ The following arguments are supported:
 * `name` - (Required) The name for the script.
 * `content` - (Required) The script content.
 
-**kv_namespace_binding** (optional) block supports:
+**binding** supports a name and one of the binding types:
 
-* `name` - (Required) The name for the binding.
-* `namespace_id` - (Required) ID of KV namespace.
+* `name` - (Required) The global variable for the binding in your Worker code.
+* `kv_namespace_id` - (Optional) ID of the KV namespace you want to use.
+* `plain_text` - (Optional) The plain text you want to store.
+* `secret_text` - (Optional) The secret text you want to store.
 
 ## Import
 

--- a/website/docs/r/worker_script.html.markdown
+++ b/website/docs/r/worker_script.html.markdown
@@ -23,18 +23,18 @@ resource "cloudflare_worker_script" "my_script" {
   content = file("script.js")
 
   kv_namespace_binding {
-    name = "KV_NAMESPACE"
+    name = "DB"
     namespace_id = cloudflare_workers_kv_namespace.my_namespace.id
   }
 
   plain_text_binding {
-    name = "PLAIN_TEXT"
-    text = "example"
+    name = "ENVIRONMENT"
+    text = "staging"
   }
 
   secret_text_binding {
-    name = "SECRET_TEXT"
-    text = "example"
+    name = "SENTRY_DSN"
+    text = var.sentry_dsn
   }
 }
 ```

--- a/website/docs/r/worker_script.html.markdown
+++ b/website/docs/r/worker_script.html.markdown
@@ -22,9 +22,19 @@ resource "cloudflare_worker_script" "my_script" {
   name = "script_1"
   content = file("script.js")
 
-  binding {
+  kv_namespace_binding {
     name = "KV_NAMESPACE"
-    kv_namespace_id = cloudflare_workers_kv_namespace.my_namespace.id
+    namespace_id = cloudflare_workers_kv_namespace.my_namespace.id
+  }
+
+  plain_text_binding {
+    name = "PLAIN_TEXT"
+    text = "example"
+  }
+
+  secret_text_binding {
+    name = "SECRET_TEXT"
+    text = "example"
   }
 }
 ```
@@ -36,12 +46,20 @@ The following arguments are supported:
 * `name` - (Required) The name for the script.
 * `content` - (Required) The script content.
 
-**binding** supports a name and one of the binding types:
+**kv_namespace_binding** supports:
 
 * `name` - (Required) The global variable for the binding in your Worker code.
-* `kv_namespace_id` - (Optional) ID of the KV namespace you want to use.
-* `plain_text` - (Optional) The plain text you want to store.
-* `secret_text` - (Optional) The secret text you want to store.
+* `kv_namespace_id` - (Required) ID of the KV namespace you want to use.
+
+**plain_text_binding** supports:
+
+* `name` - (Required) The global variable for the binding in your Worker code.
+* `text` - (Required) The plain text you want to store.
+
+**secret_text_binding** supports:
+
+* `name` - (Required) The global variable for the binding in your Worker code.
+* `text` - (Required) The secret text you want to store.
 
 ## Import
 


### PR DESCRIPTION
Closes https://github.com/terraform-providers/terraform-provider-cloudflare/issues/615, closes https://github.com/terraform-providers/terraform-provider-cloudflare/issues/164. Not entirely sure on the terraform idioms so feel free to correct anything I'm doing incorrectly.

I wanted to use separate keys in `binding` because they have different requirements for things like `sensitive` and possibly values in the future. The key in the schema determines the "type" of the binding, e.g. `secret_text`, `plain_text` or `kv_namespace_id`. Roughly follows https://github.com/terraform-providers/terraform-provider-cloudflare/issues/615#issuecomment-598801105 but didn't see the need for specifying `type` since every binding is different enough so far they can be differentiated easily by the key set.