### PR TITLE
test/spectrum_application: Remove zone listing calls

### DIFF
--- a/cloudflare/import_cloudflare_spectrum_application_test.go
+++ b/cloudflare/import_cloudflare_spectrum_application_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccCloudflareSpectrumApplication_Import(t *testing.T) {
 	t.Parallel()
 	var application cloudflare.SpectrumApplication
-	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	rnd := generateRandomResourceName()
 	name := "cloudflare_spectrum_application." + rnd
@@ -22,7 +22,7 @@ func TestAccCloudflareSpectrumApplication_Import(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflareSpectrumApplicationConfigBasic(zone, rnd),
+				Config: testAccCheckCloudflareSpectrumApplicationConfigBasic(zoneID, domain, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareSpectrumApplicationExists(name, &application),
 					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),


### PR DESCRIPTION
Since we updated the `cloudflare_zone` datasource #708 to perform
different types of matching, this test has been failing due to not
having the ability to list all zones. This isn't really a problem but it
did identify we could be lazier with the resource definition and pass in
a static zone ID instead of relying on an extra zone listing call to
fetch all the information.