### PR TITLE
Update asserted TestAccCloudflareRecord_LOC string

### DIFF
--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -133,7 +133,7 @@ func TestAccCloudflareRecord_LOC(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareRecordExists(resourceName, &record),
 					resource.TestCheckResourceAttr(
-						resourceName, "value", "37 46 46.000 N 122 23 35.000 W 0.00m 100.00m 0.00m 0.00m"),
+						resourceName, "value", "37 46 46 N 122 23 35 W 0 100 0 0"),
 					resource.TestCheckResourceAttr(
 						resourceName, "proxiable", "false"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
This value in the API response has changed so we need to update our tests.

Fixes the following:

```
------- Stdout: -------
=== RUN   TestAccCloudflareRecord_LOC
=== PAUSE TestAccCloudflareRecord_LOC
=== CONT  TestAccCloudflareRecord_LOC
--- FAIL: TestAccCloudflareRecord_LOC (4.26s)
testing.go:684: Step 0 error: Check failed: Check 2/4 error: cloudflare_record.foobar: Attribute 'value' expected "37 46 46.000 N 122 23 35.000 W 0.00m 100.00m 0.00m 0.00m", got "37 46 46 N 122 23 35 W 0 100 0 0"
FAIL
```