### PR TITLE
Update TestAccCloudflareRecord_Basic metadata count

### DIFF
--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -46,7 +46,7 @@ func TestAccCloudflareRecord_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "ttl", "3600"),
 					resource.TestCheckResourceAttr(
-						resourceName, "metadata.%", "3"),
+						resourceName, "metadata.%", "4"),
 					resource.TestCheckResourceAttr(
 						resourceName, "metadata.auto_added", "false"),
 				),


### PR DESCRIPTION
The metadata count has increased to 4 so we need to update our assertion of the field.

Fixes the following CI failure.

```
------- Stdout: -------
=== RUN   TestAccCloudflareRecord_Basic
=== PAUSE TestAccCloudflareRecord_Basic
=== CONT  TestAccCloudflareRecord_Basic
--- FAIL: TestAccCloudflareRecord_Basic (1.35s)
testing.go:684: Step 0 error: Check failed: Check 11/12 error: cloudflare_record.foobar: Attribute 'metadata.%' expected "3", got "4"
FAIL
```